### PR TITLE
refactor: centralize generate session state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import ImageDetailModal from './components/ImageDetailModal'
 import Toast from './components/Toast'
 import type { ToastType } from './components/Toast'
 import ConfirmModal from './components/ConfirmModal'
-import { storage } from './services/StorageService'
+import { generateSessionStore } from './generate-session/GenerateSession'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useImageArchive } from './hooks/useImageArchive'
 import type { ArchiveImage } from './db/types'
@@ -111,20 +111,7 @@ function App() {
     }
 
     const handleCreateSimilar = async (image: ArchiveImage) => {
-        localStorage.setItem('aura_generate_prompt', JSON.stringify(image.prompt))
-        localStorage.setItem('aura_generate_quality', JSON.stringify(image.quality))
-        localStorage.setItem('aura_generate_aspect_ratio', JSON.stringify(image.aspectRatio))
-        localStorage.setItem('aura_generate_background', JSON.stringify(image.background || 'auto'))
-        localStorage.setItem('aura_generate_style', JSON.stringify(image.style || 'none'))
-        localStorage.setItem('aura_generate_lighting', JSON.stringify(image.lighting || 'none'))
-        localStorage.setItem('aura_generate_palette', JSON.stringify(image.palette || 'none'))
-        localStorage.setItem('aura_generate_is_saved', JSON.stringify(false))
-
-        if (image.references && image.references.length > 0) {
-            await storage.save('generate_transferred_references', JSON.stringify(image.references));
-        } else {
-            await storage.remove('generate_transferred_references');
-        }
+        await generateSessionStore.transferFromArchive(image)
 
         setSelectedImage(null)
         setCurrentView('generate')

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+import { storage, type StorageProvider } from '../services/StorageService';
+import type { ImageBackground, ImageQuality } from '../utils/openai';
+
+const GENERATE_DRAFT_KEY = 'aura_generate_draft';
+const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
+const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
+const VALID_ASPECT_RATIOS = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+
+const LEGACY_KEYS = {
+    prompt: 'aura_generate_prompt',
+    quality: 'aura_generate_quality',
+    aspectRatio: 'aura_generate_aspect_ratio',
+    background: 'aura_generate_background',
+    style: 'aura_generate_style',
+    lighting: 'aura_generate_lighting',
+    palette: 'aura_generate_palette',
+    isSaved: 'aura_generate_is_saved',
+} as const;
+
+export interface GenerateDraft {
+    prompt: string;
+    quality: ImageQuality;
+    aspectRatio: string;
+    background: ImageBackground;
+    style: string;
+    lighting: string;
+    palette: string;
+    isSaved: boolean;
+}
+
+export interface GenerateSessionStore {
+    readDraft(): GenerateDraft;
+    writeDraft(draft: GenerateDraft): void;
+    transferFromArchive(image: ArchiveImage): Promise<void>;
+    loadCurrentResult(): Promise<string | null>;
+    saveCurrentResult(result: string): Promise<void>;
+    clearCurrentResult(): Promise<void>;
+    consumeTransferredReferences(): Promise<string[]>;
+}
+
+interface CreateGenerateSessionStoreDeps {
+    blobStorage?: StorageProvider;
+    localStorage?: Storage;
+}
+
+const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
+    prompt: '',
+    quality: 'medium',
+    aspectRatio: '1024x1024',
+    background: 'auto',
+    style: 'none',
+    lighting: 'none',
+    palette: 'none',
+    isSaved: false,
+};
+
+class LocalGenerateSessionStore implements GenerateSessionStore {
+    private readonly blobStorage: StorageProvider;
+    private readonly localStorage: Storage;
+
+    constructor(blobStorage: StorageProvider, localStorage: Storage) {
+        this.blobStorage = blobStorage;
+        this.localStorage = localStorage;
+    }
+
+    readDraft(): GenerateDraft {
+        const storedDraft = this.readJson<GenerateDraft>(GENERATE_DRAFT_KEY);
+        if (storedDraft) {
+            return sanitizeGenerateDraft(storedDraft);
+        }
+
+        return sanitizeGenerateDraft({
+            prompt: this.readLegacyValue(LEGACY_KEYS.prompt, DEFAULT_GENERATE_DRAFT.prompt),
+            quality: this.readLegacyValue(LEGACY_KEYS.quality, DEFAULT_GENERATE_DRAFT.quality),
+            aspectRatio: this.readLegacyValue(LEGACY_KEYS.aspectRatio, DEFAULT_GENERATE_DRAFT.aspectRatio),
+            background: this.readLegacyValue(LEGACY_KEYS.background, DEFAULT_GENERATE_DRAFT.background),
+            style: this.readLegacyValue(LEGACY_KEYS.style, DEFAULT_GENERATE_DRAFT.style),
+            lighting: this.readLegacyValue(LEGACY_KEYS.lighting, DEFAULT_GENERATE_DRAFT.lighting),
+            palette: this.readLegacyValue(LEGACY_KEYS.palette, DEFAULT_GENERATE_DRAFT.palette),
+            isSaved: this.readLegacyValue(LEGACY_KEYS.isSaved, DEFAULT_GENERATE_DRAFT.isSaved),
+        });
+    }
+
+    writeDraft(draft: GenerateDraft): void {
+        const nextDraft = sanitizeGenerateDraft(draft);
+        this.localStorage.setItem(GENERATE_DRAFT_KEY, JSON.stringify(nextDraft));
+        this.clearLegacyDraftKeys();
+    }
+
+    async transferFromArchive(image: ArchiveImage): Promise<void> {
+        this.writeDraft({
+            prompt: image.prompt,
+            quality: coerceQuality(image.quality),
+            aspectRatio: image.aspectRatio,
+            background: coerceBackground(image.background),
+            style: image.style || 'none',
+            lighting: image.lighting || 'none',
+            palette: image.palette || 'none',
+            isSaved: false,
+        });
+
+        if (image.references && image.references.length > 0) {
+            await this.blobStorage.save(GENERATE_TRANSFERRED_REFERENCES_KEY, JSON.stringify(image.references));
+            return;
+        }
+
+        await this.blobStorage.remove(GENERATE_TRANSFERRED_REFERENCES_KEY);
+    }
+
+    loadCurrentResult(): Promise<string | null> {
+        return this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
+    }
+
+    saveCurrentResult(result: string): Promise<void> {
+        return this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
+    }
+
+    clearCurrentResult(): Promise<void> {
+        return this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY);
+    }
+
+    async consumeTransferredReferences(): Promise<string[]> {
+        const value = await this.blobStorage.load(GENERATE_TRANSFERRED_REFERENCES_KEY);
+        await this.blobStorage.remove(GENERATE_TRANSFERRED_REFERENCES_KEY);
+
+        if (!value) {
+            return [];
+        }
+
+        try {
+            const references = JSON.parse(value) as string[];
+            return Array.isArray(references) ? references : [];
+        } catch {
+            return [];
+        }
+    }
+
+    private readLegacyValue<T>(key: string, fallback: T): T {
+        const rawValue = this.localStorage.getItem(key);
+        if (!rawValue) {
+            return fallback;
+        }
+
+        try {
+            return JSON.parse(rawValue) as T;
+        } catch {
+            return rawValue as T;
+        }
+    }
+
+    private readJson<T>(key: string): T | null {
+        const rawValue = this.localStorage.getItem(key);
+        if (!rawValue) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(rawValue) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    private clearLegacyDraftKeys() {
+        Object.values(LEGACY_KEYS).forEach((key) => this.localStorage.removeItem(key));
+    }
+}
+
+export function createGenerateSessionStore(deps: CreateGenerateSessionStoreDeps = {}): GenerateSessionStore {
+    return new LocalGenerateSessionStore(
+        deps.blobStorage ?? storage,
+        deps.localStorage ?? window.localStorage,
+    );
+}
+
+export const generateSessionStore = createGenerateSessionStore();
+
+export function useGenerateDraft(store: GenerateSessionStore = generateSessionStore) {
+    const [draft, setDraft] = useState<GenerateDraft>(() => store.readDraft());
+
+    useEffect(() => {
+        store.writeDraft(draft);
+    }, [draft, store]);
+
+    return [draft, setDraft] as const;
+}
+
+const sanitizeGenerateDraft = (draft: Partial<GenerateDraft>): GenerateDraft => ({
+    prompt: typeof draft.prompt === 'string' ? draft.prompt : DEFAULT_GENERATE_DRAFT.prompt,
+    quality: coerceQuality(draft.quality),
+    aspectRatio: typeof draft.aspectRatio === 'string' && VALID_ASPECT_RATIOS.has(draft.aspectRatio)
+        ? draft.aspectRatio
+        : DEFAULT_GENERATE_DRAFT.aspectRatio,
+    background: coerceBackground(draft.background),
+    style: typeof draft.style === 'string' ? draft.style : DEFAULT_GENERATE_DRAFT.style,
+    lighting: typeof draft.lighting === 'string' ? draft.lighting : DEFAULT_GENERATE_DRAFT.lighting,
+    palette: typeof draft.palette === 'string' ? draft.palette : DEFAULT_GENERATE_DRAFT.palette,
+    isSaved: typeof draft.isSaved === 'boolean' ? draft.isSaved : DEFAULT_GENERATE_DRAFT.isSaved,
+});
+
+const coerceQuality = (quality: unknown): ImageQuality => {
+    return quality === 'low' || quality === 'medium' || quality === 'high'
+        ? quality
+        : DEFAULT_GENERATE_DRAFT.quality;
+};
+
+const coerceBackground = (background: unknown): ImageBackground => {
+    return background === 'auto' || background === 'opaque' || background === 'transparent'
+        ? background
+        : DEFAULT_GENERATE_DRAFT.background;
+};

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
-import { storage } from '../services/StorageService';
 import type { ArchiveImage } from '../db/types';
