### PR TITLE
refactor: centralize archive interaction state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ImageDetailModal from './components/ImageDetailModal'
 import Toast from './components/Toast'
 import type { ToastType } from './components/Toast'
 import ConfirmModal from './components/ConfirmModal'
+import { useArchiveController } from './archive/useArchiveController'
 import { generateSessionStore } from './generate-session/GenerateSession'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useImageArchive } from './hooks/useImageArchive'
@@ -19,11 +20,7 @@ function App() {
     const { images, addImage, deleteImage } = useImageArchive()
     const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '')
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null)
-    const [selectedImage, setSelectedImage] = useState<ArchiveImage | null>(null)
     const [toasts, setToasts] = useState<{ id: string; message: string; type: ToastType }[]>([])
-    const [confirmConfig, setConfirmConfig] = useState<{ isOpen: boolean; title: string; message: string; onConfirm: () => void; type?: 'danger' | 'info' }>({
-        isOpen: false, title: '', message: '', onConfirm: () => { }, type: 'info'
-    })
     const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark')
 
     useEffect(() => {
@@ -64,18 +61,15 @@ function App() {
     }
 
     const handleDeleteImage = async (id: string) => {
-        setConfirmConfig({
-            isOpen: true,
-            title: 'Delete Masterpiece?',
-            message: 'This will permanently remove the image and its binary data from your local storage. This action cannot be undone.',
-            type: 'danger',
-            onConfirm: async () => {
-                await deleteImage(id)
-                setConfirmConfig(prev => ({ ...prev, isOpen: false }))
-                addToast('Image deleted permanently', 'info')
-                if (selectedImage?.id === id) setSelectedImage(null)
-            }
-        })
+        await deleteImage(id)
+    }
+
+    const handleDeleteImages = async (ids: string[]) => {
+        for (const id of ids) {
+            await handleDeleteImage(id)
+        }
+
+        addToast(ids.length === 1 ? 'Image deleted permanently' : `${ids.length} images deleted permanently`, 'info')
     }
 
     const handleEditImage = (image: ArchiveImage) => {
@@ -112,27 +106,16 @@ function App() {
 
     const handleCreateSimilar = async (image: ArchiveImage) => {
         await generateSessionStore.transferFromArchive(image)
-
-        setSelectedImage(null)
         setCurrentView('generate')
         addToast('Settings & references transferred', 'info')
     }
 
-    const handleNextImage = () => {
-        if (!selectedImage) return
-        const currentIndex = images.findIndex(img => img.id === selectedImage.id)
-        if (currentIndex < images.length - 1) {
-            setSelectedImage(images[currentIndex + 1])
-        }
-    }
-
-    const handlePreviousImage = () => {
-        if (!selectedImage) return
-        const currentIndex = images.findIndex(img => img.id === selectedImage.id)
-        if (currentIndex > 0) {
-            setSelectedImage(images[currentIndex - 1])
-        }
-    }
+    const archiveController = useArchiveController({
+        images,
+        onDeleteImages: handleDeleteImages,
+        onEditImage: handleEditImage,
+        onCreateSimilar: handleCreateSimilar,
+    })
 
     const renderView = () => {
         switch (currentView) {
@@ -141,9 +124,14 @@ function App() {
             case 'archive':
                 return <ArchiveView
                     images={images}
-                    onDeleteImage={handleDeleteImage}
-                    onEditImage={handleEditImage}
-                    onSelectImage={setSelectedImage}
+                    selectedIds={archiveController.selectedIds}
+                    onDeleteImage={(id) => archiveController.requestDelete([id])}
+                    onEditImage={archiveController.editImage}
+                    onOpenImage={archiveController.openImage}
+                    onToggleSelection={archiveController.toggleSelection}
+                    onToggleSelectAll={archiveController.toggleSelectAll}
+                    onClearSelection={archiveController.clearSelection}
+                    onDeleteSelected={() => archiveController.requestDelete(Array.from(archiveController.selectedIds))}
                 />;
             case 'editor':
                 return <EditorView image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
@@ -168,21 +156,28 @@ function App() {
                 </div>
             </main>
 
-            {selectedImage && (
+            {archiveController.selectedImage && (
                 <ImageDetailModal
-                    image={selectedImage}
-                    onClose={() => setSelectedImage(null)}
-                    onEdit={handleEditImage}
-                    onDelete={handleDeleteImage}
-                    onCreateSimilar={() => handleCreateSimilar(selectedImage)}
-                    onNext={handleNextImage}
-                    onPrevious={handlePreviousImage}
+                    image={archiveController.selectedImage}
+                    onClose={archiveController.closeImage}
+                    onEdit={() => archiveController.selectedImage && archiveController.editImage(archiveController.selectedImage)}
+                    onDelete={() => archiveController.selectedImage && archiveController.requestDelete([archiveController.selectedImage.id])}
+                    onCreateSimilar={archiveController.createSimilar}
+                    onNext={archiveController.showNextImage}
+                    onPrevious={archiveController.showPreviousImage}
                 />
             )}
 
             <ConfirmModal
-                {...confirmConfig}
-                onCancel={() => setConfirmConfig(prev => ({ ...prev, isOpen: false }))}
+                isOpen={archiveController.pendingDeleteIds.length > 0}
+                title={archiveController.pendingDeleteIds.length === 1 ? 'Delete Masterpiece?' : `Delete ${archiveController.pendingDeleteIds.length} Masterpieces?`}
+                message={archiveController.pendingDeleteIds.length === 1
+                    ? 'This will permanently remove the image and its binary data from your local storage. This action cannot be undone.'
+                    : `You are about to permanently remove ${archiveController.pendingDeleteIds.length} images and their binary data. This action cannot be reversed.`}
+                confirmText={archiveController.pendingDeleteIds.length === 1 ? 'Delete' : 'Delete All'}
+                type="danger"
+                onConfirm={archiveController.confirmDelete}
+                onCancel={archiveController.cancelDelete}
             />
 
             <div className="toast-container">

--- a/src/archive/useArchiveController.ts
+++ b/src/archive/useArchiveController.ts
@@ -1,0 +1,165 @@
+import { useMemo, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+
+interface UseArchiveControllerOptions {
+    images: ArchiveImage[];
+    onDeleteImages: (ids: string[]) => Promise<void>;
+    onEditImage: (image: ArchiveImage) => void;
+    onCreateSimilar: (image: ArchiveImage) => Promise<void> | void;
+}
+
+export function useArchiveController({
+    images,
+    onDeleteImages,
+    onEditImage,
+    onCreateSimilar,
+}: UseArchiveControllerOptions) {
+    const [selectedIdsState, setSelectedIdsState] = useState<Set<string>>(new Set());
+    const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+    const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
+    const imageIds = useMemo(() => new Set(images.map((image) => image.id)), [images]);
+
+    const selectedIds = useMemo(
+        () => new Set(Array.from(selectedIdsState).filter((id) => imageIds.has(id))),
+        [imageIds, selectedIdsState],
+    );
+
+    const selectedImage = useMemo(
+        () => images.find((image) => image.id === selectedImageId) ?? null,
+        [images, selectedImageId],
+    );
+
+    const toggleSelection = (id: string) => {
+        setSelectedIdsState((currentSelectedIds) => {
+            const nextSelectedIds = new Set(currentSelectedIds);
+
+            if (nextSelectedIds.has(id)) {
+                nextSelectedIds.delete(id);
+            } else {
+                nextSelectedIds.add(id);
+            }
+
+            return nextSelectedIds;
+        });
+    };
+
+    const clearSelection = () => {
+        setSelectedIdsState(new Set());
+    };
+
+    const toggleSelectAll = (ids: string[]) => {
+        const nextIds = ids.filter(Boolean);
+        if (nextIds.length === 0) {
+            return;
+        }
+
+        setSelectedIdsState((currentSelectedIds) => {
+            const areAllSelected = nextIds.every((id) => currentSelectedIds.has(id));
+
+            if (areAllSelected) {
+                const remainingSelectedIds = new Set(currentSelectedIds);
+                nextIds.forEach((id) => remainingSelectedIds.delete(id));
+                return remainingSelectedIds;
+            }
+
+            const mergedSelectedIds = new Set(currentSelectedIds);
+            nextIds.forEach((id) => mergedSelectedIds.add(id));
+            return mergedSelectedIds;
+        });
+    };
+
+    const openImage = (image: ArchiveImage) => {
+        setSelectedImageId(image.id);
+    };
+
+    const closeImage = () => {
+        setSelectedImageId(null);
+    };
+
+    const editImage = (image: ArchiveImage) => {
+        setSelectedImageId(null);
+        onEditImage(image);
+    };
+
+    const createSimilar = async () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        setSelectedImageId(null);
+        await onCreateSimilar(selectedImage);
+    };
+
+    const requestDelete = (ids: string[]) => {
+        const nextIds = Array.from(new Set(ids.filter(Boolean)));
+        if (nextIds.length === 0) {
+            return;
+        }
+
+        setPendingDeleteIds(nextIds);
+    };
+
+    const confirmDelete = async () => {
+        if (pendingDeleteIds.length === 0) {
+            return;
+        }
+
+        const idsToDelete = pendingDeleteIds;
+        await onDeleteImages(idsToDelete);
+
+        setPendingDeleteIds([]);
+        setSelectedIdsState((currentSelectedIds) => {
+            const remainingSelectedIds = new Set(currentSelectedIds);
+            idsToDelete.forEach((id) => remainingSelectedIds.delete(id));
+            return remainingSelectedIds;
+        });
+
+        if (selectedImageId && idsToDelete.includes(selectedImageId)) {
+            setSelectedImageId(null);
+        }
+    };
+
+    const cancelDelete = () => {
+        setPendingDeleteIds([]);
+    };
+
+    const showPreviousImage = () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        const currentIndex = images.findIndex((image) => image.id === selectedImage.id);
+        if (currentIndex > 0) {
+            setSelectedImageId(images[currentIndex - 1].id);
+        }
+    };
+
+    const showNextImage = () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        const currentIndex = images.findIndex((image) => image.id === selectedImage.id);
+        if (currentIndex >= 0 && currentIndex < images.length - 1) {
+            setSelectedImageId(images[currentIndex + 1].id);
+        }
+    };
+
+    return {
+        selectedIds,
+        selectedImage,
+        pendingDeleteIds,
+        toggleSelection,
+        clearSelection,
+        toggleSelectAll,
+        openImage,
+        closeImage,
+        editImage,
+        createSimilar,
+        requestDelete,
+        confirmDelete,
+        cancelDelete,
+        showPreviousImage,
+        showNextImage,
+    };
+}

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -5,8 +5,8 @@ import type { ArchiveImage } from '../db/types';
 interface ImageDetailModalProps {
     image: ArchiveImage;
     onClose: () => void;
-    onEdit: (image: ArchiveImage) => void;
-    onDelete: (id: string) => void;
+    onEdit: () => void;
+    onDelete: () => void;
     onCreateSimilar: () => void;
     onNext: () => void;
     onPrevious: () => void;
@@ -58,7 +58,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                             <button className="aura-btn aura-btn--primary" onClick={downloadImage}>
                                 <Download size={18} /> Download
                             </button>
-                            <button className="aura-btn aura-btn--glass" onClick={() => onEdit(image)}>
+                            <button className="aura-btn aura-btn--glass" onClick={onEdit}>
                                 <Edit2 size={18} /> Edit
                             </button>
                         </div>
@@ -142,7 +142,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                 <Copy size={18} /> Copy Prompt
                             </button>
                             <div className="divider" style={{ height: '1px', background: 'rgba(255,255,255,0.1)', margin: '1rem 0' }} />
-                            <button className="aura-btn aura-btn--danger" onClick={() => onDelete(image.id)} style={{ width: '100%', padding: '1rem' }}>
+                            <button className="aura-btn aura-btn--danger" onClick={onDelete} style={{ width: '100%', padding: '1rem' }}>
                                 <Trash2 size={18} /> Delete Permanently
                             </button>
                         </div>

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -4,37 +4,32 @@ import type { ArchiveImage } from '../db/types';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
 import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import ConfirmModal from '../components/ConfirmModal';
 
 interface ArchiveViewProps {
     images: ArchiveImage[];
+    selectedIds: Set<string>;
     onDeleteImage: (id: string) => void;
     onEditImage: (image: ArchiveImage) => void;
-    onSelectImage: (image: ArchiveImage) => void;
+    onOpenImage: (image: ArchiveImage) => void;
+    onToggleSelection: (id: string) => void;
+    onToggleSelectAll: (ids: string[]) => void;
+    onClearSelection: () => void;
+    onDeleteSelected: () => void;
 }
 
-const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEditImage, onSelectImage }) => {
+const ArchiveView: React.FC<ArchiveViewProps> = ({
+    images,
+    selectedIds,
+    onDeleteImage,
+    onEditImage,
+    onOpenImage,
+    onToggleSelection,
+    onToggleSelectAll,
+    onClearSelection,
+    onDeleteSelected,
+}) => {
     const [search, setSearch] = useLocalStorage('archive_search', '');
-    const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
-    const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
     const [isZipping, setIsZipping] = React.useState(false);
-
-    const toggleSelect = (id: string) => {
-        setSelectedIds(prev => {
-            const next = new Set(prev);
-            if (next.has(id)) next.delete(id);
-            else next.add(id);
-            return next;
-        });
-    };
-
-    const selectAll = () => {
-        if (selectedIds.size === filteredImages.length) {
-            setSelectedIds(new Set());
-        } else {
-            setSelectedIds(new Set(filteredImages.map(img => img.id)));
-        }
-    };
 
     const handleBulkDownload = async () => {
         if (selectedIds.size === 0) return;
@@ -73,15 +68,11 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
         }
     };
 
-    const handleBulkDelete = () => {
-        selectedIds.forEach(id => onDeleteImage(id));
-        setSelectedIds(new Set());
-        setIsConfirmOpen(false);
-    };
-
     const filteredImages = images.filter(img =>
         img.prompt.toLowerCase().includes(search.toLowerCase())
     );
+    const filteredImageIds = filteredImages.map((image) => image.id);
+    const allFilteredSelected = filteredImageIds.length > 0 && filteredImageIds.every((id) => selectedIds.has(id));
 
     return (
         <div className="archive-container">
@@ -93,11 +84,11 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                     </div>
                     <div className="header-actions">
                         <button
-                            className={`aura-btn aura-btn--glass ${selectedIds.size === filteredImages.length && filteredImages.length > 0 ? 'aura-btn--primary' : ''}`}
-                            onClick={selectAll}
+                            className={`aura-btn aura-btn--glass ${allFilteredSelected ? 'aura-btn--primary' : ''}`}
+                            onClick={() => onToggleSelectAll(filteredImageIds)}
                             disabled={filteredImages.length === 0}
                         >
-                            {selectedIds.size === filteredImages.length && filteredImages.length > 0 ? 'Deselect All' : 'Select All'}
+                            {allFilteredSelected ? 'Deselect All' : 'Select All'}
                         </button>
                         <div className="search-box glass-panel" style={{ background: 'transparent', border: 'none', boxShadow: 'none' }}>
                             <Search size={18} className="search-icon" style={{ position: 'absolute', left: '1rem', pointerEvents: 'none' }} />
@@ -130,9 +121,9 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                             image={img}
                             onDelete={onDeleteImage}
                             onEdit={onEditImage}
-                            onClick={() => onSelectImage(img)}
+                            onClick={() => onOpenImage(img)}
                             selected={selectedIds.has(img.id)}
-                            onSelect={() => toggleSelect(img.id)}
+                            onSelect={() => onToggleSelection(img.id)}
                         />
                     ))}
                 </div>
@@ -145,7 +136,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                         <span>Images Selected</span>
                     </div>
                     <div className="bulk-actions">
-                        <button className="aura-btn aura-btn--glass" onClick={() => setSelectedIds(new Set())}>
+                        <button className="aura-btn aura-btn--glass" onClick={onClearSelection}>
                             <X size={18} /> Cancel
                         </button>
                         <button
@@ -156,22 +147,12 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                             {isZipping ? <Loader2 size={18} className="spin" /> : <Download size={18} />}
                             {isZipping ? 'Generating ZIP...' : 'Download as ZIP'}
                         </button>
-                        <button className="aura-btn aura-btn--danger" onClick={() => setIsConfirmOpen(true)}>
+                        <button className="aura-btn aura-btn--danger" onClick={onDeleteSelected}>
                             <Trash2 size={18} /> Delete All
                         </button>
                     </div>
                 </div>
             )}
-
-            <ConfirmModal
-                isOpen={isConfirmOpen}
-                title={`Delete ${selectedIds.size} Masterpieces?`}
-                message={`You are about to permanently remove ${selectedIds.size} images and their binary data. This action cannot be reversed.`}
-                confirmText="Delete All"
-                type="danger"
-                onConfirm={handleBulkDelete}
-                onCancel={() => setIsConfirmOpen(false)}
-            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add an archive controller hook that owns detail-modal state, selection state, delete confirmation state, and next/previous navigation
- route both single-image and bulk delete through one confirmation flow so archive behavior no longer depends on `ArchiveView` and `App` coordinating through separate delete policies
- fix the detail-modal edit bug by clearing the active modal image before switching to the editor

## Testing
- npm run lint
- npm run build