### PR TITLE
refactor: centralize editor session state

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ npm run preview
 - `npm run dev`
   Starts the Vite development server.
 
+- `npm run dev -- --port 5175`
+  Starts the Vite development server on port 5175.
+
 - `npm run typecheck`
   Runs the TypeScript project build in type-check mode.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
                     onDeleteSelected={() => archiveController.requestDelete(Array.from(archiveController.selectedIds))}
                 />;
             case 'editor':
-                return <EditorView image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
+                return <EditorView key={editingImage?.id ?? 'empty-editor'} image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
             case 'settings':
                 return <SettingsView apiKey={apiKey} onApiKeyChange={handleApiKeyChange} />;
             default:

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
@@ -18,16 +18,21 @@ export function useEditorSession(image: ArchiveImage | null) {
         return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
     });
     const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
+    const referencePreviewsRef = useRef(referencePreviews);
+
+    useEffect(() => {
+        referencePreviewsRef.current = referencePreviews;
+    }, [referencePreviews]);
 
     useEffect(() => {
         return () => {
-            referencePreviews.forEach((url) => {
+            referencePreviewsRef.current.forEach((url) => {
                 if (url.startsWith('blob:')) {
                     URL.revokeObjectURL(url);
                 }
             });
         };
-    }, [referencePreviews]);
+    }, []);
 
     const canvasFilter = useMemo(() => {
         return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+const DEFAULT_BRIGHTNESS = 100;
+const DEFAULT_CONTRAST = 100;
+const DEFAULT_SATURATION = 100;
+const DEFAULT_FILTER = 'none';
+
+export function useEditorSession(image: ArchiveImage | null) {
+    const [brightness, setBrightness] = useLocalStorage('editor_brightness', DEFAULT_BRIGHTNESS);
+    const [contrast, setContrast] = useLocalStorage('editor_contrast', DEFAULT_CONTRAST);
+    const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
+    const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
+    const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
+    const [referenceImages, setReferenceImages] = useState<File[]>(() => {
+        return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
+    });
+    const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
+
+    useEffect(() => {
+        return () => {
+            referencePreviews.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+        };
+    }, [referencePreviews]);
+
+    const canvasFilter = useMemo(() => {
+        return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
+    }, [brightness, contrast, saturation, filter]);
+
+    const addReferenceFiles = (files: File[]) => {
+        if (files.length === 0) {
+            return;
+        }
+
+        setReferenceImages((currentImages) => [...currentImages, ...files]);
+        setReferencePreviews((currentPreviews) => [
+            ...currentPreviews,
+            ...files.map((file) => URL.createObjectURL(file)),
+        ]);
+    };
+
+    const removeReferenceAt = (index: number) => {
+        setReferenceImages((currentImages) => currentImages.filter((_, currentIndex) => currentIndex !== index));
+        setReferencePreviews((currentPreviews) => {
+            const previewToRemove = currentPreviews[index];
+            if (previewToRemove?.startsWith('blob:')) {
+                URL.revokeObjectURL(previewToRemove);
+            }
+
+            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
+        });
+    };
+
+    const resetAdjustments = () => {
+        setBrightness(DEFAULT_BRIGHTNESS);
+        setContrast(DEFAULT_CONTRAST);
+        setSaturation(DEFAULT_SATURATION);
+        setFilter(DEFAULT_FILTER);
+    };
+
+    const serializeReferences = () => {
+        return imageWorkflow.serializeReferences(referenceImages);
+    };
+
+    return {
+        brightness,
+        setBrightness,
+        contrast,
+        setContrast,
+        saturation,
+        setSaturation,
+        filter,
+        setFilter,
+        canvasFilter,
+        currentImageUrl,
+        setCurrentImageUrl,
+        referenceImages,
+        referencePreviews,
+        addReferenceFiles,
+        removeReferenceAt,
+        resetAdjustments,
+        serializeReferences,
+    };
+}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Undo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy } from 'lucide-react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
 import type { ArchiveImage } from '../db/types';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useEditorSession } from '../editor/useEditorSession';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
