### PR TITLE
refactor: centralize reference image collections

### DIFF
--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 
 const DEFAULT_BRIGHTNESS = 100;
 const DEFAULT_CONTRAST = 100;
@@ -14,53 +14,11 @@ export function useEditorSession(image: ArchiveImage | null) {
     const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
     const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
     const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
-    const [referenceImages, setReferenceImages] = useState<File[]>(() => {
-        return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
-    });
-    const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
-    const referencePreviewsRef = useRef(referencePreviews);
-
-    useEffect(() => {
-        referencePreviewsRef.current = referencePreviews;
-    }, [referencePreviews]);
-
-    useEffect(() => {
-        return () => {
-            referencePreviewsRef.current.forEach((url) => {
-                if (url.startsWith('blob:')) {
-                    URL.revokeObjectURL(url);
-                }
-            });
-        };
-    }, []);
+    const referenceCollection = useReferenceImageCollection({ initialDataUrls: image?.references });
 
     const canvasFilter = useMemo(() => {
         return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
     }, [brightness, contrast, saturation, filter]);
-
-    const addReferenceFiles = (files: File[]) => {
-        if (files.length === 0) {
-            return;
-        }
-
-        setReferenceImages((currentImages) => [...currentImages, ...files]);
-        setReferencePreviews((currentPreviews) => [
-            ...currentPreviews,
-            ...files.map((file) => URL.createObjectURL(file)),
-        ]);
-    };
-
-    const removeReferenceAt = (index: number) => {
-        setReferenceImages((currentImages) => currentImages.filter((_, currentIndex) => currentIndex !== index));
-        setReferencePreviews((currentPreviews) => {
-            const previewToRemove = currentPreviews[index];
-            if (previewToRemove?.startsWith('blob:')) {
-                URL.revokeObjectURL(previewToRemove);
-            }
-
-            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
-        });
-    };
 
     const resetAdjustments = () => {
         setBrightness(DEFAULT_BRIGHTNESS);
@@ -70,7 +28,7 @@ export function useEditorSession(image: ArchiveImage | null) {
     };
 
     const serializeReferences = () => {
-        return imageWorkflow.serializeReferences(referenceImages);
+        return referenceCollection.serialize();
     };
 
     return {
@@ -85,10 +43,10 @@ export function useEditorSession(image: ArchiveImage | null) {
         canvasFilter,
         currentImageUrl,
         setCurrentImageUrl,
-        referenceImages,
-        referencePreviews,
-        addReferenceFiles,
-        removeReferenceAt,
+        referenceImages: referenceCollection.files,
+        referencePreviews: referenceCollection.previews,
+        addReferenceFiles: referenceCollection.addFiles,
+        removeReferenceAt: referenceCollection.removeAt,
         resetAdjustments,
         serializeReferences,
     };

--- a/src/references/useReferenceImageCollection.ts
+++ b/src/references/useReferenceImageCollection.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+interface UseReferenceImageCollectionOptions {
+    initialDataUrls?: string[];
+}
+
+export function useReferenceImageCollection(options: UseReferenceImageCollectionOptions = {}) {
+    const initialDataUrls = options.initialDataUrls ?? [];
+    const [files, setFiles] = useState<File[]>(() => imageWorkflow.hydrateReferences(initialDataUrls));
+    const [previews, setPreviews] = useState<string[]>(() => initialDataUrls);
+    const previewsRef = useRef(previews);
+
+    useEffect(() => {
+        previewsRef.current = previews;
+    }, [previews]);
+
+    useEffect(() => {
+        return () => {
+            previewsRef.current.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+        };
+    }, []);
+
+    const addFiles = useCallback((nextFiles: File[]) => {
+        if (nextFiles.length === 0) {
+            return;
+        }
+
+        setFiles((currentFiles) => [...currentFiles, ...nextFiles]);
+        setPreviews((currentPreviews) => [
+            ...currentPreviews,
+            ...nextFiles.map((file) => URL.createObjectURL(file)),
+        ]);
+    }, []);
+
+    const removeAt = useCallback((index: number) => {
+        setFiles((currentFiles) => currentFiles.filter((_, currentIndex) => currentIndex !== index));
+        setPreviews((currentPreviews) => {
+            const previewToRemove = currentPreviews[index];
+            if (previewToRemove?.startsWith('blob:')) {
+                URL.revokeObjectURL(previewToRemove);
+            }
+
+            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
+        });
+    }, []);
+
+    const replaceWithDataUrls = useCallback((dataUrls: string[]) => {
+        previewsRef.current.forEach((url) => {
+            if (url.startsWith('blob:')) {
+                URL.revokeObjectURL(url);
+            }
+        });
+
+        setFiles(imageWorkflow.hydrateReferences(dataUrls));
+        setPreviews(dataUrls);
+    }, []);
+
+    const serialize = useCallback(() => {
+        return imageWorkflow.serializeReferences(files);
+    }, [files]);
+
+    return {
+        files,
+        previews,
+        addFiles,
+        removeAt,
+        replaceWithDataUrls,
+        serialize,
+    };
+}

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
 interface GenerateViewProps {
@@ -63,16 +64,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [referenceImages, setReferenceImages] = useState<File[]>([]);
-    const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
-    const referencePreviewsRef = useRef(referencePreviews);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
-
-    useEffect(() => {
-        referencePreviewsRef.current = referencePreviews;
-    }, [referencePreviews]);
+    const referenceCollection = useReferenceImageCollection();
+    const referenceImages = referenceCollection.files;
+    const referencePreviews = referenceCollection.previews;
+    const addReferenceFiles = referenceCollection.addFiles;
+    const removeReferenceAt = referenceCollection.removeAt;
+    const replaceReferences = referenceCollection.replaceWithDataUrls;
+    const serializeReferences = referenceCollection.serialize;
 
     const updateDraft = (patch: Partial<typeof draft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -99,21 +100,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
         generateSessionStore.consumeTransferredReferences().then((refs) => {
             if (refs.length > 0) {
-                const files = imageWorkflow.hydrateReferences(refs);
-                setReferenceImages(files);
-                setReferencePreviews(refs);
+                replaceReferences(refs);
             }
         });
 
-    }, []);
-
-    useEffect(() => {
-        return () => {
-            referencePreviewsRef.current.forEach((url: string) => {
-                if (url.startsWith('blob:')) URL.revokeObjectURL(url);
-            });
-        };
-    }, []);
+    }, [replaceReferences]);
 
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {
@@ -165,7 +156,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         if (!currentResult || isSaved) return;
 
         const saveRefImages = async () => {
-            const refDataUrls = await imageWorkflow.serializeReferences(referenceImages);
+            const refDataUrls = await serializeReferences();
 
             const newImage: ArchiveImage = {
                 id: crypto.randomUUID(),
@@ -207,9 +198,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
         const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
         if (files.length > 0) {
-            setReferenceImages(prev => [...prev, ...files]);
-            const newPreviews = files.map(file => URL.createObjectURL(file));
-            setReferencePreviews(prev => [...prev, ...newPreviews]);
+            addReferenceFiles(files);
         }
     };
 
@@ -362,9 +351,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                         className="remove-ref"
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            setReferenceImages((prev: File[]) => prev.filter((_, i) => i !== idx));
-                                            setReferencePreviews((prev: string[]) => prev.filter((_, i) => i !== idx));
-                                            URL.revokeObjectURL(url);
+                                            removeReferenceAt(idx);
                                             if (viewingReferenceIndex === idx) setViewingReferenceIndex(null);
                                         }}
                                     >
@@ -378,10 +365,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                     multiple
                                     accept="image/*"
                                     onChange={(e) => {
-                                        const files = Array.from(e.target.files || []);
-                                        setReferenceImages((prev: File[]) => [...prev, ...files]);
-                                        const newPreviews = files.map(file => URL.createObjectURL(file));
-                                        setReferencePreviews((prev: string[]) => [...prev, ...newPreviews]);
+                                        addReferenceFiles(Array.from(e.target.files || []));
                                     }}
                                     style={{ display: 'none' }}
                                 />


### PR DESCRIPTION
## Summary
- add a shared `useReferenceImageCollection` hook that owns reference image hydration, preview lifecycle, serialization, and cleanup
- migrate both generation and editor flows to the shared reference collection boundary instead of duplicating blob URL and file bookkeeping
- keep the preview cleanup fix in one place so future changes to reference handling do not diverge across views

## Testing
- npm run lint
- npm run build