### PR TITLE
refactor: centralize download actions

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Download, Trash2, Edit2, Clock } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadArchiveImage } from '../download/download';
 
 interface ImageCardProps {
     image: ArchiveImage;
@@ -18,10 +19,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
 
     const handleDownload = (e: React.MouseEvent) => {
         e.stopPropagation();
-        const link = document.createElement('a');
-        link.href = image.url;
-        link.download = `aura-${image.id}.png`;
-        link.click();
+        downloadArchiveImage(image);
     };
 
     return (

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2 } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadArchiveImage } from '../download/download';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -27,10 +28,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     };
 
     const downloadImage = () => {
-        const link = document.createElement('a');
-        link.href = image.url;
-        link.download = `aura-${image.id}.png`;
-        link.click();
+        downloadArchiveImage(image);
     };
 
     React.useEffect(() => {

--- a/src/download/download.ts
+++ b/src/download/download.ts
@@ -1,0 +1,22 @@
+import type { ArchiveImage } from '../db/types';
+
+export function downloadUrl(url: string, filename: string) {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+}
+
+export function downloadBlob(blob: Blob, filename: string) {
+    const url = URL.createObjectURL(blob);
+    downloadUrl(url, filename);
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+}
+
+export function downloadArchiveImage(image: Pick<ArchiveImage, 'id' | 'url'>) {
+    downloadUrl(image.url, `aura-${image.id}.png`);
+}
+
+export function downloadGeneratedImage(url: string) {
+    downloadUrl(url, `aura-generation-${Date.now()}.png`);
+}

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ImageCard from '../components/ImageCard';
 import type { ArchiveImage } from '../db/types';
+import { downloadBlob } from '../download/download';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
 import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -51,15 +52,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
 
             // Generate and download
             const content = await zip.generateAsync({ type: 'blob' });
-            const zipUrl = URL.createObjectURL(content);
-
-            const link = document.createElement('a');
-            link.href = zipUrl;
-            link.download = `aura-collection-${new Date().getTime()}.zip`;
-            link.click();
-
-            // Cleanup
-            setTimeout(() => URL.revokeObjectURL(zipUrl), 10000);
+            downloadBlob(content, `aura-collection-${new Date().getTime()}.zip`);
         } catch (error) {
             console.error('Failed to create ZIP:', error);
             // Could add a toast here if available in this view

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadGeneratedImage } from '../download/download';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
@@ -146,10 +147,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
     const handleDownload = () => {
         if (!currentResult) return;
-        const link = document.createElement('a');
-        link.href = currentResult;
-        link.download = `aura-generation-${Date.now()}.png`;
-        link.click();
+        downloadGeneratedImage(currentResult);
     };
 
     const handleSave = () => {


### PR DESCRIPTION
## Summary
- add a shared download helper module for direct image downloads and blob-backed downloads
- migrate generation, archive card, detail modal, and ZIP download flows to the shared boundary instead of duplicating anchor setup logic
- keep download naming and object URL cleanup consistent across the app

## Testing
- npm run lint
- npm run build