### PR TITLE
refactor: centralize image generation workflow

### DIFF
--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -1,0 +1,109 @@
+import { dataURLtoFile, fileToDataURL } from '../utils/file';
+import {
+    openAiImageClient,
+    type ImageBackground,
+    type ImageQuality,
+    type OpenAiImageClient,
+} from '../utils/openai';
+
+const VALID_GENERATION_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+
+export interface GenerateImageInput {
+    apiKey: string;
+    prompt: string;
+    quality: ImageQuality;
+    aspectRatio: string;
+    background: ImageBackground;
+    style: string;
+    lighting: string;
+    palette: string;
+    referenceImages: File[];
+}
+
+export interface EditImageInput {
+    apiKey: string;
+    prompt: string;
+    sourceImage: Blob;
+    referenceImages: File[];
+    quality?: ImageQuality;
+}
+
+export interface ImageWorkflow {
+    generate(input: GenerateImageInput): Promise<string>;
+    edit(input: EditImageInput): Promise<string>;
+    serializeReferences(files: File[]): Promise<string[]>;
+    hydrateReferences(dataUrls: string[]): File[];
+}
+
+export function createImageWorkflow(client: OpenAiImageClient = openAiImageClient): ImageWorkflow {
+    return {
+        async generate(input) {
+            return requestImageDataUrl(client, {
+                apiKey: input.apiKey,
+                prompt: buildGenerationPrompt(input),
+                quality: input.quality,
+                size: sanitizeGenerationSize(input.aspectRatio),
+                background: input.background,
+                referenceImages: input.referenceImages,
+            });
+        },
+
+        async edit(input) {
+            return requestImageDataUrl(client, {
+                apiKey: input.apiKey,
+                prompt: input.prompt,
+                quality: input.quality ?? 'medium',
+                referenceImages: [createEditSourceFile(input.sourceImage), ...input.referenceImages],
+            });
+        },
+
+        serializeReferences(files) {
+            return Promise.all(files.map((file) => fileToDataURL(file)));
+        },
+
+        hydrateReferences(dataUrls) {
+            return dataUrls.map((dataUrl, index) => dataURLtoFile(dataUrl, `ref-${index}.png`));
+        },
+    };
+}
+
+export const imageWorkflow = createImageWorkflow();
+
+const buildGenerationPrompt = (input: GenerateImageInput) => {
+    const modifiers: string[] = [];
+
+    if (input.style !== 'none') modifiers.push(input.style);
+    if (input.lighting !== 'none') modifiers.push(input.lighting);
+    if (input.palette !== 'none') modifiers.push(`color palette: ${input.palette}`);
+
+    return modifiers.length > 0
+        ? `${input.prompt}, ${modifiers.join(', ')}`
+        : input.prompt;
+};
+
+const sanitizeGenerationSize = (size: string) => {
+    return VALID_GENERATION_SIZES.has(size) ? size : '1024x1024';
+};
+
+const createEditSourceFile = (sourceImage: Blob) => {
+    return new File([sourceImage], 'edit-input.png', {
+        type: sourceImage.type || 'image/png',
+    });
+};
+
+const requestImageDataUrl = async (client: OpenAiImageClient, input: {
+    apiKey: string;
+    prompt: string;
+    quality?: ImageQuality;
+    size?: string;
+    background?: ImageBackground;
+    referenceImages?: File[];
+}) => {
+    const result = await client.createImage(input);
+
+    if (!result.b64_json) {
+        throw new Error('No image data returned from OpenAI');
+    }
+
+    return `data:image/png;base64,${result.b64_json}`;
+};

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -1,78 +1,89 @@
-export const generateImageWithGPTImage15 = async (
-    apiKey: string,
-    prompt: string,
-    params: {
-        quality?: 'low' | 'medium' | 'high';
-        size?: string;
-        background?: 'transparent' | 'opaque' | 'auto';
-        referenceImages?: File[];
-    }
-) : Promise<{ b64_json?: string }> => {
-    const isEdit = params.referenceImages && params.referenceImages.length > 0;
-    const endpoint = isEdit
-        ? 'https://api.openai.com/v1/images/edits'
-        : 'https://api.openai.com/v1/images/generations';
+export type ImageQuality = 'low' | 'medium' | 'high';
 
-    let body: BodyInit;
-    const headers: Record<string, string> = {
-        'Authorization': `Bearer ${apiKey}`,
-    };
+export type ImageBackground = 'transparent' | 'opaque' | 'auto';
 
-    if (isEdit) {
-        // multipart/form-data for edits/references
-        const formData = new FormData();
-        formData.append('model', 'gpt-image-1.5');
-        formData.append('prompt', prompt);
-        formData.append('n', '1');
+export interface OpenAiImageRequest {
+    apiKey: string;
+    prompt: string;
+    quality?: ImageQuality;
+    size?: string;
+    background?: ImageBackground;
+    referenceImages?: File[];
+}
 
-        params.referenceImages?.forEach(file => {
-            formData.append('image[]', file);
+export interface OpenAiImageResponse {
+    b64_json?: string;
+}
+
+export interface OpenAiImageClient {
+    createImage(request: OpenAiImageRequest): Promise<OpenAiImageResponse>;
+}
+
+export const openAiImageClient: OpenAiImageClient = {
+    async createImage(request) {
+        const isEdit = request.referenceImages && request.referenceImages.length > 0;
+        const endpoint = isEdit
+            ? 'https://api.openai.com/v1/images/edits'
+            : 'https://api.openai.com/v1/images/generations';
+
+        let body: BodyInit;
+        const headers: Record<string, string> = {
+            'Authorization': `Bearer ${request.apiKey}`,
+        };
+
+        if (isEdit) {
+            const formData = new FormData();
+            formData.append('model', 'gpt-image-1.5');
+            formData.append('prompt', request.prompt);
+            formData.append('n', '1');
+
+            request.referenceImages?.forEach((file) => {
+                formData.append('image[]', file);
+            });
+
+            if (request.size && request.size !== 'auto') formData.append('size', request.size);
+            if (request.quality) formData.append('quality', request.quality);
+            if (request.background && request.background !== 'auto') formData.append('background', request.background);
+
+            body = formData;
+        } else {
+            headers['Content-Type'] = 'application/json';
+            const jsonBody: {
+                model: string;
+                prompt: string;
+                n: number;
+                size?: string;
+                quality?: ImageQuality;
+                background?: 'transparent' | 'opaque';
+            } = {
+                model: 'gpt-image-1.5',
+                prompt: request.prompt,
+                n: 1,
+            };
+            if (request.size && request.size !== 'auto') jsonBody.size = request.size;
+            if (request.quality) jsonBody.quality = request.quality;
+            if (request.background && request.background !== 'auto') jsonBody.background = request.background;
+
+            body = JSON.stringify(jsonBody);
+        }
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers,
+            body,
         });
 
-        if (params.size && params.size !== 'auto') formData.append('size', params.size);
-        if (params.quality) formData.append('quality', params.quality);
-        if (params.background && params.background !== 'auto') formData.append('background', params.background);
+        if (!response.ok) {
+            const errorData = await response.json().catch((): { error?: { message?: string } } | null => null);
+            throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
+        }
 
-        body = formData;
-        // Do NOT set Content-Type header when using FormData; fetch sets it automatically with the boundary
-    } else {
-        // JSON for standard generations
-        headers['Content-Type'] = 'application/json';
-        const jsonBody: {
-            model: string;
-            prompt: string;
-            n: number;
-            size?: string;
-            quality?: 'low' | 'medium' | 'high';
-            background?: 'transparent' | 'opaque';
-        } = {
-            model: "gpt-image-1.5",
-            prompt,
-            n: 1,
-        };
-        if (params.size && params.size !== 'auto') jsonBody.size = params.size;
-        if (params.quality) jsonBody.quality = params.quality;
-        if (params.background && params.background !== 'auto') jsonBody.background = params.background;
+        const data: { data?: OpenAiImageResponse[] } = await response.json();
 
-        body = JSON.stringify(jsonBody);
-    }
+        if (!data.data || data.data.length === 0) {
+            throw new Error('No image data returned from OpenAI');
+        }
 
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers,
-        body
-    });
-
-    if (!response.ok) {
-        const errorData = await response.json().catch((): { error?: { message?: string } } | null => null);
-        throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
-    }
-
-    const data: { data?: Array<{ b64_json?: string }> } = await response.json();
-
-    if (!data.data || data.data.length === 0) {
-        throw new Error('No image data returned from OpenAI');
-    }
-
-    return data.data[0];
+        return data.data[0];
+    },
 };

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,9 +1,8 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Undo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy } from 'lucide-react';
-import { generateImageWithGPTImage15 } from '../utils/openai';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import type { ArchiveImage } from '../db/types';
-import { fileToDataURL, dataURLtoFile } from '../utils/file';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
@@ -49,7 +48,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
             setCurrentImageUrl(image.url);
 
             if (image.references && image.references.length > 0) {
-                const files = image.references.map((dataUrl, i) => dataURLtoFile(dataUrl, `ref-${i}.png`));
+                const files = imageWorkflow.hydrateReferences(image.references);
                 setRefImages(files);
                 setRefPreviews(image.references);
             }