@@ -13,61 +13,45 @@ interface EditorViewProps {
 const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
 
-    // Persist editor settings globally as requested
-    const [brightness, setBrightness] = useLocalStorage('editor_brightness', 100);
-    const [contrast, setContrast] = useLocalStorage('editor_contrast', 100);
-    const [saturation, setSaturation] = useLocalStorage('editor_saturation', 100);
-    const [filter, setFilter] = useLocalStorage('editor_filter', 'none');
-
     const [aiPrompt, setAiPrompt] = useState('');
     const [aiLoading, setAiLoading] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
-    const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(null);
-    const [refImages, setRefImages] = useState<File[]>([]);
-    const [refPreviews, setRefPreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
+    const {
+        brightness,
+        setBrightness,
+        contrast,
+        setContrast,
+        saturation,
+        setSaturation,
+        filter,
+        setFilter,
+        canvasFilter,
+        currentImageUrl,
+        setCurrentImageUrl,
+        referenceImages,
+        referencePreviews,
+        addReferenceFiles,
+        removeReferenceAt,
+        resetAdjustments,
+        serializeReferences,
+    } = useEditorSession(image);
 
     const applyFilters = useCallback(() => {
         const canvas = canvasRef.current;
-        if (!canvas || !image) return;
+        if (!canvas || !image || !currentImageUrl) return;
         const ctx = canvas.getContext('2d');
         if (!ctx) return;
 
         const img = new Image();
         img.crossOrigin = "anonymous";
-        img.src = currentImageUrl || '';
+        img.src = currentImageUrl;
         img.onload = () => {
-            ctx.filter = `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
+            ctx.filter = canvasFilter;
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(img, 0, 0);
         };
-    }, [brightness, contrast, currentImageUrl, filter, image, saturation]);
-
-    useEffect(() => {
-        if (image) {
-            setCurrentImageUrl(image.url);
-
-            if (image.references && image.references.length > 0) {
-                const files = imageWorkflow.hydrateReferences(image.references);
-                setRefImages(files);
-                setRefPreviews(image.references);
-            }
-        }
-
-        if (!image) {
-            setRefImages([]);
-            setRefPreviews([]);
-        }
-    }, [image]);
-
-    useEffect(() => {
-        return () => {
-            // Cleanup previews - only revoke if they are object URLs
-            refPreviews.forEach((url: string) => {
-                if (url.startsWith('blob:')) URL.revokeObjectURL(url);
-            });
-        };
-    }, [refPreviews]);
+    }, [canvasFilter, currentImageUrl, image]);
 
     useEffect(() => {
         if (!image) return;
@@ -91,7 +75,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         if (!canvas) return;
         const dataUrl = canvas.toDataURL('image/png');
 
-        const refDataUrls = await imageWorkflow.serializeReferences(refImages);
+        const refDataUrls = await serializeReferences();
 
         onSave(dataUrl, isCopy, refDataUrls);
     };
@@ -112,7 +96,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                 apiKey,
                 prompt: aiPrompt,
                 sourceImage: blob,
-                referenceImages: refImages,
+                referenceImages,
                 quality: 'medium',
             });
 
@@ -141,9 +125,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
 
         const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
         if (files.length > 0) {
-            setRefImages(prev => [...prev, ...files]);
-            const newPreviews = files.map(file => URL.createObjectURL(file));
-            setRefPreviews(prev => [...prev, ...newPreviews]);
+            addReferenceFiles(files);
         }
     };
 
@@ -272,16 +254,12 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                             >
                                 <label>ADD VISUAL CONTEXT (OPTIONAL) {isDragging && '- DROP TO UPLOAD'}</label>
                                 <div className="reference-grid mini">
-                                    {refPreviews.map((url: string, idx: number) => (
+                                    {referencePreviews.map((url: string, idx: number) => (
                                         <div key={url} className="reference-preview mini glass-panel">
                                             <img src={url} alt="Reference" />
                                             <button
                                                 className="remove-ref"
-                                                onClick={() => {
-                                                    setRefImages((prev: File[]) => prev.filter((_, i) => i !== idx));
-                                                    setRefPreviews((prev: string[]) => prev.filter((_, i) => i !== idx));
-                                                    URL.revokeObjectURL(url);
-                                                }}
+                                                onClick={() => removeReferenceAt(idx)}
                                             >
                                                 <X size={12} />
                                             </button>
@@ -293,10 +271,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                                             multiple
                                             accept="image/*"
                                             onChange={(e) => {
-                                                const files = Array.from(e.target.files || []);
-                                                setRefImages((prev: File[]) => [...prev, ...files]);
-                                                const newPreviews = files.map(file => URL.createObjectURL(file));
-                                                setRefPreviews((prev: string[]) => [...prev, ...newPreviews]);
+                                                addReferenceFiles(Array.from(e.target.files || []));
                                             }}
                                             style={{ display: 'none' }}
                                         />
@@ -318,12 +293,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                         <button className="aura-btn aura-btn--glass" onClick={() => handleExport(true)}>
                             <Copy size={18} /> Save as Copy
                         </button>
-                        <button className="aura-btn aura-btn--glass" onClick={() => {
-                            setBrightness(100);
-                            setContrast(100);
-                            setSaturation(100);
-                            setFilter('none');
-                        }}>
+                        <button className="aura-btn aura-btn--glass" onClick={resetAdjustments}>
                             <Undo2 size={18} /> Reset
                         </button>
                     </div>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
@@ -67,7 +67,12 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
+    const referencePreviewsRef = useRef(referencePreviews);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
+
+    useEffect(() => {
+        referencePreviewsRef.current = referencePreviews;
+    }, [referencePreviews]);
 
     const updateDraft = (patch: Partial<typeof draft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -104,15 +109,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
     useEffect(() => {
         return () => {
-            // Cleanup previews - only revoke if they are object URLs, not data URLs
-            // Actually, in this component we always use object URLs for new uploads, 
-            // but transferred refs might be data URLs.
-            // dataURL previews don't need revocation.
-            referencePreviews.forEach((url: string) => {
+            referencePreviewsRef.current.forEach((url: string) => {
                 if (url.startsWith('blob:')) URL.revokeObjectURL(url);
             });
         };
-    }, [referencePreviews]);
+    }, []);
 
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {


### PR DESCRIPTION
## Summary
- add an editor session hook that owns persistent filter settings, current image state, and reference image add/remove lifecycle
- simplify `EditorView` so it focuses on canvas rendering and button wiring instead of local storage and preview bookkeeping
- key the editor view by image id so switching images remounts the editing session cleanly

## Testing
- npm run lint
- npm run build