+import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
@@ -60,21 +59,19 @@ const PALETTES = [
 ];
 
 const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
-    const [prompt, setPrompt] = useLocalStorage('aura_generate_prompt', '');
-    const [quality, setQuality] = useLocalStorage<'low' | 'medium' | 'high'>('aura_generate_quality', 'medium');
-    const [aspectRatio, setAspectRatio] = useLocalStorage('aura_generate_aspect_ratio', '1024x1024');
-    const [background, setBackground] = useLocalStorage<'opaque' | 'transparent' | 'auto'>('aura_generate_background', 'auto');
-    const [style, setStyle] = useLocalStorage('aura_generate_style', 'none');
-    const [lighting, setLighting] = useLocalStorage('aura_generate_lighting', 'none');
-    const [palette, setPalette] = useLocalStorage('aura_generate_palette', 'none');
+    const [draft, setDraft] = useGenerateDraft();
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [isSaved, setIsSaved] = useLocalStorage('aura_generate_is_saved', false);
     const [referenceImages, setReferenceImages] = useState<File[]>([]);
     const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
+    const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
+
+    const updateDraft = (patch: Partial<typeof draft>) => {
+        setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
+    };
 
     const handleNextReference = () => {
         if (viewingReferenceIndex === null) return;
@@ -91,22 +88,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     };
 
     useEffect(() => {
-        storage.load('generate_current_result').then(val => {
+        generateSessionStore.loadCurrentResult().then(val => {
             if (val) setCurrentResult(val);
         });
 
-        storage.load('generate_transferred_references').then(val => {
-            if (val) {
-                try {
-                    const refs = JSON.parse(val) as string[];
-                    const files = imageWorkflow.hydrateReferences(refs);
-                    setReferenceImages(files);
-                    setReferencePreviews(refs);
-                    // Clear it so it doesn't persist forever
-                    storage.remove('generate_transferred_references');
-                } catch (e) {
-                    console.error('Failed to load transferred references', e);
-                }
+        generateSessionStore.consumeTransferredReferences().then((refs) => {
+            if (refs.length > 0) {
+                const files = imageWorkflow.hydrateReferences(refs);
+                setReferenceImages(files);
+                setReferencePreviews(refs);
             }
         });
 
@@ -124,13 +114,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         };
     }, [referencePreviews]);
 
-    // Sanitize persistent state for GPT-Image-1.5 compatibility
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {
-            console.warn(`Sanitizing invalid aspectRatio: ${aspectRatio}`);
-            setAspectRatio('1024x1024');
+            setDraft((currentDraft) => ({ ...currentDraft, aspectRatio: '1024x1024' }));
         }
-    }, [aspectRatio, setAspectRatio]);
+    }, [aspectRatio, setDraft]);
 
     const handleGenerate = async () => {
         if (!apiKey) {
@@ -155,8 +143,8 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
             });
 
             setCurrentResult(imageUrl);
