### PR TITLE
fix: harden workflow and archive boundaries

### DIFF
--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -1,55 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useArchiveController } from '../archive/useArchiveController';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore } from '../generate-session/GenerateSession';
-import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useAppNotifications } from './useAppNotifications';
+import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';
-import type { ToastType } from '../components/Toast';
-import type { AppView } from '../types';
-
-interface AppToast {
-    id: string;
-    message: string;
-    type: ToastType;
-}
 
 export function useAppController() {
-    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
-    const { images, addImage, deleteImage } = useImageArchive();
-    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
+    const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
+    const { toasts, addToast, removeToast, notifyError } = useAppNotifications();
+    const handleArchiveError = useCallback((error: Error, operation: 'load' | 'save' | 'delete') => {
+        notifyError(error, `Archive ${operation} failed`);
+    }, [notifyError]);
+    const { images, addImage, deleteImage } = useImageArchive({
+        onError: handleArchiveError,
+    });
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
-    const [toasts, setToasts] = useState<AppToast[]>([]);
-    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
-
-    useEffect(() => {
-        document.documentElement.setAttribute('data-theme', theme);
-    }, [theme]);
-
-    useEffect(() => {
-        if (!apiKey) {
-            const legacyKey = localStorage.getItem('openai_api_key');
-            if (legacyKey) {
-                setApiKey(legacyKey);
-            }
-        }
-    }, [apiKey, setApiKey]);
-
-    const addToast = useCallback((message: string, type: ToastType = 'info') => {
-        const id = crypto.randomUUID();
-        setToasts((currentToasts) => [...currentToasts, { id, message, type }]);
-    }, []);
-
-    const removeToast = useCallback((id: string) => {
-        setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
-    }, []);
-
-    const changeView = useCallback((view: AppView) => {
-        setCurrentView(view);
-    }, [setCurrentView]);
-
-    const updateApiKey = useCallback((key: string) => {
-        setApiKey(key);
-    }, [setApiKey]);
 
     const saveImage = useCallback(async (image: ArchiveImage) => {
         await addImage(image);
@@ -66,8 +32,8 @@ export function useAppController() {
 
     const editImage = useCallback((image: ArchiveImage) => {
         setEditingImage(image);
-        setCurrentView('editor');
-    }, [setCurrentView]);
+        changeView('editor');
+    }, [changeView]);
 
     const saveEditedImage = useCallback(async (updatedUrl: string, isCopy: boolean = false, references?: string[]) => {
         if (!editingImage) {
@@ -92,19 +58,19 @@ export function useAppController() {
             addToast('Masterpiece updated', 'success');
         }
 
-        setCurrentView('archive');
+        changeView('archive');
         setEditingImage(null);
-    }, [addImage, addToast, editingImage, setCurrentView]);
+    }, [addImage, addToast, changeView, editingImage]);
 
     const createSimilar = useCallback(async (image: ArchiveImage) => {
-        await generateSessionStore.transferFromArchive(image);
-        setCurrentView('generate');
-        addToast('Settings & references transferred', 'info');
-    }, [addToast, setCurrentView]);
-
-    const toggleTheme = useCallback(() => {
-        setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
-    }, [setTheme]);
+        try {
+            await generateSessionStore.transferFromArchive(image);
+            changeView('generate');
+            addToast('Settings & references transferred', 'info');
+        } catch (error) {
+            notifyError(error, 'Failed to transfer image settings');
+        }
+    }, [addToast, changeView, notifyError]);
 
     const archiveController = useArchiveController({
         images,
@@ -138,6 +104,7 @@ export function useAppController() {
             onToggleSelectAll: archiveController.toggleSelectAll,
             onClearSelection: archiveController.clearSelection,
             onDeleteSelected: () => archiveController.requestDelete(Array.from(archiveController.selectedIds)),
+            onBulkDownloadError: (error: Error) => notifyError(error, 'Failed to export archive ZIP'),
         },
         editorViewProps: {
             key: editingImage?.id ?? 'empty-editor',

--- a/src/app/useAppNotifications.ts
+++ b/src/app/useAppNotifications.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+import type { ToastType } from '../components/Toast';
+
+interface AppToast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+export function useAppNotifications() {
+    const [toasts, setToasts] = useState<AppToast[]>([]);
+
+    const addToast = useCallback((message: string, type: ToastType = 'info') => {
+        const id = crypto.randomUUID();
+        setToasts((currentToasts) => [...currentToasts, { id, message, type }]);
+    }, []);
+
+    const removeToast = useCallback((id: string) => {
+        setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+    }, []);
+
+    const notifyError = useCallback((error: unknown, fallback: string) => {
+        addToast(error instanceof Error ? error.message : fallback, 'error');
+    }, [addToast]);
+
+    return {
+        toasts,
+        addToast,
+        removeToast,
+        notifyError,
+    };
+}

--- a/src/app/useAppPreferences.ts
+++ b/src/app/useAppPreferences.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import type { AppView } from '../types';
+
+export function useAppPreferences() {
+    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
+    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
+    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
+
+    useEffect(() => {
+        document.documentElement.setAttribute('data-theme', theme);
+    }, [theme]);
+
+    useEffect(() => {
+        if (!apiKey) {
+            const legacyKey = localStorage.getItem('openai_api_key');
+            if (legacyKey) {
+                setApiKey(legacyKey);
+            }
+        }
+    }, [apiKey, setApiKey]);
+
+    const changeView = useCallback((view: AppView) => {
+        setCurrentView(view);
+    }, [setCurrentView]);
+
+    const updateApiKey = useCallback((key: string) => {
+        setApiKey(key);
+    }, [setApiKey]);
+
+    const toggleTheme = useCallback(() => {
+        setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
+    }, [setTheme]);
+
+    return {
+        currentView,
+        apiKey,
+        theme,
+        changeView,
+        updateApiKey,
+        toggleTheme,
+    };
+}

--- a/src/archive/ArchiveExport.ts
+++ b/src/archive/ArchiveExport.ts
@@ -1,0 +1,32 @@
+import JSZip from 'jszip';
+import type { ArchiveImage } from '../db/types';
+import { downloadBlob } from '../download/download';
+
+export async function downloadArchiveImagesAsZip(images: ArchiveImage[]) {
+    const zip = new JSZip();
+
+    for (const image of images) {
+        zip.file(`aura-${image.id}.png`, await imageUrlToBlob(image.url));
+    }
+
+    const content = await zip.generateAsync({ type: 'blob' });
+    downloadBlob(content, `aura-collection-${Date.now()}.zip`);
+}
+
+async function imageUrlToBlob(url: string) {
+    if (!url.startsWith('data:')) {
+        const response = await fetch(url);
+        return response.blob();
+    }
+
+    const [metadata, base64Data] = url.split(',', 2);
+    if (!metadata || !base64Data) {
+        throw new Error('Invalid image data URL');
+    }
+
+    const mimeType = metadata.match(/data:(.*?);base64/)?.[1] ?? 'image/png';
+    const binary = atob(base64Data);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+    return new Blob([bytes], { type: mimeType });
+}

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -78,7 +78,8 @@ class LocalArchiveStore implements ArchiveStore {
 
     async list(): Promise<ArchiveImage[]> {
         const records = await this.metadata.list();
-        return Promise.all(records.map((record) => this.hydrate(record)));
+        const images = await Promise.all(records.map((record) => this.hydrate(record)));
+        return images.filter((image): image is ArchiveImage => image !== null);
     }
 
     async save(input: SaveArchiveImageInput): Promise<ArchiveImage> {
@@ -86,26 +87,34 @@ class LocalArchiveStore implements ArchiveStore {
         const existing = await this.metadata.get(id);
         const timestamp = input.timestamp ?? existing?.timestamp ?? this.clock();
         const referenceIds = input.references?.map((_, index) => index) ?? [];
+        const snapshot = await this.captureSnapshot(id, existing?.referenceIds ?? []);
+        const touchedReferenceIds = getTouchedReferenceIds(existing?.referenceIds ?? [], referenceIds);
 
-        await this.blobs.save(getImageBlobKey(id), input.url);
-        await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
+        try {
+            await this.blobs.save(getImageBlobKey(id), input.url);
+            await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
 
-        await this.metadata.save({
-            id,
-            storedUrl: id,
-            prompt: input.prompt,
-            quality: input.quality,
-            aspectRatio: input.aspectRatio,
-            background: input.background,
-            timestamp,
-            model: input.model,
-            width: input.width,
-            height: input.height,
-            style: input.style,
-            lighting: input.lighting,
-            palette: input.palette,
-            referenceIds,
-        });
+            await this.metadata.save({
+                id,
+                storedUrl: id,
+                prompt: input.prompt,
+                quality: input.quality,
+                aspectRatio: input.aspectRatio,
+                background: input.background,
+                timestamp,
+                model: input.model,
+                width: input.width,
+                height: input.height,
+                style: input.style,
+                lighting: input.lighting,
+                palette: input.palette,
+                referenceIds,
+            });
+        } catch (error) {
+            await this.restoreMetadata(id, existing);
+            await this.restoreSnapshot(id, snapshot, touchedReferenceIds);
+            throw error;
+        }
 
         return {
             id,
@@ -127,21 +136,34 @@ class LocalArchiveStore implements ArchiveStore {
 
     async remove(id: string): Promise<void> {
         const existing = await this.metadata.get(id);
+        const snapshot = await this.captureSnapshot(id, existing?.referenceIds ?? []);
+        const touchedReferenceIds = existing?.referenceIds ?? [];
 
-        await this.blobs.remove(getImageBlobKey(id));
-        await Promise.all((existing?.referenceIds ?? []).map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
-        await this.metadata.remove(id);
+        try {
+            await this.blobs.remove(getImageBlobKey(id));
+            await Promise.all(touchedReferenceIds.map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
+            await this.metadata.remove(id);
+        } catch (error) {
+            await this.restoreMetadata(id, existing);
+            await this.restoreSnapshot(id, snapshot, touchedReferenceIds);
+            throw error;
+        }
     }
 
-    private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage> {
+    private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage | null> {
         const [imageUrl, references] = await Promise.all([
             this.blobs.load(getImageBlobKey(record.id)),
             Promise.all(record.referenceIds.map((index) => this.blobs.load(getReferenceBlobKey(record.id, index)))),
         ]);
 
+        const resolvedImageUrl = imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : null);
+        if (!resolvedImageUrl) {
+            return null;
+        }
+
         return {
             id: record.id,
-            url: imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : ''),
+            url: resolvedImageUrl,
             prompt: record.prompt,
             quality: record.quality,
             aspectRatio: record.aspectRatio,
@@ -157,6 +179,46 @@ class LocalArchiveStore implements ArchiveStore {
         };
     }
 
+    private async captureSnapshot(id: string, referenceIds: number[]) {
+        const [image, references] = await Promise.all([
+            this.blobs.load(getImageBlobKey(id)),
+            Promise.all(referenceIds.map(async (index) => [index, await this.blobs.load(getReferenceBlobKey(id, index))] as const)),
+        ]);
+
+        return {
+            image,
+            references: new Map(references.filter((entry): entry is readonly [number, string] => entry[1] !== null)),
+        };
+    }
+
+    private async restoreSnapshot(id: string, snapshot: { image: string | null; references: Map<number, string> }, touchedReferenceIds: number[]) {
+        if (snapshot.image !== null) {
+            await this.blobs.save(getImageBlobKey(id), snapshot.image);
+        } else {
+            await this.blobs.remove(getImageBlobKey(id));
+        }
+
+        const referenceIds = getTouchedReferenceIds(Array.from(snapshot.references.keys()), touchedReferenceIds);
+        await Promise.all(referenceIds.map(async (index) => {
+            const previousReference = snapshot.references.get(index);
+            if (previousReference !== undefined) {
+                await this.blobs.save(getReferenceBlobKey(id, index), previousReference);
+                return;
+            }
+
+            await this.blobs.remove(getReferenceBlobKey(id, index));
+        }));
+    }
+
+    private async restoreMetadata(id: string, record: ArchiveMetadataRecord | null) {
+        if (record) {
+            await this.metadata.save(record);
+            return;
+        }
+
+        await this.metadata.remove(id);
+    }
+
     private async syncReferences(id: string, previousReferenceIds: number[], nextReferences: string[]): Promise<void> {
         await Promise.all(nextReferences.map((reference, index) => this.blobs.save(getReferenceBlobKey(id, index), reference)));
 
@@ -170,6 +232,10 @@ class LocalArchiveStore implements ArchiveStore {
 const getImageBlobKey = (id: string) => `img_${id}`;
 
 const getReferenceBlobKey = (id: string, index: number) => `ref_${id}_${index}`;
+
+const getTouchedReferenceIds = (left: number[], right: number[]) => {
+    return Array.from(new Set([...left, ...right]));
+};
 
 export function createArchiveStore(deps: CreateArchiveStoreDeps = {}): ArchiveStore {
     return new LocalArchiveStore(

--- a/src/editor/useEditorCanvas.ts
+++ b/src/editor/useEditorCanvas.ts
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: string) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [readyToken, setReadyToken] = useState<string | null>(null);
+    const canvasToken = currentImageUrl ? `${currentImageUrl}:${canvasFilter}` : null;
+    const isReady = readyToken === canvasToken;
 
     useEffect(() => {
         if (!currentImageUrl) {
@@ -32,12 +35,18 @@ export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: st
             context.filter = canvasFilter;
             context.clearRect(0, 0, canvas.width, canvas.height);
             context.drawImage(image, 0, 0);
+            setReadyToken(canvasToken);
+        };
+        image.onerror = () => {
+            if (!cancelled) {
+                setReadyToken(null);
+            }
         };
 
         return () => {
             cancelled = true;
         };
-    }, [canvasFilter, currentImageUrl]);
+    }, [canvasFilter, canvasToken, currentImageUrl]);
 
     const exportDataUrl = useCallback(() => {
         const canvas = canvasRef.current;
@@ -68,6 +77,7 @@ export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: st
 
     return {
         canvasRef,
+        isReady,
         exportDataUrl,
         exportBlob,
     };

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -3,6 +3,7 @@ import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 
 interface UseEditorControllerOptions {
     apiKey: string | null;
+    isCanvasReady: boolean;
     currentImageUrl: string | null;
     setCurrentImageUrl: (url: string) => void;
     referenceImages: File[];
@@ -15,6 +16,7 @@ interface UseEditorControllerOptions {
 
 export function useEditorController({
     apiKey,
+    isCanvasReady,
     currentImageUrl,
     setCurrentImageUrl,
     referenceImages,
@@ -30,13 +32,21 @@ export function useEditorController({
     const [isDragging, setIsDragging] = useState(false);
 
     const save = useCallback(async (isCopy: boolean = false) => {
-        const dataUrl = exportDataUrl();
-        const references = await serializeReferences();
-        await Promise.resolve(onSave(dataUrl, isCopy, references));
-    }, [exportDataUrl, onSave, serializeReferences]);
+        if (!isCanvasReady) {
+            return;
+        }
+
+        try {
+            const dataUrl = exportDataUrl();
+            const references = await serializeReferences();
+            await Promise.resolve(onSave(dataUrl, isCopy, references));
+        } catch (err: unknown) {
+            setAiError(err instanceof Error ? err.message : 'Failed to save image');
+        }
+    }, [exportDataUrl, isCanvasReady, onSave, serializeReferences]);
 
     const applyAiEdit = useCallback(async () => {
-        if (!apiKey || !aiPrompt.trim() || !currentImageUrl) {
+        if (!apiKey || !aiPrompt.trim() || !currentImageUrl || !isCanvasReady) {
             return;
         }
 
@@ -60,7 +70,7 @@ export function useEditorController({
         } finally {
             setAiLoading(false);
         }
-    }, [aiPrompt, apiKey, currentImageUrl, exportBlob, referenceImages, setCurrentImageUrl]);
+    }, [aiPrompt, apiKey, currentImageUrl, exportBlob, isCanvasReady, referenceImages, setCurrentImageUrl]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();
@@ -88,6 +98,7 @@ export function useEditorController({
         aiLoading,
         aiError,
         isDragging,
+        isCanvasReady,
         save,
         applyAiEdit,
         handleDragOver,

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -9,10 +9,11 @@ const DEFAULT_SATURATION = 100;
 const DEFAULT_FILTER = 'none';
 
 export function useEditorSession(image: ArchiveImage | null) {
-    const [brightness, setBrightness] = useLocalStorage('editor_brightness', DEFAULT_BRIGHTNESS);
-    const [contrast, setContrast] = useLocalStorage('editor_contrast', DEFAULT_CONTRAST);
-    const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
-    const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
+    const sessionKey = image?.id ?? 'default';
+    const [brightness, setBrightness] = useLocalStorage(`editor_${sessionKey}_brightness`, DEFAULT_BRIGHTNESS);
+    const [contrast, setContrast] = useLocalStorage(`editor_${sessionKey}_contrast`, DEFAULT_CONTRAST);
+    const [saturation, setSaturation] = useLocalStorage(`editor_${sessionKey}_saturation`, DEFAULT_SATURATION);
+    const [filter, setFilter] = useLocalStorage(`editor_${sessionKey}_filter`, DEFAULT_FILTER);
     const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
     const referenceCollection = useReferenceImageCollection({ initialDataUrls: image?.references });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -94,25 +94,29 @@ export function useGenerateController({
             return;
         }
 
-        const references = await serializeReferences();
-        const { width, height } = getImageDimensions(draft.aspectRatio);
-        await Promise.resolve(onSaveImage({
-            id: crypto.randomUUID(),
-            url: currentResult,
-            prompt: draft.prompt,
-            model: 'gpt-image-1.5',
-            timestamp: new Date().toISOString(),
-            width,
-            height,
-            quality: draft.quality,
-            aspectRatio: draft.aspectRatio,
-            background: draft.background,
-            style: draft.style,
-            lighting: draft.lighting,
-            palette: draft.palette,
-            references,
-        }));
-        updateDraft({ isSaved: true });
+        try {
+            const references = await serializeReferences();
+            const { width, height } = getImageDimensions(draft.aspectRatio);
+            await Promise.resolve(onSaveImage({
+                id: crypto.randomUUID(),
+                url: currentResult,
+                prompt: draft.prompt,
+                model: 'gpt-image-1.5',
+                timestamp: new Date().toISOString(),
+                width,
+                height,
+                quality: draft.quality,
+                aspectRatio: draft.aspectRatio,
+                background: draft.background,
+                style: draft.style,
+                lighting: draft.lighting,
+                palette: draft.palette,
+                references,
+            }));
+            updateDraft({ isSaved: true });
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Failed to save image');
+        }
     }, [currentResult, draft, onSaveImage, serializeReferences, updateDraft]);
 
     const download = useCallback(() => {

--- a/src/hooks/useImageArchive.ts
+++ b/src/hooks/useImageArchive.ts
@@ -2,11 +2,20 @@ import { useState, useEffect, useCallback } from 'react';
 import { archiveStore, type ArchiveStore } from '../archive/ArchiveStore';
 import type { ArchiveImage } from '../db/types';
 
+type ArchiveOperation = 'load' | 'save' | 'delete';
+
+interface UseImageArchiveOptions {
+    store?: ArchiveStore;
+    onError?: (error: Error, operation: ArchiveOperation) => void;
+}
+
 const sortImagesByTimestamp = (images: ArchiveImage[]) => {
     return [...images].sort((left, right) => right.timestamp.localeCompare(left.timestamp));
 };
 
-export function useImageArchive(store: ArchiveStore = archiveStore) {
+export function useImageArchive(options: UseImageArchiveOptions = {}) {
+    const store = options.store ?? archiveStore;
+    const onError = options.onError;
     const [images, setImages] = useState<ArchiveImage[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
@@ -17,11 +26,13 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
             const data = await store.list();
             setImages(data);
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to load images'));
+            const nextError = err instanceof Error ? err : new Error('Failed to load images');
+            setError(nextError);
+            onError?.(nextError, 'load');
         } finally {
             setLoading(false);
         }
-    }, [store]);
+    }, [onError, store]);
 
     const addImage = async (image: ArchiveImage) => {
         try {
@@ -31,7 +42,9 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
                 ...current.filter((entry) => entry.id !== savedImage.id),
             ]));
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to save image'));
+            const nextError = err instanceof Error ? err : new Error('Failed to save image');
+            setError(nextError);
+            onError?.(nextError, 'save');
             throw err;
         }
     };
@@ -41,7 +54,9 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
             await store.remove(id);
             setImages((current) => current.filter((entry) => entry.id !== id));
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to delete image'));
+            const nextError = err instanceof Error ? err : new Error('Failed to delete image');
+            setError(nextError);
+            onError?.(nextError, 'delete');
             throw err;
         }
     };

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
+import { downloadArchiveImagesAsZip } from '../archive/ArchiveExport';
 import ImageCard from '../components/ImageCard';
 import type { ArchiveImage } from '../db/types';
-import { downloadBlob } from '../download/download';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
-import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface ArchiveViewProps {
@@ -16,6 +15,7 @@ interface ArchiveViewProps {
     onToggleSelectAll: (ids: string[]) => void;
     onClearSelection: () => void;
     onDeleteSelected: () => void;
+    onBulkDownloadError: (error: Error) => void;
 }
 
 const ArchiveView: React.FC<ArchiveViewProps> = ({
@@ -28,6 +28,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
     onToggleSelectAll,
     onClearSelection,
     onDeleteSelected,
+    onBulkDownloadError,
 }) => {
     const [search, setSearch] = useLocalStorage('archive_search', '');
     const [isZipping, setIsZipping] = React.useState(false);
@@ -37,25 +38,9 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
 
         setIsZipping(true);
         try {
-            const zip = new JSZip();
-            const selectedImages = images.filter(img => selectedIds.has(img.id));
-
-            for (const img of selectedImages) {
-                // Fetch the image data
-                const response = await fetch(img.url);
-                const blob = await response.blob();
-
-                // Add to zip with a descriptive name
-                const filename = `aura-${img.id}.png`;
-                zip.file(filename, blob);
-            }
-
-            // Generate and download
-            const content = await zip.generateAsync({ type: 'blob' });
-            downloadBlob(content, `aura-collection-${new Date().getTime()}.zip`);
+            await downloadArchiveImagesAsZip(images.filter((image) => selectedIds.has(image.id)));
         } catch (error) {
-            console.error('Failed to create ZIP:', error);
-            // Could add a toast here if available in this view
+            onBulkDownloadError(error instanceof Error ? error : new Error('Failed to create ZIP archive'));
         } finally {
             setIsZipping(false);
         }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -31,13 +31,14 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         resetAdjustments,
         serializeReferences,
     } = useEditorSession(image);
-    const { canvasRef, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
+    const { canvasRef, isReady, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
     const {
         aiPrompt,
         setAiPrompt,
         aiLoading,
         aiError,
         isDragging,
+        isCanvasReady,
         save,
         applyAiEdit,
         handleDragOver,
@@ -45,6 +46,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         handleDrop,
     } = useEditorController({
         apiKey,
+        isCanvasReady: isReady,
         currentImageUrl,
         setCurrentImageUrl,
         referenceImages,
@@ -160,12 +162,12 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                                 onChange={(e) => setAiPrompt(e.target.value)}
                                 className="aura-input"
                                 style={{ minHeight: '100px', resize: 'vertical' }}
-                                disabled={aiLoading || !apiKey}
+                                disabled={aiLoading || !apiKey || !isCanvasReady}
                             />
                             <button
                                 className="aura-btn aura-btn--primary"
                                 onClick={() => { void applyAiEdit(); }}
-                                disabled={aiLoading || !aiPrompt.trim() || !apiKey}
+                                disabled={aiLoading || !aiPrompt.trim() || !apiKey || !isCanvasReady}
                                 style={{ width: '100%' }}
                             >
                                 {aiLoading ? <Loader2 className="spin" size={16} /> : <Sparkles size={16} />}
@@ -213,10 +215,10 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                     </div>
 
                     <div className="editor-actions">
-                        <button className="aura-btn aura-btn--primary" onClick={() => { void save(false); }}>
+                        <button className="aura-btn aura-btn--primary" onClick={() => { void save(false); }} disabled={!isCanvasReady}>
                             <Save size={18} /> Save Changes
                         </button>
-                        <button className="aura-btn aura-btn--glass" onClick={() => { void save(true); }}>
+                        <button className="aura-btn aura-btn--glass" onClick={() => { void save(true); }} disabled={!isCanvasReady}>
                             <Copy size={18} /> Save as Copy
                         </button>
                         <button className="aura-btn aura-btn--glass" onClick={resetAdjustments}>


### PR DESCRIPTION
## Summary
- gate editor save and AI edit actions on canvas readiness and scope editor adjustment persistence per image
- harden archive persistence with rollback behavior, corrupted-entry filtering, and a dedicated ZIP export service that reports failures through app notifications
- centralize more user-facing error handling by splitting app preferences/notifications from the app controller and wiring archive operation failures into toasts

## Testing
- npm run lint
- npm run build