### PR TITLE
refactor: deepen archive persistence behind ArchiveStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.claude/skills/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ai-image-manager",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "idb-keyval": "^6.2.2",
         "jszip": "^3.10.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ function App() {
                 url: updatedUrl,
                 references: references || editingImage.references
             }
-            await addImage(updatedImage) // SQLiteAdapter's saveImage uses INSERT OR REPLACE
+            await addImage(updatedImage)
             addToast('Masterpiece updated', 'success')
         }
 

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -1,5 +1,5 @@
 import type { ArchiveImage } from '../db/types';
-import { SQLiteArchiveMetadataPort } from '../db/SQLiteAdapter';
+import { SQLiteArchiveMetadataPort } from './SQLiteArchiveMetadataPort';
 import { storage, type StorageProvider } from '../services/StorageService';
 
 export type SaveArchiveImageInput = Omit<ArchiveImage, 'id' | 'timestamp'> & {

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -1,0 +1,183 @@
+import type { ArchiveImage } from '../db/types';
+import { SQLiteArchiveMetadataPort } from '../db/SQLiteAdapter';
+import { storage, type StorageProvider } from '../services/StorageService';
+
+export type SaveArchiveImageInput = Omit<ArchiveImage, 'id' | 'timestamp'> & {
+    id?: string;
+    timestamp?: string;
+};
+
+export interface ArchiveStore {
+    list(): Promise<ArchiveImage[]>;
+    save(input: SaveArchiveImageInput): Promise<ArchiveImage>;
+    remove(id: string): Promise<void>;
+}
+
+type ArchiveMetadataRecord = Omit<ArchiveImage, 'url' | 'references'> & {
+    storedUrl: string;
+    referenceIds: number[];
+};
+
+interface ArchiveMetadataPort {
+    list(): Promise<ArchiveMetadataRecord[]>;
+    get(id: string): Promise<ArchiveMetadataRecord | null>;
+    save(record: ArchiveMetadataRecord): Promise<void>;
+    remove(id: string): Promise<void>;
+}
+
+interface ArchiveBlobPort {
+    save(key: string, data: string): Promise<void>;
+    load(key: string): Promise<string | null>;
+    remove(key: string): Promise<void>;
+}
+
+interface CreateArchiveStoreDeps {
+    metadata?: ArchiveMetadataPort;
+    blobs?: ArchiveBlobPort;
+    clock?: () => string;
+    makeId?: () => string;
+}
+
+class StorageArchiveBlobPort implements ArchiveBlobPort {
+    private readonly provider: StorageProvider;
+
+    constructor(provider: StorageProvider) {
+        this.provider = provider;
+    }
+
+    save(key: string, data: string): Promise<void> {
+        return this.provider.save(key, data);
+    }
+
+    load(key: string): Promise<string | null> {
+        return this.provider.load(key);
+    }
+
+    remove(key: string): Promise<void> {
+        return this.provider.remove(key);
+    }
+}
+
+class LocalArchiveStore implements ArchiveStore {
+    private readonly metadata: ArchiveMetadataPort;
+    private readonly blobs: ArchiveBlobPort;
+    private readonly clock: () => string;
+    private readonly makeId: () => string;
+
+    constructor(
+        metadata: ArchiveMetadataPort,
+        blobs: ArchiveBlobPort,
+        clock: () => string,
+        makeId: () => string,
+    ) {
+        this.metadata = metadata;
+        this.blobs = blobs;
+        this.clock = clock;
+        this.makeId = makeId;
+    }
+
+    async list(): Promise<ArchiveImage[]> {
+        const records = await this.metadata.list();
+        return Promise.all(records.map((record) => this.hydrate(record)));
+    }
+
+    async save(input: SaveArchiveImageInput): Promise<ArchiveImage> {
+        const id = input.id ?? this.makeId();
+        const existing = await this.metadata.get(id);
+        const timestamp = input.timestamp ?? existing?.timestamp ?? this.clock();
+        const referenceIds = input.references?.map((_, index) => index) ?? [];
+
+        await this.blobs.save(getImageBlobKey(id), input.url);
+        await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
+
+        await this.metadata.save({
+            id,
+            storedUrl: id,
+            prompt: input.prompt,
+            quality: input.quality,
+            aspectRatio: input.aspectRatio,
+            background: input.background,
+            timestamp,
+            model: input.model,
+            width: input.width,
+            height: input.height,
+            style: input.style,
+            lighting: input.lighting,
+            palette: input.palette,
+            referenceIds,
+        });
+
+        return {
+            id,
+            url: input.url,
+            prompt: input.prompt,
+            quality: input.quality,
+            aspectRatio: input.aspectRatio,
+            background: input.background,
+            timestamp,
+            model: input.model,
+            width: input.width,
+            height: input.height,
+            references: input.references,
+            style: input.style,
+            lighting: input.lighting,
+            palette: input.palette,
+        };
+    }
+
+    async remove(id: string): Promise<void> {
+        const existing = await this.metadata.get(id);
+
+        await this.blobs.remove(getImageBlobKey(id));
+        await Promise.all((existing?.referenceIds ?? []).map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
+        await this.metadata.remove(id);
+    }
+
+    private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage> {
+        const [imageUrl, references] = await Promise.all([
+            this.blobs.load(getImageBlobKey(record.id)),
+            Promise.all(record.referenceIds.map((index) => this.blobs.load(getReferenceBlobKey(record.id, index)))),
+        ]);
+
+        return {
+            id: record.id,
+            url: imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : ''),
+            prompt: record.prompt,
+            quality: record.quality,
+            aspectRatio: record.aspectRatio,
+            background: record.background,
+            timestamp: record.timestamp,
+            model: record.model,
+            width: record.width,
+            height: record.height,
+            references: references.filter((reference): reference is string => reference !== null),
+            style: record.style,
+            lighting: record.lighting,
+            palette: record.palette,
+        };
+    }
+
+    private async syncReferences(id: string, previousReferenceIds: number[], nextReferences: string[]): Promise<void> {
+        await Promise.all(nextReferences.map((reference, index) => this.blobs.save(getReferenceBlobKey(id, index), reference)));
+
+        const nextReferenceIds = new Set(nextReferences.map((_, index) => index));
+        const staleReferenceIds = previousReferenceIds.filter((index) => !nextReferenceIds.has(index));
+
+        await Promise.all(staleReferenceIds.map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
+    }
+}
+
+const getImageBlobKey = (id: string) => `img_${id}`;
+
+const getReferenceBlobKey = (id: string, index: number) => `ref_${id}_${index}`;
+
+export function createArchiveStore(deps: CreateArchiveStoreDeps = {}): ArchiveStore {
+    return new LocalArchiveStore(
+        deps.metadata ?? new SQLiteArchiveMetadataPort(),
+        deps.blobs ?? new StorageArchiveBlobPort(storage),
+        deps.clock ?? (() => new Date().toISOString()),
+        deps.makeId ?? (() => crypto.randomUUID()),
+    );
+}
+
+export const archiveStore = createArchiveStore();

--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -1,5 +1,5 @@
 import { SQLocal } from 'sqlocal';
-import type { ArchiveImage } from './types';
+import type { ArchiveImage } from '../db/types';
 
 type ArchiveImageRow = ArchiveImage & { ref_ids?: string };
 
@@ -36,16 +36,9 @@ export class SQLiteArchiveMetadataPort {
             );
         `;
 
-        // Migration: Ensure ref_ids column exists
         await this.sql.sql`ALTER TABLE images ADD COLUMN ref_ids TEXT`.catch(() => null);
-
-        // Migration: Ensure style column exists
         await this.sql.sql`ALTER TABLE images ADD COLUMN style TEXT`.catch(() => null);
-
-        // Migration: Ensure lighting column exists
         await this.sql.sql`ALTER TABLE images ADD COLUMN lighting TEXT`.catch(() => null);
-
-        // Migration: Ensure palette column exists
         await this.sql.sql`ALTER TABLE images ADD COLUMN palette TEXT`.catch(() => null);
 
         this.initialized = true;

--- a/src/db/SQLiteAdapter.ts
+++ b/src/db/SQLiteAdapter.ts
@@ -1,10 +1,14 @@
 import { SQLocal } from 'sqlocal';
-import { storage } from '../services/StorageService';
-import type { DatabaseAdapter, ArchiveImage } from './types';
+import type { ArchiveImage } from './types';
 
 type ArchiveImageRow = ArchiveImage & { ref_ids?: string };
 
-export class SQLiteAdapter implements DatabaseAdapter {
+type ArchiveMetadataRecord = Omit<ArchiveImage, 'url' | 'references'> & {
+    storedUrl: string;
+    referenceIds: number[];
+};
+
+export class SQLiteArchiveMetadataPort {
     private sql: SQLocal;
     private initialized: boolean = false;
 
@@ -47,101 +51,94 @@ export class SQLiteAdapter implements DatabaseAdapter {
         this.initialized = true;
     }
 
-    async saveImage(image: ArchiveImage): Promise<void> {
+    async save(record: ArchiveMetadataRecord): Promise<void> {
         await this.init();
-
-        // Move binary to storage if it's a data URL
-        if (image.url.startsWith('data:')) {
-            await storage.save(`img_${image.id}`, image.url);
-        }
-
-        // Handle Reference Images
-        const refIds: number[] = [];
-        if (image.references && image.references.length > 0) {
-            // Save each reference blob to storage
-            for (let i = 0; i < image.references.length; i++) {
-                await storage.save(`ref_${image.id}_${i}`, image.references[i]);
-                refIds.push(i);
-            }
-        }
 
         await this.sql.sql`
             INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, ref_ids, style, lighting, palette)
             VALUES (
-                ${image.id},
-                ${image.id}, -- Store ID as internal reference in url column
-                ${image.prompt},
-                ${image.quality},
-                ${image.aspectRatio},
-                ${image.background},
-                ${image.timestamp},
-                ${image.model || 'gpt-image-1.5'},
-                ${image.width || 1024},
-                ${image.height || 1024},
-                ${JSON.stringify(refIds)},
-                ${image.style || null},
-                ${image.lighting || null},
-                ${image.palette || null}
+                ${record.id},
+                ${record.storedUrl},
+                ${record.prompt},
+                ${record.quality},
+                ${record.aspectRatio},
+                ${record.background},
+                ${record.timestamp},
+                ${record.model || 'gpt-image-1.5'},
+                ${record.width || 1024},
+                ${record.height || 1024},
+                ${JSON.stringify(record.referenceIds)},
+                ${record.style || null},
+                ${record.lighting || null},
+                ${record.palette || null}
             )
         `;
     }
 
-    async getImages(): Promise<ArchiveImage[]> {
+    async list(): Promise<ArchiveMetadataRecord[]> {
         await this.init();
         const result = await this.sql.sql`SELECT * FROM images ORDER BY timestamp DESC`;
         const images = result as ArchiveImageRow[];
 
-        // Resolve images with their binary data
-        for (const img of images) {
-            const data = await storage.load(`img_${img.id}`);
-            if (data) img.url = data;
-
-            // Load references if present
-            if (img.ref_ids) {
-                try {
-                    const refIds = JSON.parse(img.ref_ids) as number[];
-                    const loadedRefs: string[] = [];
-                    for (const idx of refIds) {
-                        const refData = await storage.load(`ref_${img.id}_${idx}`);
-                        if (refData) loadedRefs.push(refData);
-                    }
-                    img.references = loadedRefs;
-                } catch {
-                    img.references = [];
-                }
-            }
-        }
-
-        return images;
+        return images.map((image) => ({
+            id: image.id,
+            storedUrl: image.url,
+            prompt: image.prompt,
+            quality: image.quality,
+            aspectRatio: image.aspectRatio,
+            background: image.background,
+            timestamp: image.timestamp,
+            model: image.model,
+            width: image.width,
+            height: image.height,
+            style: image.style,
+            lighting: image.lighting,
+            palette: image.palette,
+            referenceIds: parseReferenceIds(image.ref_ids),
+        }));
     }
 
-    async deleteImage(id: string): Promise<void> {
+    async get(id: string): Promise<ArchiveMetadataRecord | null> {
         await this.init();
-        await storage.remove(`img_${id}`);
+        const result = await this.sql.sql`SELECT * FROM images WHERE id = ${id}`;
+        const row = (result as ArchiveImageRow[])[0];
 
-        // We need to fetch the image first to know how many references to delete
-        // Or we can just brute force delete a reasonable number, but fetching is safer
-        const result = await this.sql.sql`SELECT ref_ids FROM images WHERE id = ${id}` as { ref_ids?: string }[];
-        if (result && result.length > 0 && result[0].ref_ids) {
-            let refIds: number[] = [];
-            try {
-                refIds = JSON.parse(result[0].ref_ids) as number[];
-            } catch {
-                refIds = [];
-            }
-
-            for (const idx of refIds) {
-                await storage.remove(`ref_${id}_${idx}`);
-            }
+        if (!row) {
+            return null;
         }
 
+        return {
+            id: row.id,
+            storedUrl: row.url,
+            prompt: row.prompt,
+            quality: row.quality,
+            aspectRatio: row.aspectRatio,
+            background: row.background,
+            timestamp: row.timestamp,
+            model: row.model,
+            width: row.width,
+            height: row.height,
+            style: row.style,
+            lighting: row.lighting,
+            palette: row.palette,
+            referenceIds: parseReferenceIds(row.ref_ids),
+        };
+    }
+
+    async remove(id: string): Promise<void> {
+        await this.init();
         await this.sql.sql`DELETE FROM images WHERE id = ${id}`;
-    }
-
-    async clearAll(): Promise<void> {
-        await this.init();
-        await this.sql.sql`DELETE FROM images`;
     }
 }
 
-export const db = new SQLiteAdapter();
+const parseReferenceIds = (value?: string): number[] => {
+    if (!value) {
+        return [];
+    }
+
+    try {
+        return JSON.parse(value) as number[];
+    } catch {
+        return [];
+    }
+};

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -14,11 +14,3 @@ export interface ArchiveImage {
     lighting?: string;
     palette?: string;
 }
-
-export interface DatabaseAdapter {
-    init(): Promise<void>;
-    saveImage(image: ArchiveImage): Promise<void>;
-    getImages(): Promise<ArchiveImage[]>;
-    deleteImage(id: string): Promise<void>;
-    clearAll(): Promise<void>;
-}

--- a/src/hooks/useImageArchive.ts
+++ b/src/hooks/useImageArchive.ts
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { db } from '../db/SQLiteAdapter';
+import { archiveStore } from '../archive/ArchiveStore';
 import type { ArchiveImage } from '../db/types';
+
+const sortImagesByTimestamp = (images: ArchiveImage[]) => {
+    return [...images].sort((left, right) => right.timestamp.localeCompare(left.timestamp));
+};
 
 export function useImageArchive() {
     const [images, setImages] = useState<ArchiveImage[]>([]);
@@ -10,7 +14,7 @@ export function useImageArchive() {
     const loadImages = useCallback(async () => {
         try {
             setLoading(true);
-            const data = await db.getImages();
+            const data = await archiveStore.list();
             setImages(data);
         } catch (err) {
             setError(err instanceof Error ? err : new Error('Failed to load images'));
@@ -21,8 +25,11 @@ export function useImageArchive() {
 
     const addImage = async (image: ArchiveImage) => {
         try {
-            await db.saveImage(image);
-            await loadImages();
+            const savedImage = await archiveStore.save(image);
+            setImages((current) => sortImagesByTimestamp([
+                savedImage,
+                ...current.filter((entry) => entry.id !== savedImage.id),
+            ]));
         } catch (err) {
             setError(err instanceof Error ? err : new Error('Failed to save image'));
             throw err;
@@ -31,8 +38,8 @@ export function useImageArchive() {
 
     const deleteImage = async (id: string) => {
         try {
-            await db.deleteImage(id);
-            await loadImages();
+            await archiveStore.remove(id);
+            setImages((current) => current.filter((entry) => entry.id !== id));
         } catch (err) {
             setError(err instanceof Error ? err : new Error('Failed to delete image'));
             throw err;

--- a/src/hooks/useImageArchive.ts
+++ b/src/hooks/useImageArchive.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import { archiveStore } from '../archive/ArchiveStore';
+import { archiveStore, type ArchiveStore } from '../archive/ArchiveStore';
 import type { ArchiveImage } from '../db/types';
 
 const sortImagesByTimestamp = (images: ArchiveImage[]) => {
     return [...images].sort((left, right) => right.timestamp.localeCompare(left.timestamp));
 };
 
-export function useImageArchive() {
+export function useImageArchive(store: ArchiveStore = archiveStore) {
     const [images, setImages] = useState<ArchiveImage[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
@@ -14,18 +14,18 @@ export function useImageArchive() {
     const loadImages = useCallback(async () => {
         try {
             setLoading(true);
-            const data = await archiveStore.list();
+            const data = await store.list();
             setImages(data);
         } catch (err) {
             setError(err instanceof Error ? err : new Error('Failed to load images'));
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [store]);
 
     const addImage = async (image: ArchiveImage) => {
         try {
-            const savedImage = await archiveStore.save(image);
+            const savedImage = await store.save(image);
             setImages((current) => sortImagesByTimestamp([
                 savedImage,
                 ...current.filter((entry) => entry.id !== savedImage.id),
@@ -38,7 +38,7 @@ export function useImageArchive() {
 
     const deleteImage = async (id: string) => {
         try {
-            await archiveStore.remove(id);
+            await store.remove(id);
             setImages((current) => current.filter((entry) => entry.id !== id));
         } catch (err) {
             setError(err instanceof Error ? err : new Error('Failed to delete image'));


### PR DESCRIPTION
## Summary
- add an `ArchiveStore` boundary that owns archive save/list/remove behavior instead of splitting it across the hook, SQLite adapter, and blob storage
- move the SQLite metadata adapter under `src/archive/` and keep the archive hook focused on UI state with incremental updates and optional store injection for tests
- remove the old shallow archive adapter contract so archive persistence details stay inside the archive module

## Testing
- npm run lint
- npm run build