-            setIsSaved(false);
-            await storage.save('generate_current_result', imageUrl);
+            updateDraft({ isSaved: false });
+            await generateSessionStore.saveCurrentResult(imageUrl);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to generate image');
         } finally {
@@ -196,7 +184,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
             };
 
             onSaveImage(newImage);
-            setIsSaved(true);
+            updateDraft({ isSaved: true });
         };
 
         saveRefImages();
@@ -241,7 +229,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <select
                                 value=""
                                 onChange={(e) => {
-                                    if (e.target.value) setPrompt(e.target.value);
+                                    if (e.target.value) updateDraft({ prompt: e.target.value });
                                 }}
                                 className="example-prompt-select"
                             >
@@ -254,7 +242,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                         <textarea
                             placeholder="Describe what you want to see... (e.g., 'A bioluminescent forest with crystal butterflies')"
                             value={prompt}
-                            onChange={(e) => setPrompt(e.target.value)}
+                            onChange={(e) => updateDraft({ prompt: e.target.value })}
                             className="prompt-input"
                         />
                     </div>
@@ -265,15 +253,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <div className="toggle-group">
                                 <button
                                     className={quality === 'low' ? 'active' : ''}
-                                    onClick={() => setQuality('low')}
+                                    onClick={() => updateDraft({ quality: 'low' })}
                                 >Low</button>
                                 <button
                                     className={quality === 'medium' ? 'active' : ''}