@@ -92,8 +91,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         if (!canvas) return;
         const dataUrl = canvas.toDataURL('image/png');
 
-        // Convert current refImages to data URLs to persist them
-        const refDataUrls = await Promise.all(refImages.map(file => fileToDataURL(file)));
+        const refDataUrls = await imageWorkflow.serializeReferences(refImages);
 
         onSave(dataUrl, isCopy, refDataUrls);
     };
@@ -105,27 +103,21 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         setAiError(null);
 
         try {
-            // 1. Get current canvas as blob
             const canvas = canvasRef.current;
             const blob = await new Promise<Blob>((resolve, reject) => {
                 canvas.toBlob((b: Blob | null) => b ? resolve(b) : reject(new Error('Canvas conversion failed')), 'image/png');
             });
 
-            // 2. Wrap in File object
-            const file = new File([blob], 'edit-input.png', { type: 'image/png' });
-
-            // 3. Call OpenAI
-            const result = await generateImageWithGPTImage15(apiKey, aiPrompt, {
-                referenceImages: [file, ...refImages],
-                // Preserve current view settings if possible, though edit might override
+            const newUrl = await imageWorkflow.edit({
+                apiKey,
+                prompt: aiPrompt,
+                sourceImage: blob,
+                referenceImages: refImages,
                 quality: 'medium',
             });
 
-            if (result.b64_json) {
-                const newUrl = `data:image/png;base64,${result.b64_json}`;
-                setCurrentImageUrl(newUrl);
-                setAiPrompt(''); // Clear prompt on success
-            }
+            setCurrentImageUrl(newUrl);
+            setAiPrompt('');
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'AI Edit failed');
         } finally {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
-import { generateImageWithGPTImage15 } from '../utils/openai';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storage } from '../services/StorageService';
 import type { ArchiveImage } from '../db/types';
-import { fileToDataURL, dataURLtoFile } from '../utils/file';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
 interface GenerateViewProps {
@@ -100,7 +99,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
             if (val) {
                 try {
                     const refs = JSON.parse(val) as string[];
-                    const files = refs.map((dataUrl, i) => dataURLtoFile(dataUrl, `ref-${i}.png`));
+                    const files = imageWorkflow.hydrateReferences(refs);
                     setReferenceImages(files);
                     setReferencePreviews(refs);
                     // Clear it so it doesn't persist forever
@@ -143,33 +142,21 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         setLoading(true);
         setError(null);
         try {
-            // Final validation before call
-            const safeSize = VALID_SIZES.includes(aspectRatio) ? aspectRatio : '1024x1024';
-
-            // Build final prompt with style modifiers
-            const modifiers: string[] = [];
-            if (style !== 'none') modifiers.push(style);
-            if (lighting !== 'none') modifiers.push(lighting);
-            if (palette !== 'none') modifiers.push(`color palette: ${palette}`);
-
-            let finalPrompt = prompt;
-            if (modifiers.length > 0) {
-                finalPrompt = `${prompt}, ${modifiers.join(', ')}`;
-            }
-
-            const result = await generateImageWithGPTImage15(apiKey, finalPrompt, {
+            const imageUrl = await imageWorkflow.generate({
+                apiKey,
+                prompt,
                 quality,
-                size: safeSize,
+                aspectRatio,
                 background,
-                referenceImages
+                style,
+                lighting,
+                palette,
+                referenceImages,
             });
 
-            if (result.b64_json) {
-                const imageUrl = `data:image/png;base64,${result.b64_json}`;
-                setCurrentResult(imageUrl);
-                setIsSaved(false); // New image generated
-                await storage.save('generate_current_result', imageUrl);
-            }
+            setCurrentResult(imageUrl);
+            setIsSaved(false);
+            await storage.save('generate_current_result', imageUrl);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to generate image');
         } finally {
@@ -189,7 +176,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         if (!currentResult || isSaved) return;
 
         const saveRefImages = async () => {
-            const refDataUrls = await Promise.all(referenceImages.map(file => fileToDataURL(file)));
+            const refDataUrls = await imageWorkflow.serializeReferences(referenceImages);
 
             const newImage: ArchiveImage = {
                 id: crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- add an `ImageWorkflow` module that owns prompt composition, request mode selection, reference hydration, and reference serialization for generation and edit flows
- narrow `openai.ts` to a typed OpenAI image client so the workflow depends on one injectable boundary instead of view-local request assembly
- simplify `GenerateView` and `EditorView` so they orchestrate UI state while the workflow module owns the image operation details

## Testing
- npm run lint
- npm run build