-                                    onClick={() => setQuality('medium')}
+                                    onClick={() => updateDraft({ quality: 'medium' })}
                                 >Medium</button>
                                 <button
                                     className={quality === 'high' ? 'active' : ''}
-                                    onClick={() => setQuality('high')}
+                                    onClick={() => updateDraft({ quality: 'high' })}
                                 >High</button>
                             </div>
                         </div>
@@ -282,7 +270,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>ASPECT RATIO</label>
                             <select
                                 value={VALID_SIZES.includes(aspectRatio) ? aspectRatio : '1024x1024'}
-                                onChange={(e) => setAspectRatio(e.target.value)}
+                                onChange={(e) => updateDraft({ aspectRatio: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="auto">Auto</option>
@@ -297,15 +285,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <div className="toggle-group">
                                 <button
                                     className={background === 'auto' ? 'active' : ''}
-                                    onClick={() => setBackground('auto')}
+                                    onClick={() => updateDraft({ background: 'auto' })}
                                 >Auto</button>
                                 <button
                                     className={background === 'opaque' ? 'active' : ''}
-                                    onClick={() => setBackground('opaque')}
+                                    onClick={() => updateDraft({ background: 'opaque' })}
                                 >Opaque</button>
                                 <button
                                     className={background === 'transparent' ? 'active' : ''}
-                                    onClick={() => setBackground('transparent')}
+                                    onClick={() => updateDraft({ background: 'transparent' })}
                                 >Transparent</button>
                             </div>
                         </div>
@@ -314,7 +302,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>STYLE</label>
                             <select
                                 value={style}
-                                onChange={(e) => setStyle(e.target.value)}
+                                onChange={(e) => updateDraft({ style: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -328,7 +316,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>LIGHTING</label>
                             <select
                                 value={lighting}
-                                onChange={(e) => setLighting(e.target.value)}
+                                onChange={(e) => updateDraft({ lighting: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -342,7 +330,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>PALETTE</label>
                             <select
                                 value={palette}
-                                onChange={(e) => setPalette(e.target.value)}
+                                onChange={(e) => updateDraft({ palette: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -435,7 +423,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                 </button>
                                 <button onClick={async () => {
                                     setCurrentResult(null);
-                                    await storage.remove('generate_current_result');
+                                    await generateSessionStore.clearCurrentResult();
                                 }} className="aura-btn aura-btn--danger">
                                     <Trash2 size={18} />
                                 </button>


### PR DESCRIPTION
## Summary
- add a `GenerateSession` module that owns generate draft persistence, current result persistence, and archive-to-generate transfer behavior
- migrate `GenerateView` from scattered `useLocalStorage` keys to one draft boundary while preserving compatibility with legacy stored keys
- simplify `App` so `Create Similar` uses the session boundary instead of writing magic storage keys directly

## Testing
- npm run lint
- npm run build