### PR TITLE
refactor: merge remaining workflow stack into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ npm run preview
 - `npm run dev`
   Starts the Vite development server.
 
+- `npm run dev -- --port 5175`
+  Starts the Vite development server on port 5175.
+
 - `npm run typecheck`
   Runs the TypeScript project build in type-check mode.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
                     onDeleteSelected={() => archiveController.requestDelete(Array.from(archiveController.selectedIds))}
                 />;
             case 'editor':
-                return <EditorView image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
+                return <EditorView key={editingImage?.id ?? 'empty-editor'} image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
             case 'settings':
                 return <SettingsView apiKey={apiKey} onApiKeyChange={handleApiKeyChange} />;
             default:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react'
 import Sidebar from './components/Sidebar'
 import SettingsView from './views/SettingsView'
 import GenerateView from './views/GenerateView'
@@ -6,137 +5,34 @@ import ArchiveView from './views/ArchiveView'
 import EditorView from './views/EditorView'
 import ImageDetailModal from './components/ImageDetailModal'
 import Toast from './components/Toast'
-import type { ToastType } from './components/Toast'
 import ConfirmModal from './components/ConfirmModal'
-import { useArchiveController } from './archive/useArchiveController'
-import { generateSessionStore } from './generate-session/GenerateSession'
-import { useLocalStorage } from './hooks/useLocalStorage'
-import { useImageArchive } from './hooks/useImageArchive'
-import type { ArchiveImage } from './db/types'
-import type { AppView } from './types'
+import { useAppController } from './app/useAppController'
 
 function App() {
-    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate')
-    const { images, addImage, deleteImage } = useImageArchive()
-    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '')
-    const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null)
-    const [toasts, setToasts] = useState<{ id: string; message: string; type: ToastType }[]>([])
-    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark')
-
-    useEffect(() => {
-        document.documentElement.setAttribute('data-theme', theme)
-    }, [theme])
-
-    const addToast = (message: string, type: ToastType = 'info') => {
-        const id = crypto.randomUUID()
-        setToasts(prev => [...prev, { id, message, type }])
-    }
-
-    const removeToast = (id: string) => {
-        setToasts(prev => prev.filter(t => t.id !== id))
-    }
-
-    // Migration for legacy API keys
-    useEffect(() => {
-        if (!apiKey) {
-            const legacyKey = localStorage.getItem('openai_api_key');
-            if (legacyKey) {
-                setApiKey(legacyKey);
-                // We leave the legacy key for safety but the app now uses aura_openapi_key
-            }
-        }
-    }, [apiKey, setApiKey]);
-
-    const handleViewChange = (view: AppView) => {
-        setCurrentView(view)
-    }
-
-    const handleApiKeyChange = (key: string) => {
-        setApiKey(key)
-    }
-
-    const handleSaveImage = async (image: ArchiveImage) => {
-        await addImage(image)
-        addToast('Image saved to archive', 'success')
-    }
-
-    const handleDeleteImage = async (id: string) => {
-        await deleteImage(id)
-    }
-
-    const handleDeleteImages = async (ids: string[]) => {
-        for (const id of ids) {
-            await handleDeleteImage(id)
-        }
-
-        addToast(ids.length === 1 ? 'Image deleted permanently' : `${ids.length} images deleted permanently`, 'info')
-    }
-
-    const handleEditImage = (image: ArchiveImage) => {
-        setEditingImage(image)
-        setCurrentView('editor')
-    }
-
-    const handleSaveEditedImage = async (updatedUrl: string, isCopy: boolean = false, references?: string[]) => {
-        if (!editingImage) return
-
-        if (isCopy) {
-            const newImage = {
-                ...editingImage,
-                id: crypto.randomUUID(),
-                url: updatedUrl,
-                timestamp: new Date().toISOString(),
-                references: references || editingImage.references
-            }
-            await addImage(newImage)
-            addToast('Design saved as new copy', 'success')
-        } else {
-            const updatedImage = {
-                ...editingImage,
-                url: updatedUrl,
-                references: references || editingImage.references
-            }
-            await addImage(updatedImage)
-            addToast('Masterpiece updated', 'success')
-        }
-
-        setCurrentView('archive')
-        setEditingImage(null)
-    }
-
-    const handleCreateSimilar = async (image: ArchiveImage) => {
-        await generateSessionStore.transferFromArchive(image)
-        setCurrentView('generate')
-        addToast('Settings & references transferred', 'info')
-    }
-
-    const archiveController = useArchiveController({
-        images,
-        onDeleteImages: handleDeleteImages,
-        onEditImage: handleEditImage,
-        onCreateSimilar: handleCreateSimilar,
-    })
+    const {
+        currentView,
+        theme,
+        toasts,
+        archiveController,
+        changeView,
+        toggleTheme,
+        removeToast,
+        generateViewProps,
+        archiveViewProps,
+        editorViewProps,
+        settingsViewProps,
+    } = useAppController()
 
     const renderView = () => {
         switch (currentView) {
             case 'generate':
-                return <GenerateView apiKey={apiKey} onSaveImage={handleSaveImage} />;
+                return <GenerateView {...generateViewProps} />;
             case 'archive':
-                return <ArchiveView
-                    images={images}
-                    selectedIds={archiveController.selectedIds}
-                    onDeleteImage={(id) => archiveController.requestDelete([id])}
-                    onEditImage={archiveController.editImage}
-                    onOpenImage={archiveController.openImage}
-                    onToggleSelection={archiveController.toggleSelection}
-                    onToggleSelectAll={archiveController.toggleSelectAll}
-                    onClearSelection={archiveController.clearSelection}
-                    onDeleteSelected={() => archiveController.requestDelete(Array.from(archiveController.selectedIds))}
-                />;
+                return <ArchiveView {...archiveViewProps} />;
             case 'editor':
-                return <EditorView key={editingImage?.id ?? 'empty-editor'} image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
+                return <EditorView {...editorViewProps} />;
             case 'settings':
-                return <SettingsView apiKey={apiKey} onApiKeyChange={handleApiKeyChange} />;
+                return <SettingsView {...settingsViewProps} />;
             default:
                 return <div>View not found</div>;
         }
@@ -146,9 +42,9 @@ function App() {
         <div className="app-container">
             <Sidebar
                 currentView={currentView}
-                onViewChange={handleViewChange}
+                onViewChange={changeView}
                 theme={theme}
-                onThemeToggle={() => setTheme(prev => prev === 'dark' ? 'light' : 'dark')}
+                onThemeToggle={toggleTheme}
             />
             <main className="main-content">
                 <div className="view-wrapper">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ImageDetailModal from './components/ImageDetailModal'
 import Toast from './components/Toast'
 import type { ToastType } from './components/Toast'
 import ConfirmModal from './components/ConfirmModal'
+import { useArchiveController } from './archive/useArchiveController'
 import { generateSessionStore } from './generate-session/GenerateSession'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useImageArchive } from './hooks/useImageArchive'
@@ -19,11 +20,7 @@ function App() {
     const { images, addImage, deleteImage } = useImageArchive()
     const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '')
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null)
-    const [selectedImage, setSelectedImage] = useState<ArchiveImage | null>(null)
     const [toasts, setToasts] = useState<{ id: string; message: string; type: ToastType }[]>([])
-    const [confirmConfig, setConfirmConfig] = useState<{ isOpen: boolean; title: string; message: string; onConfirm: () => void; type?: 'danger' | 'info' }>({
-        isOpen: false, title: '', message: '', onConfirm: () => { }, type: 'info'
-    })
     const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark')
 
     useEffect(() => {
@@ -64,18 +61,15 @@ function App() {
     }
 
     const handleDeleteImage = async (id: string) => {
-        setConfirmConfig({
-            isOpen: true,
-            title: 'Delete Masterpiece?',
-            message: 'This will permanently remove the image and its binary data from your local storage. This action cannot be undone.',
-            type: 'danger',
-            onConfirm: async () => {
-                await deleteImage(id)
-                setConfirmConfig(prev => ({ ...prev, isOpen: false }))
-                addToast('Image deleted permanently', 'info')
-                if (selectedImage?.id === id) setSelectedImage(null)
-            }
-        })
+        await deleteImage(id)
+    }
+
+    const handleDeleteImages = async (ids: string[]) => {
+        for (const id of ids) {
+            await handleDeleteImage(id)
+        }
+
+        addToast(ids.length === 1 ? 'Image deleted permanently' : `${ids.length} images deleted permanently`, 'info')
     }
 
     const handleEditImage = (image: ArchiveImage) => {
@@ -112,27 +106,16 @@ function App() {
 
     const handleCreateSimilar = async (image: ArchiveImage) => {
         await generateSessionStore.transferFromArchive(image)
-
-        setSelectedImage(null)
         setCurrentView('generate')
         addToast('Settings & references transferred', 'info')
     }
 
-    const handleNextImage = () => {
-        if (!selectedImage) return
-        const currentIndex = images.findIndex(img => img.id === selectedImage.id)
-        if (currentIndex < images.length - 1) {
-            setSelectedImage(images[currentIndex + 1])
-        }
-    }
-
-    const handlePreviousImage = () => {
-        if (!selectedImage) return
-        const currentIndex = images.findIndex(img => img.id === selectedImage.id)
-        if (currentIndex > 0) {
-            setSelectedImage(images[currentIndex - 1])
-        }
-    }
+    const archiveController = useArchiveController({
+        images,
+        onDeleteImages: handleDeleteImages,
+        onEditImage: handleEditImage,
+        onCreateSimilar: handleCreateSimilar,
+    })
 
     const renderView = () => {
         switch (currentView) {
@@ -141,9 +124,14 @@ function App() {
             case 'archive':
                 return <ArchiveView
                     images={images}
-                    onDeleteImage={handleDeleteImage}
-                    onEditImage={handleEditImage}
-                    onSelectImage={setSelectedImage}
+                    selectedIds={archiveController.selectedIds}
+                    onDeleteImage={(id) => archiveController.requestDelete([id])}
+                    onEditImage={archiveController.editImage}
+                    onOpenImage={archiveController.openImage}
+                    onToggleSelection={archiveController.toggleSelection}
+                    onToggleSelectAll={archiveController.toggleSelectAll}
+                    onClearSelection={archiveController.clearSelection}
+                    onDeleteSelected={() => archiveController.requestDelete(Array.from(archiveController.selectedIds))}
                 />;
             case 'editor':
                 return <EditorView image={editingImage} apiKey={apiKey} onSave={handleSaveEditedImage} />;
@@ -168,21 +156,28 @@ function App() {
                 </div>
             </main>
 
-            {selectedImage && (
+            {archiveController.selectedImage && (
                 <ImageDetailModal
-                    image={selectedImage}
-                    onClose={() => setSelectedImage(null)}
-                    onEdit={handleEditImage}
-                    onDelete={handleDeleteImage}
-                    onCreateSimilar={() => handleCreateSimilar(selectedImage)}
-                    onNext={handleNextImage}
-                    onPrevious={handlePreviousImage}
+                    image={archiveController.selectedImage}
+                    onClose={archiveController.closeImage}
+                    onEdit={() => archiveController.selectedImage && archiveController.editImage(archiveController.selectedImage)}
+                    onDelete={() => archiveController.selectedImage && archiveController.requestDelete([archiveController.selectedImage.id])}
+                    onCreateSimilar={archiveController.createSimilar}
+                    onNext={archiveController.showNextImage}
+                    onPrevious={archiveController.showPreviousImage}
                 />
             )}
 
             <ConfirmModal
-                {...confirmConfig}
-                onCancel={() => setConfirmConfig(prev => ({ ...prev, isOpen: false }))}
+                isOpen={archiveController.pendingDeleteIds.length > 0}
+                title={archiveController.pendingDeleteIds.length === 1 ? 'Delete Masterpiece?' : `Delete ${archiveController.pendingDeleteIds.length} Masterpieces?`}
+                message={archiveController.pendingDeleteIds.length === 1
+                    ? 'This will permanently remove the image and its binary data from your local storage. This action cannot be undone.'
+                    : `You are about to permanently remove ${archiveController.pendingDeleteIds.length} images and their binary data. This action cannot be reversed.`}
+                confirmText={archiveController.pendingDeleteIds.length === 1 ? 'Delete' : 'Delete All'}
+                type="danger"
+                onConfirm={archiveController.confirmDelete}
+                onCancel={archiveController.cancelDelete}
             />
 
             <div className="toast-container">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import ImageDetailModal from './components/ImageDetailModal'
 import Toast from './components/Toast'
 import type { ToastType } from './components/Toast'
 import ConfirmModal from './components/ConfirmModal'
-import { storage } from './services/StorageService'
+import { generateSessionStore } from './generate-session/GenerateSession'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useImageArchive } from './hooks/useImageArchive'
 import type { ArchiveImage } from './db/types'
@@ -111,20 +111,7 @@ function App() {
     }
 
     const handleCreateSimilar = async (image: ArchiveImage) => {
-        localStorage.setItem('aura_generate_prompt', JSON.stringify(image.prompt))
-        localStorage.setItem('aura_generate_quality', JSON.stringify(image.quality))
-        localStorage.setItem('aura_generate_aspect_ratio', JSON.stringify(image.aspectRatio))
-        localStorage.setItem('aura_generate_background', JSON.stringify(image.background || 'auto'))
-        localStorage.setItem('aura_generate_style', JSON.stringify(image.style || 'none'))
-        localStorage.setItem('aura_generate_lighting', JSON.stringify(image.lighting || 'none'))
-        localStorage.setItem('aura_generate_palette', JSON.stringify(image.palette || 'none'))
-        localStorage.setItem('aura_generate_is_saved', JSON.stringify(false))
-
-        if (image.references && image.references.length > 0) {
-            await storage.save('generate_transferred_references', JSON.stringify(image.references));
-        } else {
-            await storage.remove('generate_transferred_references');
-        }
+        await generateSessionStore.transferFromArchive(image)
 
         setSelectedImage(null)
         setCurrentView('generate')

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -1,55 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useArchiveController } from '../archive/useArchiveController';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore } from '../generate-session/GenerateSession';
-import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useAppNotifications } from './useAppNotifications';
+import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';
-import type { ToastType } from '../components/Toast';
-import type { AppView } from '../types';
-
-interface AppToast {
-    id: string;
-    message: string;
-    type: ToastType;
-}
 
 export function useAppController() {
-    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
-    const { images, addImage, deleteImage } = useImageArchive();
-    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
+    const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
+    const { toasts, addToast, removeToast, notifyError } = useAppNotifications();
+    const handleArchiveError = useCallback((error: Error, operation: 'load' | 'save' | 'delete') => {
+        notifyError(error, `Archive ${operation} failed`);
+    }, [notifyError]);
+    const { images, addImage, deleteImage } = useImageArchive({
+        onError: handleArchiveError,
+    });
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
-    const [toasts, setToasts] = useState<AppToast[]>([]);
-    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
-
-    useEffect(() => {
-        document.documentElement.setAttribute('data-theme', theme);
-    }, [theme]);
-
-    useEffect(() => {
-        if (!apiKey) {
-            const legacyKey = localStorage.getItem('openai_api_key');
-            if (legacyKey) {
-                setApiKey(legacyKey);
-            }
-        }
-    }, [apiKey, setApiKey]);
-
-    const addToast = useCallback((message: string, type: ToastType = 'info') => {
-        const id = crypto.randomUUID();
-        setToasts((currentToasts) => [...currentToasts, { id, message, type }]);
-    }, []);
-
-    const removeToast = useCallback((id: string) => {
-        setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
-    }, []);
-
-    const changeView = useCallback((view: AppView) => {
-        setCurrentView(view);
-    }, [setCurrentView]);
-
-    const updateApiKey = useCallback((key: string) => {
-        setApiKey(key);
-    }, [setApiKey]);
 
     const saveImage = useCallback(async (image: ArchiveImage) => {
         await addImage(image);
@@ -66,8 +32,8 @@ export function useAppController() {
 
     const editImage = useCallback((image: ArchiveImage) => {
         setEditingImage(image);
-        setCurrentView('editor');
-    }, [setCurrentView]);
+        changeView('editor');
+    }, [changeView]);
 
     const saveEditedImage = useCallback(async (updatedUrl: string, isCopy: boolean = false, references?: string[]) => {
         if (!editingImage) {
@@ -92,19 +58,19 @@ export function useAppController() {
             addToast('Masterpiece updated', 'success');
         }
 
-        setCurrentView('archive');
+        changeView('archive');
         setEditingImage(null);
-    }, [addImage, addToast, editingImage, setCurrentView]);
+    }, [addImage, addToast, changeView, editingImage]);
 
     const createSimilar = useCallback(async (image: ArchiveImage) => {
-        await generateSessionStore.transferFromArchive(image);
-        setCurrentView('generate');
-        addToast('Settings & references transferred', 'info');
-    }, [addToast, setCurrentView]);
-
-    const toggleTheme = useCallback(() => {
-        setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
-    }, [setTheme]);
+        try {
+            await generateSessionStore.transferFromArchive(image);
+            changeView('generate');
+            addToast('Settings & references transferred', 'info');
+        } catch (error) {
+            notifyError(error, 'Failed to transfer image settings');
+        }
+    }, [addToast, changeView, notifyError]);
 
     const archiveController = useArchiveController({
         images,
@@ -138,6 +104,7 @@ export function useAppController() {
             onToggleSelectAll: archiveController.toggleSelectAll,
             onClearSelection: archiveController.clearSelection,
             onDeleteSelected: () => archiveController.requestDelete(Array.from(archiveController.selectedIds)),
+            onBulkDownloadError: (error: Error) => notifyError(error, 'Failed to export archive ZIP'),
         },
         editorViewProps: {
             key: editingImage?.id ?? 'empty-editor',

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useArchiveController } from '../archive/useArchiveController';
+import type { ArchiveImage } from '../db/types';
+import { generateSessionStore } from '../generate-session/GenerateSession';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useImageArchive } from '../hooks/useImageArchive';
+import type { ToastType } from '../components/Toast';
+import type { AppView } from '../types';
+
+interface AppToast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+export function useAppController() {
+    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
+    const { images, addImage, deleteImage } = useImageArchive();
+    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
+    const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
+    const [toasts, setToasts] = useState<AppToast[]>([]);
+    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
+
+    useEffect(() => {
+        document.documentElement.setAttribute('data-theme', theme);
+    }, [theme]);
+
+    useEffect(() => {
+        if (!apiKey) {
+            const legacyKey = localStorage.getItem('openai_api_key');
+            if (legacyKey) {
+                setApiKey(legacyKey);
+            }
+        }
+    }, [apiKey, setApiKey]);
+
+    const addToast = useCallback((message: string, type: ToastType = 'info') => {
+        const id = crypto.randomUUID();
+        setToasts((currentToasts) => [...currentToasts, { id, message, type }]);
+    }, []);
+
+    const removeToast = useCallback((id: string) => {
+        setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+    }, []);
+
+    const changeView = useCallback((view: AppView) => {
+        setCurrentView(view);
+    }, [setCurrentView]);
+
+    const updateApiKey = useCallback((key: string) => {
+        setApiKey(key);
+    }, [setApiKey]);
+
+    const saveImage = useCallback(async (image: ArchiveImage) => {
+        await addImage(image);
+        addToast('Image saved to archive', 'success');
+    }, [addImage, addToast]);
+
+    const deleteImages = useCallback(async (ids: string[]) => {
+        for (const id of ids) {
+            await deleteImage(id);
+        }
+
+        addToast(ids.length === 1 ? 'Image deleted permanently' : `${ids.length} images deleted permanently`, 'info');
+    }, [addToast, deleteImage]);
+
+    const editImage = useCallback((image: ArchiveImage) => {
+        setEditingImage(image);
+        setCurrentView('editor');
+    }, [setCurrentView]);
+
+    const saveEditedImage = useCallback(async (updatedUrl: string, isCopy: boolean = false, references?: string[]) => {
+        if (!editingImage) {
+            return;
+        }
+
+        if (isCopy) {
+            await addImage({
+                ...editingImage,
+                id: crypto.randomUUID(),
+                url: updatedUrl,
+                timestamp: new Date().toISOString(),
+                references: references || editingImage.references,
+            });
+            addToast('Design saved as new copy', 'success');
+        } else {
+            await addImage({
+                ...editingImage,
+                url: updatedUrl,
+                references: references || editingImage.references,
+            });
+            addToast('Masterpiece updated', 'success');
+        }
+
+        setCurrentView('archive');
+        setEditingImage(null);
+    }, [addImage, addToast, editingImage, setCurrentView]);
+
+    const createSimilar = useCallback(async (image: ArchiveImage) => {
+        await generateSessionStore.transferFromArchive(image);
+        setCurrentView('generate');
+        addToast('Settings & references transferred', 'info');
+    }, [addToast, setCurrentView]);
+
+    const toggleTheme = useCallback(() => {
+        setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
+    }, [setTheme]);
+
+    const archiveController = useArchiveController({
+        images,
+        onDeleteImages: deleteImages,
+        onEditImage: editImage,
+        onCreateSimilar: createSimilar,
+    });
+
+    return {
+        currentView,
+        apiKey,
+        editingImage,
+        theme,
+        toasts,
+        archiveController,
+        changeView,
+        updateApiKey,
+        toggleTheme,
+        removeToast,
+        generateViewProps: {
+            apiKey,
+            onSaveImage: saveImage,
+        },
+        archiveViewProps: {
+            images,
+            selectedIds: archiveController.selectedIds,
+            onDeleteImage: (id: string) => archiveController.requestDelete([id]),
+            onEditImage: archiveController.editImage,
+            onOpenImage: archiveController.openImage,
+            onToggleSelection: archiveController.toggleSelection,
+            onToggleSelectAll: archiveController.toggleSelectAll,
+            onClearSelection: archiveController.clearSelection,
+            onDeleteSelected: () => archiveController.requestDelete(Array.from(archiveController.selectedIds)),
+        },
+        editorViewProps: {
+            key: editingImage?.id ?? 'empty-editor',
+            image: editingImage,
+            apiKey,
+            onSave: saveEditedImage,
+        },
+        settingsViewProps: {
+            apiKey,
+            onApiKeyChange: updateApiKey,
+        },
+    };
+}

--- a/src/app/useAppNotifications.ts
+++ b/src/app/useAppNotifications.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+import type { ToastType } from '../components/Toast';
+
+interface AppToast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+export function useAppNotifications() {
+    const [toasts, setToasts] = useState<AppToast[]>([]);
+
+    const addToast = useCallback((message: string, type: ToastType = 'info') => {
+        const id = crypto.randomUUID();
+        setToasts((currentToasts) => [...currentToasts, { id, message, type }]);
+    }, []);
+
+    const removeToast = useCallback((id: string) => {
+        setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+    }, []);
+
+    const notifyError = useCallback((error: unknown, fallback: string) => {
+        addToast(error instanceof Error ? error.message : fallback, 'error');
+    }, [addToast]);
+
+    return {
+        toasts,
+        addToast,
+        removeToast,
+        notifyError,
+    };
+}

--- a/src/app/useAppPreferences.ts
+++ b/src/app/useAppPreferences.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import type { AppView } from '../types';
+
+export function useAppPreferences() {
+    const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
+    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
+    const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
+
+    useEffect(() => {
+        document.documentElement.setAttribute('data-theme', theme);
+    }, [theme]);
+
+    useEffect(() => {
+        if (!apiKey) {
+            const legacyKey = localStorage.getItem('openai_api_key');
+            if (legacyKey) {
+                setApiKey(legacyKey);
+            }
+        }
+    }, [apiKey, setApiKey]);
+
+    const changeView = useCallback((view: AppView) => {
+        setCurrentView(view);
+    }, [setCurrentView]);
+
+    const updateApiKey = useCallback((key: string) => {
+        setApiKey(key);
+    }, [setApiKey]);
+
+    const toggleTheme = useCallback(() => {
+        setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
+    }, [setTheme]);
+
+    return {
+        currentView,
+        apiKey,
+        theme,
+        changeView,
+        updateApiKey,
+        toggleTheme,
+    };
+}

--- a/src/archive/ArchiveExport.ts
+++ b/src/archive/ArchiveExport.ts
@@ -1,0 +1,32 @@
+import JSZip from 'jszip';
+import type { ArchiveImage } from '../db/types';
+import { downloadBlob } from '../download/download';
+
+export async function downloadArchiveImagesAsZip(images: ArchiveImage[]) {
+    const zip = new JSZip();
+
+    for (const image of images) {
+        zip.file(`aura-${image.id}.png`, await imageUrlToBlob(image.url));
+    }
+
+    const content = await zip.generateAsync({ type: 'blob' });
+    downloadBlob(content, `aura-collection-${Date.now()}.zip`);
+}
+
+async function imageUrlToBlob(url: string) {
+    if (!url.startsWith('data:')) {
+        const response = await fetch(url);
+        return response.blob();
+    }
+
+    const [metadata, base64Data] = url.split(',', 2);
+    if (!metadata || !base64Data) {
+        throw new Error('Invalid image data URL');
+    }
+
+    const mimeType = metadata.match(/data:(.*?);base64/)?.[1] ?? 'image/png';
+    const binary = atob(base64Data);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+    return new Blob([bytes], { type: mimeType });
+}

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -78,7 +78,8 @@ class LocalArchiveStore implements ArchiveStore {
 
     async list(): Promise<ArchiveImage[]> {
         const records = await this.metadata.list();
-        return Promise.all(records.map((record) => this.hydrate(record)));
+        const images = await Promise.all(records.map((record) => this.hydrate(record)));
+        return images.filter((image): image is ArchiveImage => image !== null);
     }
 
     async save(input: SaveArchiveImageInput): Promise<ArchiveImage> {
@@ -86,26 +87,34 @@ class LocalArchiveStore implements ArchiveStore {
         const existing = await this.metadata.get(id);
         const timestamp = input.timestamp ?? existing?.timestamp ?? this.clock();
         const referenceIds = input.references?.map((_, index) => index) ?? [];
+        const snapshot = await this.captureSnapshot(id, existing?.referenceIds ?? []);
+        const touchedReferenceIds = getTouchedReferenceIds(existing?.referenceIds ?? [], referenceIds);
 
-        await this.blobs.save(getImageBlobKey(id), input.url);
-        await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
+        try {
+            await this.blobs.save(getImageBlobKey(id), input.url);
+            await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
 
-        await this.metadata.save({
-            id,
-            storedUrl: id,
-            prompt: input.prompt,
-            quality: input.quality,
-            aspectRatio: input.aspectRatio,
-            background: input.background,
-            timestamp,
-            model: input.model,
-            width: input.width,
-            height: input.height,
-            style: input.style,
-            lighting: input.lighting,
-            palette: input.palette,
-            referenceIds,
-        });
+            await this.metadata.save({
+                id,
+                storedUrl: id,
+                prompt: input.prompt,
+                quality: input.quality,
+                aspectRatio: input.aspectRatio,
+                background: input.background,
+                timestamp,
+                model: input.model,
+                width: input.width,
+                height: input.height,
+                style: input.style,
+                lighting: input.lighting,
+                palette: input.palette,
+                referenceIds,
+            });
+        } catch (error) {
+            await this.restoreMetadata(id, existing);
+            await this.restoreSnapshot(id, snapshot, touchedReferenceIds);
+            throw error;
+        }
 
         return {
             id,
@@ -127,21 +136,34 @@ class LocalArchiveStore implements ArchiveStore {
 
     async remove(id: string): Promise<void> {
         const existing = await this.metadata.get(id);
+        const snapshot = await this.captureSnapshot(id, existing?.referenceIds ?? []);
+        const touchedReferenceIds = existing?.referenceIds ?? [];
 
-        await this.blobs.remove(getImageBlobKey(id));
-        await Promise.all((existing?.referenceIds ?? []).map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
-        await this.metadata.remove(id);
+        try {
+            await this.blobs.remove(getImageBlobKey(id));
+            await Promise.all(touchedReferenceIds.map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
+            await this.metadata.remove(id);
+        } catch (error) {
+            await this.restoreMetadata(id, existing);
+            await this.restoreSnapshot(id, snapshot, touchedReferenceIds);
+            throw error;
+        }
     }
 
-    private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage> {
+    private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage | null> {
         const [imageUrl, references] = await Promise.all([
             this.blobs.load(getImageBlobKey(record.id)),
             Promise.all(record.referenceIds.map((index) => this.blobs.load(getReferenceBlobKey(record.id, index)))),
         ]);
 
+        const resolvedImageUrl = imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : null);
+        if (!resolvedImageUrl) {
+            return null;
+        }
+
         return {
             id: record.id,
-            url: imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : ''),
+            url: resolvedImageUrl,
             prompt: record.prompt,
             quality: record.quality,
             aspectRatio: record.aspectRatio,
@@ -157,6 +179,46 @@ class LocalArchiveStore implements ArchiveStore {
         };
     }
 
+    private async captureSnapshot(id: string, referenceIds: number[]) {
+        const [image, references] = await Promise.all([
+            this.blobs.load(getImageBlobKey(id)),
+            Promise.all(referenceIds.map(async (index) => [index, await this.blobs.load(getReferenceBlobKey(id, index))] as const)),
+        ]);
+
+        return {
+            image,
+            references: new Map(references.filter((entry): entry is readonly [number, string] => entry[1] !== null)),
+        };
+    }
+
+    private async restoreSnapshot(id: string, snapshot: { image: string | null; references: Map<number, string> }, touchedReferenceIds: number[]) {
+        if (snapshot.image !== null) {
+            await this.blobs.save(getImageBlobKey(id), snapshot.image);
+        } else {
+            await this.blobs.remove(getImageBlobKey(id));
+        }
+
+        const referenceIds = getTouchedReferenceIds(Array.from(snapshot.references.keys()), touchedReferenceIds);
+        await Promise.all(referenceIds.map(async (index) => {
+            const previousReference = snapshot.references.get(index);
+            if (previousReference !== undefined) {
+                await this.blobs.save(getReferenceBlobKey(id, index), previousReference);
+                return;
+            }
+
+            await this.blobs.remove(getReferenceBlobKey(id, index));
+        }));
+    }
+
+    private async restoreMetadata(id: string, record: ArchiveMetadataRecord | null) {
+        if (record) {
+            await this.metadata.save(record);
+            return;
+        }
+
+        await this.metadata.remove(id);
+    }
+
     private async syncReferences(id: string, previousReferenceIds: number[], nextReferences: string[]): Promise<void> {
         await Promise.all(nextReferences.map((reference, index) => this.blobs.save(getReferenceBlobKey(id, index), reference)));
 
@@ -170,6 +232,10 @@ class LocalArchiveStore implements ArchiveStore {
 const getImageBlobKey = (id: string) => `img_${id}`;
 
 const getReferenceBlobKey = (id: string, index: number) => `ref_${id}_${index}`;
+
+const getTouchedReferenceIds = (left: number[], right: number[]) => {
+    return Array.from(new Set([...left, ...right]));
+};
 
 export function createArchiveStore(deps: CreateArchiveStoreDeps = {}): ArchiveStore {
     return new LocalArchiveStore(

--- a/src/archive/useArchiveController.ts
+++ b/src/archive/useArchiveController.ts
@@ -1,0 +1,165 @@
+import { useMemo, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+
+interface UseArchiveControllerOptions {
+    images: ArchiveImage[];
+    onDeleteImages: (ids: string[]) => Promise<void>;
+    onEditImage: (image: ArchiveImage) => void;
+    onCreateSimilar: (image: ArchiveImage) => Promise<void> | void;
+}
+
+export function useArchiveController({
+    images,
+    onDeleteImages,
+    onEditImage,
+    onCreateSimilar,
+}: UseArchiveControllerOptions) {
+    const [selectedIdsState, setSelectedIdsState] = useState<Set<string>>(new Set());
+    const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+    const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
+    const imageIds = useMemo(() => new Set(images.map((image) => image.id)), [images]);
+
+    const selectedIds = useMemo(
+        () => new Set(Array.from(selectedIdsState).filter((id) => imageIds.has(id))),
+        [imageIds, selectedIdsState],
+    );
+
+    const selectedImage = useMemo(
+        () => images.find((image) => image.id === selectedImageId) ?? null,
+        [images, selectedImageId],
+    );
+
+    const toggleSelection = (id: string) => {
+        setSelectedIdsState((currentSelectedIds) => {
+            const nextSelectedIds = new Set(currentSelectedIds);
+
+            if (nextSelectedIds.has(id)) {
+                nextSelectedIds.delete(id);
+            } else {
+                nextSelectedIds.add(id);
+            }
+
+            return nextSelectedIds;
+        });
+    };
+
+    const clearSelection = () => {
+        setSelectedIdsState(new Set());
+    };
+
+    const toggleSelectAll = (ids: string[]) => {
+        const nextIds = ids.filter(Boolean);
+        if (nextIds.length === 0) {
+            return;
+        }
+
+        setSelectedIdsState((currentSelectedIds) => {
+            const areAllSelected = nextIds.every((id) => currentSelectedIds.has(id));
+
+            if (areAllSelected) {
+                const remainingSelectedIds = new Set(currentSelectedIds);
+                nextIds.forEach((id) => remainingSelectedIds.delete(id));
+                return remainingSelectedIds;
+            }
+
+            const mergedSelectedIds = new Set(currentSelectedIds);
+            nextIds.forEach((id) => mergedSelectedIds.add(id));
+            return mergedSelectedIds;
+        });
+    };
+
+    const openImage = (image: ArchiveImage) => {
+        setSelectedImageId(image.id);
+    };
+
+    const closeImage = () => {
+        setSelectedImageId(null);
+    };
+
+    const editImage = (image: ArchiveImage) => {
+        setSelectedImageId(null);
+        onEditImage(image);
+    };
+
+    const createSimilar = async () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        setSelectedImageId(null);
+        await onCreateSimilar(selectedImage);
+    };
+
+    const requestDelete = (ids: string[]) => {
+        const nextIds = Array.from(new Set(ids.filter(Boolean)));
+        if (nextIds.length === 0) {
+            return;
+        }
+
+        setPendingDeleteIds(nextIds);
+    };
+
+    const confirmDelete = async () => {
+        if (pendingDeleteIds.length === 0) {
+            return;
+        }
+
+        const idsToDelete = pendingDeleteIds;
+        await onDeleteImages(idsToDelete);
+
+        setPendingDeleteIds([]);
+        setSelectedIdsState((currentSelectedIds) => {
+            const remainingSelectedIds = new Set(currentSelectedIds);
+            idsToDelete.forEach((id) => remainingSelectedIds.delete(id));
+            return remainingSelectedIds;
+        });
+
+        if (selectedImageId && idsToDelete.includes(selectedImageId)) {
+            setSelectedImageId(null);
+        }
+    };
+
+    const cancelDelete = () => {
+        setPendingDeleteIds([]);
+    };
+
+    const showPreviousImage = () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        const currentIndex = images.findIndex((image) => image.id === selectedImage.id);
+        if (currentIndex > 0) {
+            setSelectedImageId(images[currentIndex - 1].id);
+        }
+    };
+
+    const showNextImage = () => {
+        if (!selectedImage) {
+            return;
+        }
+
+        const currentIndex = images.findIndex((image) => image.id === selectedImage.id);
+        if (currentIndex >= 0 && currentIndex < images.length - 1) {
+            setSelectedImageId(images[currentIndex + 1].id);
+        }
+    };
+
+    return {
+        selectedIds,
+        selectedImage,
+        pendingDeleteIds,
+        toggleSelection,
+        clearSelection,
+        toggleSelectAll,
+        openImage,
+        closeImage,
+        editImage,
+        createSimilar,
+        requestDelete,
+        confirmDelete,
+        cancelDelete,
+        showPreviousImage,
+        showNextImage,
+    };
+}

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Download, Trash2, Edit2, Clock } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadArchiveImage } from '../download/download';
 
 interface ImageCardProps {
     image: ArchiveImage;
@@ -18,10 +19,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
 
     const handleDownload = (e: React.MouseEvent) => {
         e.stopPropagation();
-        const link = document.createElement('a');
-        link.href = image.url;
-        link.download = `aura-${image.id}.png`;
-        link.click();
+        downloadArchiveImage(image);
     };
 
     return (

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -5,8 +5,8 @@ import type { ArchiveImage } from '../db/types';
 interface ImageDetailModalProps {
     image: ArchiveImage;
     onClose: () => void;
-    onEdit: (image: ArchiveImage) => void;
-    onDelete: (id: string) => void;
+    onEdit: () => void;
+    onDelete: () => void;
     onCreateSimilar: () => void;
     onNext: () => void;
     onPrevious: () => void;
@@ -58,7 +58,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                             <button className="aura-btn aura-btn--primary" onClick={downloadImage}>
                                 <Download size={18} /> Download
                             </button>
-                            <button className="aura-btn aura-btn--glass" onClick={() => onEdit(image)}>
+                            <button className="aura-btn aura-btn--glass" onClick={onEdit}>
                                 <Edit2 size={18} /> Edit
                             </button>
                         </div>
@@ -142,7 +142,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                 <Copy size={18} /> Copy Prompt
                             </button>
                             <div className="divider" style={{ height: '1px', background: 'rgba(255,255,255,0.1)', margin: '1rem 0' }} />
-                            <button className="aura-btn aura-btn--danger" onClick={() => onDelete(image.id)} style={{ width: '100%', padding: '1rem' }}>
+                            <button className="aura-btn aura-btn--danger" onClick={onDelete} style={{ width: '100%', padding: '1rem' }}>
                                 <Trash2 size={18} /> Delete Permanently
                             </button>
                         </div>

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2 } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadArchiveImage } from '../download/download';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -27,10 +28,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     };
 
     const downloadImage = () => {
-        const link = document.createElement('a');
-        link.href = image.url;
-        link.download = `aura-${image.id}.png`;
-        link.click();
+        downloadArchiveImage(image);
     };
 
     React.useEffect(() => {

--- a/src/download/download.ts
+++ b/src/download/download.ts
@@ -1,0 +1,22 @@
+import type { ArchiveImage } from '../db/types';
+
+export function downloadUrl(url: string, filename: string) {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+}
+
+export function downloadBlob(blob: Blob, filename: string) {
+    const url = URL.createObjectURL(blob);
+    downloadUrl(url, filename);
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+}
+
+export function downloadArchiveImage(image: Pick<ArchiveImage, 'id' | 'url'>) {
+    downloadUrl(image.url, `aura-${image.id}.png`);
+}
+
+export function downloadGeneratedImage(url: string) {
+    downloadUrl(url, `aura-generation-${Date.now()}.png`);
+}

--- a/src/editor/useEditorCanvas.ts
+++ b/src/editor/useEditorCanvas.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: string) {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        if (!currentImageUrl) {
+            return;
+        }
+
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return;
+        }
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return;
+        }
+
+        let cancelled = false;
+        const image = new Image();
+        image.crossOrigin = 'anonymous';
+        image.src = currentImageUrl;
+        image.onload = () => {
+            if (cancelled) {
+                return;
+            }
+
+            canvas.width = image.width;
+            canvas.height = image.height;
+            context.filter = canvasFilter;
+            context.clearRect(0, 0, canvas.width, canvas.height);
+            context.drawImage(image, 0, 0);
+        };
+
+        return () => {
+            cancelled = true;
+        };
+    }, [canvasFilter, currentImageUrl]);
+
+    const exportDataUrl = useCallback(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            throw new Error('Canvas not ready');
+        }
+
+        return canvas.toDataURL('image/png');
+    }, []);
+
+    const exportBlob = useCallback(async () => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            throw new Error('Canvas not ready');
+        }
+
+        return new Promise<Blob>((resolve, reject) => {
+            canvas.toBlob((blob) => {
+                if (blob) {
+                    resolve(blob);
+                    return;
+                }
+
+                reject(new Error('Canvas conversion failed'));
+            }, 'image/png');
+        });
+    }, []);
+
+    return {
+        canvasRef,
+        exportDataUrl,
+        exportBlob,
+    };
+}

--- a/src/editor/useEditorCanvas.ts
+++ b/src/editor/useEditorCanvas.ts
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: string) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [readyToken, setReadyToken] = useState<string | null>(null);
+    const canvasToken = currentImageUrl ? `${currentImageUrl}:${canvasFilter}` : null;
+    const isReady = readyToken === canvasToken;
 
     useEffect(() => {
         if (!currentImageUrl) {
@@ -32,12 +35,18 @@ export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: st
             context.filter = canvasFilter;
             context.clearRect(0, 0, canvas.width, canvas.height);
             context.drawImage(image, 0, 0);
+            setReadyToken(canvasToken);
+        };
+        image.onerror = () => {
+            if (!cancelled) {
+                setReadyToken(null);
+            }
         };
 
         return () => {
             cancelled = true;
         };
-    }, [canvasFilter, currentImageUrl]);
+    }, [canvasFilter, canvasToken, currentImageUrl]);
 
     const exportDataUrl = useCallback(() => {
         const canvas = canvasRef.current;
@@ -68,6 +77,7 @@ export function useEditorCanvas(currentImageUrl: string | null, canvasFilter: st
 
     return {
         canvasRef,
+        isReady,
         exportDataUrl,
         exportBlob,
     };

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -3,6 +3,7 @@ import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 
 interface UseEditorControllerOptions {
     apiKey: string | null;
+    isCanvasReady: boolean;
     currentImageUrl: string | null;
     setCurrentImageUrl: (url: string) => void;
     referenceImages: File[];
@@ -15,6 +16,7 @@ interface UseEditorControllerOptions {
 
 export function useEditorController({
     apiKey,
+    isCanvasReady,
     currentImageUrl,
     setCurrentImageUrl,
     referenceImages,
@@ -30,13 +32,21 @@ export function useEditorController({
     const [isDragging, setIsDragging] = useState(false);
 
     const save = useCallback(async (isCopy: boolean = false) => {
-        const dataUrl = exportDataUrl();
-        const references = await serializeReferences();
-        await Promise.resolve(onSave(dataUrl, isCopy, references));
-    }, [exportDataUrl, onSave, serializeReferences]);
+        if (!isCanvasReady) {
+            return;
+        }
+
+        try {
+            const dataUrl = exportDataUrl();
+            const references = await serializeReferences();
+            await Promise.resolve(onSave(dataUrl, isCopy, references));
+        } catch (err: unknown) {
+            setAiError(err instanceof Error ? err.message : 'Failed to save image');
+        }
+    }, [exportDataUrl, isCanvasReady, onSave, serializeReferences]);
 
     const applyAiEdit = useCallback(async () => {
-        if (!apiKey || !aiPrompt.trim() || !currentImageUrl) {
+        if (!apiKey || !aiPrompt.trim() || !currentImageUrl || !isCanvasReady) {
             return;
         }
 
@@ -60,7 +70,7 @@ export function useEditorController({
         } finally {
             setAiLoading(false);
         }
-    }, [aiPrompt, apiKey, currentImageUrl, exportBlob, referenceImages, setCurrentImageUrl]);
+    }, [aiPrompt, apiKey, currentImageUrl, exportBlob, isCanvasReady, referenceImages, setCurrentImageUrl]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();
@@ -88,6 +98,7 @@ export function useEditorController({
         aiLoading,
         aiError,
         isDragging,
+        isCanvasReady,
         save,
         applyAiEdit,
         handleDragOver,

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+interface UseEditorControllerOptions {
+    apiKey: string | null;
+    currentImageUrl: string | null;
+    setCurrentImageUrl: (url: string) => void;
+    referenceImages: File[];
+    addReferenceFiles: (files: File[]) => void;
+    serializeReferences: () => Promise<string[]>;
+    exportDataUrl: () => string;
+    exportBlob: () => Promise<Blob>;
+    onSave: (updatedUrl: string, isCopy?: boolean, references?: string[]) => void | Promise<void>;
+}
+
+export function useEditorController({
+    apiKey,
+    currentImageUrl,
+    setCurrentImageUrl,
+    referenceImages,
+    addReferenceFiles,
+    serializeReferences,
+    exportDataUrl,
+    exportBlob,
+    onSave,
+}: UseEditorControllerOptions) {
+    const [aiPrompt, setAiPrompt] = useState('');
+    const [aiLoading, setAiLoading] = useState(false);
+    const [aiError, setAiError] = useState<string | null>(null);
+    const [isDragging, setIsDragging] = useState(false);
+
+    const save = useCallback(async (isCopy: boolean = false) => {
+        const dataUrl = exportDataUrl();
+        const references = await serializeReferences();
+        await Promise.resolve(onSave(dataUrl, isCopy, references));
+    }, [exportDataUrl, onSave, serializeReferences]);
+
+    const applyAiEdit = useCallback(async () => {
+        if (!apiKey || !aiPrompt.trim() || !currentImageUrl) {
+            return;
+        }
+
+        setAiLoading(true);
+        setAiError(null);
+
+        try {
+            const blob = await exportBlob();
+            const newUrl = await imageWorkflow.edit({
+                apiKey,
+                prompt: aiPrompt,
+                sourceImage: blob,
+                referenceImages,
+                quality: 'medium',
+            });
+
+            setCurrentImageUrl(newUrl);
+            setAiPrompt('');
+        } catch (err: unknown) {
+            setAiError(err instanceof Error ? err.message : 'AI Edit failed');
+        } finally {
+            setAiLoading(false);
+        }
+    }, [aiPrompt, apiKey, currentImageUrl, exportBlob, referenceImages, setCurrentImageUrl]);
+
+    const handleDragOver = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(true);
+    }, []);
+
+    const handleDragLeave = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+    }, []);
+
+    const handleDrop = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+
+        const files = Array.from(e.dataTransfer.files).filter((file) => file.type.startsWith('image/'));
+        if (files.length > 0) {
+            addReferenceFiles(files);
+        }
+    }, [addReferenceFiles]);
+
+    return {
+        aiPrompt,
+        setAiPrompt,
+        aiLoading,
+        aiError,
+        isDragging,
+        save,
+        applyAiEdit,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
+    };
+}

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
@@ -18,16 +18,21 @@ export function useEditorSession(image: ArchiveImage | null) {
         return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
     });
     const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
+    const referencePreviewsRef = useRef(referencePreviews);
+
+    useEffect(() => {
+        referencePreviewsRef.current = referencePreviews;
+    }, [referencePreviews]);
 
     useEffect(() => {
         return () => {
-            referencePreviews.forEach((url) => {
+            referencePreviewsRef.current.forEach((url) => {
                 if (url.startsWith('blob:')) {
                     URL.revokeObjectURL(url);
                 }
             });
         };
-    }, [referencePreviews]);
+    }, []);
 
     const canvasFilter = useMemo(() => {
         return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -9,10 +9,11 @@ const DEFAULT_SATURATION = 100;
 const DEFAULT_FILTER = 'none';
 
 export function useEditorSession(image: ArchiveImage | null) {
-    const [brightness, setBrightness] = useLocalStorage('editor_brightness', DEFAULT_BRIGHTNESS);
-    const [contrast, setContrast] = useLocalStorage('editor_contrast', DEFAULT_CONTRAST);
-    const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
-    const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
+    const sessionKey = image?.id ?? 'default';
+    const [brightness, setBrightness] = useLocalStorage(`editor_${sessionKey}_brightness`, DEFAULT_BRIGHTNESS);
+    const [contrast, setContrast] = useLocalStorage(`editor_${sessionKey}_contrast`, DEFAULT_CONTRAST);
+    const [saturation, setSaturation] = useLocalStorage(`editor_${sessionKey}_saturation`, DEFAULT_SATURATION);
+    const [filter, setFilter] = useLocalStorage(`editor_${sessionKey}_filter`, DEFAULT_FILTER);
     const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
     const referenceCollection = useReferenceImageCollection({ initialDataUrls: image?.references });
 

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+const DEFAULT_BRIGHTNESS = 100;
+const DEFAULT_CONTRAST = 100;
+const DEFAULT_SATURATION = 100;
+const DEFAULT_FILTER = 'none';
+
+export function useEditorSession(image: ArchiveImage | null) {
+    const [brightness, setBrightness] = useLocalStorage('editor_brightness', DEFAULT_BRIGHTNESS);
+    const [contrast, setContrast] = useLocalStorage('editor_contrast', DEFAULT_CONTRAST);
+    const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
+    const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
+    const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
+    const [referenceImages, setReferenceImages] = useState<File[]>(() => {
+        return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
+    });
+    const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
+
+    useEffect(() => {
+        return () => {
+            referencePreviews.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+        };
+    }, [referencePreviews]);
+
+    const canvasFilter = useMemo(() => {
+        return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
+    }, [brightness, contrast, saturation, filter]);
+
+    const addReferenceFiles = (files: File[]) => {
+        if (files.length === 0) {
+            return;
+        }
+
+        setReferenceImages((currentImages) => [...currentImages, ...files]);
+        setReferencePreviews((currentPreviews) => [
+            ...currentPreviews,
+            ...files.map((file) => URL.createObjectURL(file)),
+        ]);
+    };
+
+    const removeReferenceAt = (index: number) => {
+        setReferenceImages((currentImages) => currentImages.filter((_, currentIndex) => currentIndex !== index));
+        setReferencePreviews((currentPreviews) => {
+            const previewToRemove = currentPreviews[index];
+            if (previewToRemove?.startsWith('blob:')) {
+                URL.revokeObjectURL(previewToRemove);
+            }
+
+            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
+        });
+    };
+
+    const resetAdjustments = () => {
+        setBrightness(DEFAULT_BRIGHTNESS);
+        setContrast(DEFAULT_CONTRAST);
+        setSaturation(DEFAULT_SATURATION);
+        setFilter(DEFAULT_FILTER);
+    };
+
+    const serializeReferences = () => {
+        return imageWorkflow.serializeReferences(referenceImages);
+    };
+
+    return {
+        brightness,
+        setBrightness,
+        contrast,
+        setContrast,
+        saturation,
+        setSaturation,
+        filter,
+        setFilter,
+        canvasFilter,
+        currentImageUrl,
+        setCurrentImageUrl,
+        referenceImages,
+        referencePreviews,
+        addReferenceFiles,
+        removeReferenceAt,
+        resetAdjustments,
+        serializeReferences,
+    };
+}

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 
 const DEFAULT_BRIGHTNESS = 100;
 const DEFAULT_CONTRAST = 100;
@@ -14,53 +14,11 @@ export function useEditorSession(image: ArchiveImage | null) {
     const [saturation, setSaturation] = useLocalStorage('editor_saturation', DEFAULT_SATURATION);
     const [filter, setFilter] = useLocalStorage('editor_filter', DEFAULT_FILTER);
     const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(() => image?.url ?? null);
-    const [referenceImages, setReferenceImages] = useState<File[]>(() => {
-        return image?.references ? imageWorkflow.hydrateReferences(image.references) : [];
-    });
-    const [referencePreviews, setReferencePreviews] = useState<string[]>(() => image?.references ?? []);
-    const referencePreviewsRef = useRef(referencePreviews);
-
-    useEffect(() => {
-        referencePreviewsRef.current = referencePreviews;
-    }, [referencePreviews]);
-
-    useEffect(() => {
-        return () => {
-            referencePreviewsRef.current.forEach((url) => {
-                if (url.startsWith('blob:')) {
-                    URL.revokeObjectURL(url);
-                }
-            });
-        };
-    }, []);
+    const referenceCollection = useReferenceImageCollection({ initialDataUrls: image?.references });
 
     const canvasFilter = useMemo(() => {
         return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
     }, [brightness, contrast, saturation, filter]);
-
-    const addReferenceFiles = (files: File[]) => {
-        if (files.length === 0) {
-            return;
-        }
-
-        setReferenceImages((currentImages) => [...currentImages, ...files]);
-        setReferencePreviews((currentPreviews) => [
-            ...currentPreviews,
-            ...files.map((file) => URL.createObjectURL(file)),
-        ]);
-    };
-
-    const removeReferenceAt = (index: number) => {
-        setReferenceImages((currentImages) => currentImages.filter((_, currentIndex) => currentIndex !== index));
-        setReferencePreviews((currentPreviews) => {
-            const previewToRemove = currentPreviews[index];
-            if (previewToRemove?.startsWith('blob:')) {
-                URL.revokeObjectURL(previewToRemove);
-            }
-
-            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
-        });
-    };
 
     const resetAdjustments = () => {
         setBrightness(DEFAULT_BRIGHTNESS);
@@ -70,7 +28,7 @@ export function useEditorSession(image: ArchiveImage | null) {
     };
 
     const serializeReferences = () => {
-        return imageWorkflow.serializeReferences(referenceImages);
+        return referenceCollection.serialize();
     };
 
     return {
@@ -85,10 +43,10 @@ export function useEditorSession(image: ArchiveImage | null) {
         canvasFilter,
         currentImageUrl,
         setCurrentImageUrl,
-        referenceImages,
-        referencePreviews,
-        addReferenceFiles,
-        removeReferenceAt,
+        referenceImages: referenceCollection.files,
+        referencePreviews: referenceCollection.previews,
+        addReferenceFiles: referenceCollection.addFiles,
+        removeReferenceAt: referenceCollection.removeAt,
         resetAdjustments,
         serializeReferences,
     };

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import type { ArchiveImage } from '../db/types';
+import { storage, type StorageProvider } from '../services/StorageService';
+import type { ImageBackground, ImageQuality } from '../utils/openai';
+
+const GENERATE_DRAFT_KEY = 'aura_generate_draft';
+const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
+const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
+const VALID_ASPECT_RATIOS = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+
+const LEGACY_KEYS = {
+    prompt: 'aura_generate_prompt',
+    quality: 'aura_generate_quality',
+    aspectRatio: 'aura_generate_aspect_ratio',
+    background: 'aura_generate_background',
+    style: 'aura_generate_style',
+    lighting: 'aura_generate_lighting',
+    palette: 'aura_generate_palette',
+    isSaved: 'aura_generate_is_saved',
+} as const;
+
+export interface GenerateDraft {
+    prompt: string;
+    quality: ImageQuality;
+    aspectRatio: string;
+    background: ImageBackground;
+    style: string;
+    lighting: string;
+    palette: string;
+    isSaved: boolean;
+}
+
+export interface GenerateSessionStore {
+    readDraft(): GenerateDraft;
+    writeDraft(draft: GenerateDraft): void;
+    transferFromArchive(image: ArchiveImage): Promise<void>;
+    loadCurrentResult(): Promise<string | null>;
+    saveCurrentResult(result: string): Promise<void>;
+    clearCurrentResult(): Promise<void>;
+    consumeTransferredReferences(): Promise<string[]>;
+}
+
+interface CreateGenerateSessionStoreDeps {
+    blobStorage?: StorageProvider;
+    localStorage?: Storage;
+}
+
+const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
+    prompt: '',
+    quality: 'medium',
+    aspectRatio: '1024x1024',
+    background: 'auto',
+    style: 'none',
+    lighting: 'none',
+    palette: 'none',
+    isSaved: false,
+};
+
+class LocalGenerateSessionStore implements GenerateSessionStore {
+    private readonly blobStorage: StorageProvider;
+    private readonly localStorage: Storage;
+
+    constructor(blobStorage: StorageProvider, localStorage: Storage) {
+        this.blobStorage = blobStorage;
+        this.localStorage = localStorage;
+    }
+
+    readDraft(): GenerateDraft {
+        const storedDraft = this.readJson<GenerateDraft>(GENERATE_DRAFT_KEY);
+        if (storedDraft) {
+            return sanitizeGenerateDraft(storedDraft);
+        }
+
+        return sanitizeGenerateDraft({
+            prompt: this.readLegacyValue(LEGACY_KEYS.prompt, DEFAULT_GENERATE_DRAFT.prompt),
+            quality: this.readLegacyValue(LEGACY_KEYS.quality, DEFAULT_GENERATE_DRAFT.quality),
+            aspectRatio: this.readLegacyValue(LEGACY_KEYS.aspectRatio, DEFAULT_GENERATE_DRAFT.aspectRatio),
+            background: this.readLegacyValue(LEGACY_KEYS.background, DEFAULT_GENERATE_DRAFT.background),
+            style: this.readLegacyValue(LEGACY_KEYS.style, DEFAULT_GENERATE_DRAFT.style),
+            lighting: this.readLegacyValue(LEGACY_KEYS.lighting, DEFAULT_GENERATE_DRAFT.lighting),
+            palette: this.readLegacyValue(LEGACY_KEYS.palette, DEFAULT_GENERATE_DRAFT.palette),
+            isSaved: this.readLegacyValue(LEGACY_KEYS.isSaved, DEFAULT_GENERATE_DRAFT.isSaved),
+        });
+    }
+
+    writeDraft(draft: GenerateDraft): void {
+        const nextDraft = sanitizeGenerateDraft(draft);
+        this.localStorage.setItem(GENERATE_DRAFT_KEY, JSON.stringify(nextDraft));
+        this.clearLegacyDraftKeys();
+    }
+
+    async transferFromArchive(image: ArchiveImage): Promise<void> {
+        this.writeDraft({
+            prompt: image.prompt,
+            quality: coerceQuality(image.quality),
+            aspectRatio: image.aspectRatio,
+            background: coerceBackground(image.background),
+            style: image.style || 'none',
+            lighting: image.lighting || 'none',
+            palette: image.palette || 'none',
+            isSaved: false,
+        });
+
+        if (image.references && image.references.length > 0) {
+            await this.blobStorage.save(GENERATE_TRANSFERRED_REFERENCES_KEY, JSON.stringify(image.references));
+            return;
+        }
+
+        await this.blobStorage.remove(GENERATE_TRANSFERRED_REFERENCES_KEY);
+    }
+
+    loadCurrentResult(): Promise<string | null> {
+        return this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
+    }
+
+    saveCurrentResult(result: string): Promise<void> {
+        return this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
+    }
+
+    clearCurrentResult(): Promise<void> {
+        return this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY);
+    }
+
+    async consumeTransferredReferences(): Promise<string[]> {
+        const value = await this.blobStorage.load(GENERATE_TRANSFERRED_REFERENCES_KEY);
+        await this.blobStorage.remove(GENERATE_TRANSFERRED_REFERENCES_KEY);
+
+        if (!value) {
+            return [];
+        }
+
+        try {
+            const references = JSON.parse(value) as string[];
+            return Array.isArray(references) ? references : [];
+        } catch {
+            return [];
+        }
+    }
+
+    private readLegacyValue<T>(key: string, fallback: T): T {
+        const rawValue = this.localStorage.getItem(key);
+        if (!rawValue) {
+            return fallback;
+        }
+
+        try {
+            return JSON.parse(rawValue) as T;
+        } catch {
+            return rawValue as T;
+        }
+    }
+
+    private readJson<T>(key: string): T | null {
+        const rawValue = this.localStorage.getItem(key);
+        if (!rawValue) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(rawValue) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    private clearLegacyDraftKeys() {
+        Object.values(LEGACY_KEYS).forEach((key) => this.localStorage.removeItem(key));
+    }
+}
+
+export function createGenerateSessionStore(deps: CreateGenerateSessionStoreDeps = {}): GenerateSessionStore {
+    return new LocalGenerateSessionStore(
+        deps.blobStorage ?? storage,
+        deps.localStorage ?? window.localStorage,
+    );
+}
+
+export const generateSessionStore = createGenerateSessionStore();
+
+export function useGenerateDraft(store: GenerateSessionStore = generateSessionStore) {
+    const [draft, setDraft] = useState<GenerateDraft>(() => store.readDraft());
+
+    useEffect(() => {
+        store.writeDraft(draft);
+    }, [draft, store]);
+
+    return [draft, setDraft] as const;
+}
+
+const sanitizeGenerateDraft = (draft: Partial<GenerateDraft>): GenerateDraft => ({
+    prompt: typeof draft.prompt === 'string' ? draft.prompt : DEFAULT_GENERATE_DRAFT.prompt,
+    quality: coerceQuality(draft.quality),
+    aspectRatio: typeof draft.aspectRatio === 'string' && VALID_ASPECT_RATIOS.has(draft.aspectRatio)
+        ? draft.aspectRatio
+        : DEFAULT_GENERATE_DRAFT.aspectRatio,
+    background: coerceBackground(draft.background),
+    style: typeof draft.style === 'string' ? draft.style : DEFAULT_GENERATE_DRAFT.style,
+    lighting: typeof draft.lighting === 'string' ? draft.lighting : DEFAULT_GENERATE_DRAFT.lighting,
+    palette: typeof draft.palette === 'string' ? draft.palette : DEFAULT_GENERATE_DRAFT.palette,
+    isSaved: typeof draft.isSaved === 'boolean' ? draft.isSaved : DEFAULT_GENERATE_DRAFT.isSaved,
+});
+
+const coerceQuality = (quality: unknown): ImageQuality => {
+    return quality === 'low' || quality === 'medium' || quality === 'high'
+        ? quality
+        : DEFAULT_GENERATE_DRAFT.quality;
+};
+
+const coerceBackground = (background: unknown): ImageBackground => {
+    return background === 'auto' || background === 'opaque' || background === 'transparent'
+        ? background
+        : DEFAULT_GENERATE_DRAFT.background;
+};

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -95,14 +95,15 @@ export function useGenerateController({
         }
 
         const references = await serializeReferences();
+        const { width, height } = getImageDimensions(draft.aspectRatio);
         await Promise.resolve(onSaveImage({
             id: crypto.randomUUID(),
             url: currentResult,
             prompt: draft.prompt,
             model: 'gpt-image-1.5',
             timestamp: new Date().toISOString(),
-            width: 1024,
-            height: 1024,
+            width,
+            height,
             quality: draft.quality,
             aspectRatio: draft.aspectRatio,
             background: draft.background,
@@ -137,4 +138,18 @@ export function useGenerateController({
         download,
         clear,
     };
+}
+
+function getImageDimensions(aspectRatio: string) {
+    if (aspectRatio === 'auto') {
+        return { width: 1024, height: 1024 };
+    }
+
+    const [width, height] = aspectRatio.split('x').map(Number);
+
+    if (!width || !height) {
+        return { width: 1024, height: 1024 };
+    }
+
+    return { width, height };
 }

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import type { ArchiveImage } from '../db/types';
+import { downloadGeneratedImage } from '../download/download';
+import { generateSessionStore, type GenerateDraft } from './GenerateSession';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+interface UseGenerateControllerOptions {
+    apiKey: string | null;
+    draft: GenerateDraft;
+    setDraft: Dispatch<SetStateAction<GenerateDraft>>;
+    referenceImages: File[];
+    replaceReferences: (dataUrls: string[]) => void;
+    serializeReferences: () => Promise<string[]>;
+    onSaveImage: (image: ArchiveImage) => void | Promise<void>;
+}
+
+const VALID_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
+
+export function useGenerateController({
+    apiKey,
+    draft,
+    setDraft,
+    referenceImages,
+    replaceReferences,
+    serializeReferences,
+    onSaveImage,
+}: UseGenerateControllerOptions) {
+    const [currentResult, setCurrentResult] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const updateDraft = useCallback((patch: Partial<GenerateDraft>) => {
+        setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
+    }, [setDraft]);
+
+    useEffect(() => {
+        generateSessionStore.loadCurrentResult().then((value) => {
+            if (value) {
+                setCurrentResult(value);
+            }
+        });
+
+        generateSessionStore.consumeTransferredReferences().then((references) => {
+            if (references.length > 0) {
+                replaceReferences(references);
+            }
+        });
+    }, [replaceReferences]);
+
+    useEffect(() => {
+        if (!VALID_SIZES.has(draft.aspectRatio)) {
+            setDraft((currentDraft) => ({ ...currentDraft, aspectRatio: '1024x1024' }));
+        }
+    }, [draft.aspectRatio, setDraft]);
+
+    const generate = useCallback(async () => {
+        if (!apiKey) {
+            setError('Please set your OpenAI API Key in Settings first.');
+            return;
+        }
+
+        if (!draft.prompt.trim()) {
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        try {
+            const imageUrl = await imageWorkflow.generate({
+                apiKey,
+                prompt: draft.prompt,
+                quality: draft.quality,
+                aspectRatio: draft.aspectRatio,
+                background: draft.background,
+                style: draft.style,
+                lighting: draft.lighting,
+                palette: draft.palette,
+                referenceImages,
+            });
+
+            setCurrentResult(imageUrl);
+            updateDraft({ isSaved: false });
+            await generateSessionStore.saveCurrentResult(imageUrl);
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Failed to generate image');
+        } finally {
+            setLoading(false);
+        }
+    }, [apiKey, draft, referenceImages, updateDraft]);
+
+    const save = useCallback(async () => {
+        if (!currentResult || draft.isSaved) {
+            return;
+        }
+
+        const references = await serializeReferences();
+        await Promise.resolve(onSaveImage({
+            id: crypto.randomUUID(),
+            url: currentResult,
+            prompt: draft.prompt,
+            model: 'gpt-image-1.5',
+            timestamp: new Date().toISOString(),
+            width: 1024,
+            height: 1024,
+            quality: draft.quality,
+            aspectRatio: draft.aspectRatio,
+            background: draft.background,
+            style: draft.style,
+            lighting: draft.lighting,
+            palette: draft.palette,
+            references,
+        }));
+        updateDraft({ isSaved: true });
+    }, [currentResult, draft, onSaveImage, serializeReferences, updateDraft]);
+
+    const download = useCallback(() => {
+        if (!currentResult) {
+            return;
+        }
+
+        downloadGeneratedImage(currentResult);
+    }, [currentResult]);
+
+    const clear = useCallback(async () => {
+        setCurrentResult(null);
+        await generateSessionStore.clearCurrentResult();
+    }, []);
+
+    return {
+        currentResult,
+        loading,
+        error,
+        updateDraft,
+        generate,
+        save,
+        download,
+        clear,
+    };
+}

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -94,25 +94,29 @@ export function useGenerateController({
             return;
         }
 
-        const references = await serializeReferences();
-        const { width, height } = getImageDimensions(draft.aspectRatio);
-        await Promise.resolve(onSaveImage({
-            id: crypto.randomUUID(),
-            url: currentResult,
-            prompt: draft.prompt,
-            model: 'gpt-image-1.5',
-            timestamp: new Date().toISOString(),
-            width,
-            height,
-            quality: draft.quality,
-            aspectRatio: draft.aspectRatio,
-            background: draft.background,
-            style: draft.style,
-            lighting: draft.lighting,
-            palette: draft.palette,
-            references,
-        }));
-        updateDraft({ isSaved: true });
+        try {
+            const references = await serializeReferences();
+            const { width, height } = getImageDimensions(draft.aspectRatio);
+            await Promise.resolve(onSaveImage({
+                id: crypto.randomUUID(),
+                url: currentResult,
+                prompt: draft.prompt,
+                model: 'gpt-image-1.5',
+                timestamp: new Date().toISOString(),
+                width,
+                height,
+                quality: draft.quality,
+                aspectRatio: draft.aspectRatio,
+                background: draft.background,
+                style: draft.style,
+                lighting: draft.lighting,
+                palette: draft.palette,
+                references,
+            }));
+            updateDraft({ isSaved: true });
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Failed to save image');
+        }
     }, [currentResult, draft, onSaveImage, serializeReferences, updateDraft]);
 
     const download = useCallback(() => {

--- a/src/hooks/useImageArchive.ts
+++ b/src/hooks/useImageArchive.ts
@@ -2,11 +2,20 @@ import { useState, useEffect, useCallback } from 'react';
 import { archiveStore, type ArchiveStore } from '../archive/ArchiveStore';
 import type { ArchiveImage } from '../db/types';
 
+type ArchiveOperation = 'load' | 'save' | 'delete';
+
+interface UseImageArchiveOptions {
+    store?: ArchiveStore;
+    onError?: (error: Error, operation: ArchiveOperation) => void;
+}
+
 const sortImagesByTimestamp = (images: ArchiveImage[]) => {
     return [...images].sort((left, right) => right.timestamp.localeCompare(left.timestamp));
 };
 
-export function useImageArchive(store: ArchiveStore = archiveStore) {
+export function useImageArchive(options: UseImageArchiveOptions = {}) {
+    const store = options.store ?? archiveStore;
+    const onError = options.onError;
     const [images, setImages] = useState<ArchiveImage[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
@@ -17,11 +26,13 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
             const data = await store.list();
             setImages(data);
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to load images'));
+            const nextError = err instanceof Error ? err : new Error('Failed to load images');
+            setError(nextError);
+            onError?.(nextError, 'load');
         } finally {
             setLoading(false);
         }
-    }, [store]);
+    }, [onError, store]);
 
     const addImage = async (image: ArchiveImage) => {
         try {
@@ -31,7 +42,9 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
                 ...current.filter((entry) => entry.id !== savedImage.id),
             ]));
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to save image'));
+            const nextError = err instanceof Error ? err : new Error('Failed to save image');
+            setError(nextError);
+            onError?.(nextError, 'save');
             throw err;
         }
     };
@@ -41,7 +54,9 @@ export function useImageArchive(store: ArchiveStore = archiveStore) {
             await store.remove(id);
             setImages((current) => current.filter((entry) => entry.id !== id));
         } catch (err) {
-            setError(err instanceof Error ? err : new Error('Failed to delete image'));
+            const nextError = err instanceof Error ? err : new Error('Failed to delete image');
+            setError(nextError);
+            onError?.(nextError, 'delete');
             throw err;
         }
     };

--- a/src/references/useReferenceImageCollection.ts
+++ b/src/references/useReferenceImageCollection.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+interface UseReferenceImageCollectionOptions {
+    initialDataUrls?: string[];
+}
+
+export function useReferenceImageCollection(options: UseReferenceImageCollectionOptions = {}) {
+    const initialDataUrls = options.initialDataUrls ?? [];
+    const [files, setFiles] = useState<File[]>(() => imageWorkflow.hydrateReferences(initialDataUrls));
+    const [previews, setPreviews] = useState<string[]>(() => initialDataUrls);
+    const previewsRef = useRef(previews);
+
+    useEffect(() => {
+        previewsRef.current = previews;
+    }, [previews]);
+
+    useEffect(() => {
+        return () => {
+            previewsRef.current.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+        };
+    }, []);
+
+    const addFiles = useCallback((nextFiles: File[]) => {
+        if (nextFiles.length === 0) {
+            return;
+        }
+
+        setFiles((currentFiles) => [...currentFiles, ...nextFiles]);
+        setPreviews((currentPreviews) => [
+            ...currentPreviews,
+            ...nextFiles.map((file) => URL.createObjectURL(file)),
+        ]);
+    }, []);
+
+    const removeAt = useCallback((index: number) => {
+        setFiles((currentFiles) => currentFiles.filter((_, currentIndex) => currentIndex !== index));
+        setPreviews((currentPreviews) => {
+            const previewToRemove = currentPreviews[index];
+            if (previewToRemove?.startsWith('blob:')) {
+                URL.revokeObjectURL(previewToRemove);
+            }
+
+            return currentPreviews.filter((_, currentIndex) => currentIndex !== index);
+        });
+    }, []);
+
+    const replaceWithDataUrls = useCallback((dataUrls: string[]) => {
+        previewsRef.current.forEach((url) => {
+            if (url.startsWith('blob:')) {
+                URL.revokeObjectURL(url);
+            }
+        });
+
+        setFiles(imageWorkflow.hydrateReferences(dataUrls));
+        setPreviews(dataUrls);
+    }, []);
+
+    const serialize = useCallback(() => {
+        return imageWorkflow.serializeReferences(files);
+    }, [files]);
+
+    return {
+        files,
+        previews,
+        addFiles,
+        removeAt,
+        replaceWithDataUrls,
+        serialize,
+    };
+}

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
+import { downloadArchiveImagesAsZip } from '../archive/ArchiveExport';
 import ImageCard from '../components/ImageCard';
 import type { ArchiveImage } from '../db/types';
-import { downloadBlob } from '../download/download';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
-import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface ArchiveViewProps {
@@ -16,6 +15,7 @@ interface ArchiveViewProps {
     onToggleSelectAll: (ids: string[]) => void;
     onClearSelection: () => void;
     onDeleteSelected: () => void;
+    onBulkDownloadError: (error: Error) => void;
 }
 
 const ArchiveView: React.FC<ArchiveViewProps> = ({
@@ -28,6 +28,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
     onToggleSelectAll,
     onClearSelection,
     onDeleteSelected,
+    onBulkDownloadError,
 }) => {
     const [search, setSearch] = useLocalStorage('archive_search', '');
     const [isZipping, setIsZipping] = React.useState(false);
@@ -37,25 +38,9 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
 
         setIsZipping(true);
         try {
-            const zip = new JSZip();
-            const selectedImages = images.filter(img => selectedIds.has(img.id));
-
-            for (const img of selectedImages) {
-                // Fetch the image data
-                const response = await fetch(img.url);
-                const blob = await response.blob();
-
-                // Add to zip with a descriptive name
-                const filename = `aura-${img.id}.png`;
-                zip.file(filename, blob);
-            }
-
-            // Generate and download
-            const content = await zip.generateAsync({ type: 'blob' });
-            downloadBlob(content, `aura-collection-${new Date().getTime()}.zip`);
+            await downloadArchiveImagesAsZip(images.filter((image) => selectedIds.has(image.id)));
         } catch (error) {
-            console.error('Failed to create ZIP:', error);
-            // Could add a toast here if available in this view
+            onBulkDownloadError(error instanceof Error ? error : new Error('Failed to create ZIP archive'));
         } finally {
             setIsZipping(false);
         }

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ImageCard from '../components/ImageCard';
 import type { ArchiveImage } from '../db/types';
+import { downloadBlob } from '../download/download';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
 import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -51,15 +52,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({
 
             // Generate and download
             const content = await zip.generateAsync({ type: 'blob' });
-            const zipUrl = URL.createObjectURL(content);
-
-            const link = document.createElement('a');
-            link.href = zipUrl;
-            link.download = `aura-collection-${new Date().getTime()}.zip`;
-            link.click();
-
-            // Cleanup
-            setTimeout(() => URL.revokeObjectURL(zipUrl), 10000);
+            downloadBlob(content, `aura-collection-${new Date().getTime()}.zip`);
         } catch (error) {
             console.error('Failed to create ZIP:', error);
             // Could add a toast here if available in this view

--- a/src/views/ArchiveView.tsx
+++ b/src/views/ArchiveView.tsx
@@ -4,37 +4,32 @@ import type { ArchiveImage } from '../db/types';
 import { Image as ImageIcon, Search, Download, Trash2, X, Loader2 } from 'lucide-react';
 import JSZip from 'jszip';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import ConfirmModal from '../components/ConfirmModal';
 
 interface ArchiveViewProps {
     images: ArchiveImage[];
+    selectedIds: Set<string>;
     onDeleteImage: (id: string) => void;
     onEditImage: (image: ArchiveImage) => void;
-    onSelectImage: (image: ArchiveImage) => void;
+    onOpenImage: (image: ArchiveImage) => void;
+    onToggleSelection: (id: string) => void;
+    onToggleSelectAll: (ids: string[]) => void;
+    onClearSelection: () => void;
+    onDeleteSelected: () => void;
 }
 
-const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEditImage, onSelectImage }) => {
+const ArchiveView: React.FC<ArchiveViewProps> = ({
+    images,
+    selectedIds,
+    onDeleteImage,
+    onEditImage,
+    onOpenImage,
+    onToggleSelection,
+    onToggleSelectAll,
+    onClearSelection,
+    onDeleteSelected,
+}) => {
     const [search, setSearch] = useLocalStorage('archive_search', '');
-    const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
-    const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
     const [isZipping, setIsZipping] = React.useState(false);
-
-    const toggleSelect = (id: string) => {
-        setSelectedIds(prev => {
-            const next = new Set(prev);
-            if (next.has(id)) next.delete(id);
-            else next.add(id);
-            return next;
-        });
-    };
-
-    const selectAll = () => {
-        if (selectedIds.size === filteredImages.length) {
-            setSelectedIds(new Set());
-        } else {
-            setSelectedIds(new Set(filteredImages.map(img => img.id)));
-        }
-    };
 
     const handleBulkDownload = async () => {
         if (selectedIds.size === 0) return;
@@ -73,15 +68,11 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
         }
     };
 
-    const handleBulkDelete = () => {
-        selectedIds.forEach(id => onDeleteImage(id));
-        setSelectedIds(new Set());
-        setIsConfirmOpen(false);
-    };
-
     const filteredImages = images.filter(img =>
         img.prompt.toLowerCase().includes(search.toLowerCase())
     );
+    const filteredImageIds = filteredImages.map((image) => image.id);
+    const allFilteredSelected = filteredImageIds.length > 0 && filteredImageIds.every((id) => selectedIds.has(id));
 
     return (
         <div className="archive-container">
@@ -93,11 +84,11 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                     </div>
                     <div className="header-actions">
                         <button
-                            className={`aura-btn aura-btn--glass ${selectedIds.size === filteredImages.length && filteredImages.length > 0 ? 'aura-btn--primary' : ''}`}
-                            onClick={selectAll}
+                            className={`aura-btn aura-btn--glass ${allFilteredSelected ? 'aura-btn--primary' : ''}`}
+                            onClick={() => onToggleSelectAll(filteredImageIds)}
                             disabled={filteredImages.length === 0}
                         >
-                            {selectedIds.size === filteredImages.length && filteredImages.length > 0 ? 'Deselect All' : 'Select All'}
+                            {allFilteredSelected ? 'Deselect All' : 'Select All'}
                         </button>
                         <div className="search-box glass-panel" style={{ background: 'transparent', border: 'none', boxShadow: 'none' }}>
                             <Search size={18} className="search-icon" style={{ position: 'absolute', left: '1rem', pointerEvents: 'none' }} />
@@ -130,9 +121,9 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                             image={img}
                             onDelete={onDeleteImage}
                             onEdit={onEditImage}
-                            onClick={() => onSelectImage(img)}
+                            onClick={() => onOpenImage(img)}
                             selected={selectedIds.has(img.id)}
-                            onSelect={() => toggleSelect(img.id)}
+                            onSelect={() => onToggleSelection(img.id)}
                         />
                     ))}
                 </div>
@@ -145,7 +136,7 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                         <span>Images Selected</span>
                     </div>
                     <div className="bulk-actions">
-                        <button className="aura-btn aura-btn--glass" onClick={() => setSelectedIds(new Set())}>
+                        <button className="aura-btn aura-btn--glass" onClick={onClearSelection}>
                             <X size={18} /> Cancel
                         </button>
                         <button
@@ -156,22 +147,12 @@ const ArchiveView: React.FC<ArchiveViewProps> = ({ images, onDeleteImage, onEdit
                             {isZipping ? <Loader2 size={18} className="spin" /> : <Download size={18} />}
                             {isZipping ? 'Generating ZIP...' : 'Download as ZIP'}
                         </button>
-                        <button className="aura-btn aura-btn--danger" onClick={() => setIsConfirmOpen(true)}>
+                        <button className="aura-btn aura-btn--danger" onClick={onDeleteSelected}>
                             <Trash2 size={18} /> Delete All
                         </button>
                     </div>
                 </div>
             )}
-
-            <ConfirmModal
-                isOpen={isConfirmOpen}
-                title={`Delete ${selectedIds.size} Masterpieces?`}
-                message={`You are about to permanently remove ${selectedIds.size} images and their binary data. This action cannot be reversed.`}
-                confirmText="Delete All"
-                type="danger"
-                onConfirm={handleBulkDelete}
-                onCancel={() => setIsConfirmOpen(false)}
-            />
         </div>
     );
 };

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -31,13 +31,14 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         resetAdjustments,
         serializeReferences,
     } = useEditorSession(image);
-    const { canvasRef, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
+    const { canvasRef, isReady, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
     const {
         aiPrompt,
         setAiPrompt,
         aiLoading,
         aiError,
         isDragging,
+        isCanvasReady,
         save,
         applyAiEdit,
         handleDragOver,
@@ -45,6 +46,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         handleDrop,
     } = useEditorController({
         apiKey,
+        isCanvasReady: isReady,
         currentImageUrl,
         setCurrentImageUrl,
         referenceImages,
@@ -160,12 +162,12 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                                 onChange={(e) => setAiPrompt(e.target.value)}
                                 className="aura-input"
                                 style={{ minHeight: '100px', resize: 'vertical' }}
-                                disabled={aiLoading || !apiKey}
+                                disabled={aiLoading || !apiKey || !isCanvasReady}
                             />
                             <button
                                 className="aura-btn aura-btn--primary"
                                 onClick={() => { void applyAiEdit(); }}
-                                disabled={aiLoading || !aiPrompt.trim() || !apiKey}
+                                disabled={aiLoading || !aiPrompt.trim() || !apiKey || !isCanvasReady}
                                 style={{ width: '100%' }}
                             >
                                 {aiLoading ? <Loader2 className="spin" size={16} /> : <Sparkles size={16} />}
@@ -213,10 +215,10 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                     </div>
 
                     <div className="editor-actions">
-                        <button className="aura-btn aura-btn--primary" onClick={() => { void save(false); }}>
+                        <button className="aura-btn aura-btn--primary" onClick={() => { void save(false); }} disabled={!isCanvasReady}>
                             <Save size={18} /> Save Changes
                         </button>
-                        <button className="aura-btn aura-btn--glass" onClick={() => { void save(true); }}>
+                        <button className="aura-btn aura-btn--glass" onClick={() => { void save(true); }} disabled={!isCanvasReady}>
                             <Copy size={18} /> Save as Copy
                         </button>
                         <button className="aura-btn aura-btn--glass" onClick={resetAdjustments}>

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { Undo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { useEditorCanvas } from '../editor/useEditorCanvas';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { useEditorSession } from '../editor/useEditorSession';
 
@@ -11,8 +12,6 @@ interface EditorViewProps {
 }
 
 const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-
     const [aiPrompt, setAiPrompt] = useState('');
     const [aiLoading, setAiLoading] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
@@ -36,44 +35,10 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         resetAdjustments,
         serializeReferences,
     } = useEditorSession(image);
-
-    const applyFilters = useCallback(() => {
-        const canvas = canvasRef.current;
-        if (!canvas || !image || !currentImageUrl) return;
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        const img = new Image();
-        img.crossOrigin = "anonymous";
-        img.src = currentImageUrl;
-        img.onload = () => {
-            ctx.filter = canvasFilter;
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(img, 0, 0);
-        };
-    }, [canvasFilter, currentImageUrl, image]);
-
-    useEffect(() => {
-        if (!image) return;
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        const img = new Image();
-        img.crossOrigin = "anonymous";
-        img.src = currentImageUrl || '';
-        img.onload = () => {
-            canvas.width = img.width;
-            canvas.height = img.height;
-            applyFilters();
-        };
-    }, [applyFilters, currentImageUrl, image]);
+    const { canvasRef, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
 
     const handleExport = async (isCopy: boolean = false) => {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const dataUrl = canvas.toDataURL('image/png');
+        const dataUrl = exportDataUrl();
 
         const refDataUrls = await serializeReferences();
 
@@ -81,16 +46,13 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
     };
 
     const handleAiEdit = async () => {
-        if (!apiKey || !aiPrompt.trim() || !canvasRef.current || !currentImageUrl) return;
+        if (!apiKey || !aiPrompt.trim() || !currentImageUrl) return;
 
         setAiLoading(true);
         setAiError(null);
 
         try {
-            const canvas = canvasRef.current;
-            const blob = await new Promise<Blob>((resolve, reject) => {
-                canvas.toBlob((b: Blob | null) => b ? resolve(b) : reject(new Error('Canvas conversion failed')), 'image/png');
-            });
+            const blob = await exportBlob();
 
             const newUrl = await imageWorkflow.edit({
                 apiKey,

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Undo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { useEditorCanvas } from '../editor/useEditorCanvas';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useEditorController } from '../editor/useEditorController';
 import { useEditorSession } from '../editor/useEditorSession';
 
 interface EditorViewProps {
@@ -12,10 +12,6 @@ interface EditorViewProps {
 }
 
 const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
-    const [aiPrompt, setAiPrompt] = useState('');
-    const [aiLoading, setAiLoading] = useState(false);
-    const [aiError, setAiError] = useState<string | null>(null);
-    const [isDragging, setIsDragging] = useState(false);
     const {
         brightness,
         setBrightness,
@@ -36,60 +32,28 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         serializeReferences,
     } = useEditorSession(image);
     const { canvasRef, exportDataUrl, exportBlob } = useEditorCanvas(currentImageUrl, canvasFilter);
-
-    const handleExport = async (isCopy: boolean = false) => {
-        const dataUrl = exportDataUrl();
-
-        const refDataUrls = await serializeReferences();
-
-        onSave(dataUrl, isCopy, refDataUrls);
-    };
-
-    const handleAiEdit = async () => {
-        if (!apiKey || !aiPrompt.trim() || !currentImageUrl) return;
-
-        setAiLoading(true);
-        setAiError(null);
-
-        try {
-            const blob = await exportBlob();
-
-            const newUrl = await imageWorkflow.edit({
-                apiKey,
-                prompt: aiPrompt,
-                sourceImage: blob,
-                referenceImages,
-                quality: 'medium',
-            });
-
-            setCurrentImageUrl(newUrl);
-            setAiPrompt('');
-        } catch (err: unknown) {
-            setAiError(err instanceof Error ? err.message : 'AI Edit failed');
-        } finally {
-            setAiLoading(false);
-        }
-    };
-
-    const handleDragOver = (e: React.DragEvent) => {
-        e.preventDefault();
-        setIsDragging(true);
-    };
-
-    const handleDragLeave = (e: React.DragEvent) => {
-        e.preventDefault();
-        setIsDragging(false);
-    };
-
-    const handleDrop = (e: React.DragEvent) => {
-        e.preventDefault();
-        setIsDragging(false);
-
-        const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
-        if (files.length > 0) {
-            addReferenceFiles(files);
-        }
-    };
+    const {
+        aiPrompt,
+        setAiPrompt,
+        aiLoading,
+        aiError,
+        isDragging,
+        save,
+        applyAiEdit,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
+    } = useEditorController({
+        apiKey,
+        currentImageUrl,
+        setCurrentImageUrl,
+        referenceImages,
+        addReferenceFiles,
+        serializeReferences,
+        exportDataUrl,
+        exportBlob,
+        onSave,
+    });
 
     if (!image) {
         return (
@@ -200,7 +164,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                             />
                             <button
                                 className="aura-btn aura-btn--primary"
-                                onClick={handleAiEdit}
+                                onClick={() => { void applyAiEdit(); }}
                                 disabled={aiLoading || !aiPrompt.trim() || !apiKey}
                                 style={{ width: '100%' }}
                             >
@@ -249,10 +213,10 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                     </div>
 
                     <div className="editor-actions">
-                        <button className="aura-btn aura-btn--primary" onClick={() => handleExport(false)}>
+                        <button className="aura-btn aura-btn--primary" onClick={() => { void save(false); }}>
                             <Save size={18} /> Save Changes
                         </button>
-                        <button className="aura-btn aura-btn--glass" onClick={() => handleExport(true)}>
+                        <button className="aura-btn aura-btn--glass" onClick={() => { void save(true); }}>
                             <Copy size={18} /> Save as Copy
                         </button>
                         <button className="aura-btn aura-btn--glass" onClick={resetAdjustments}>

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Undo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy } from 'lucide-react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
 import type { ArchiveImage } from '../db/types';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useEditorSession } from '../editor/useEditorSession';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
@@ -13,61 +13,45 @@ interface EditorViewProps {
 const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
 
-    // Persist editor settings globally as requested
-    const [brightness, setBrightness] = useLocalStorage('editor_brightness', 100);
-    const [contrast, setContrast] = useLocalStorage('editor_contrast', 100);
-    const [saturation, setSaturation] = useLocalStorage('editor_saturation', 100);
-    const [filter, setFilter] = useLocalStorage('editor_filter', 'none');
-
     const [aiPrompt, setAiPrompt] = useState('');
     const [aiLoading, setAiLoading] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
-    const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(null);
-    const [refImages, setRefImages] = useState<File[]>([]);
-    const [refPreviews, setRefPreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
+    const {
+        brightness,
+        setBrightness,
+        contrast,
+        setContrast,
+        saturation,
+        setSaturation,
+        filter,
+        setFilter,
+        canvasFilter,
+        currentImageUrl,
+        setCurrentImageUrl,
+        referenceImages,
+        referencePreviews,
+        addReferenceFiles,
+        removeReferenceAt,
+        resetAdjustments,
+        serializeReferences,
+    } = useEditorSession(image);
 
     const applyFilters = useCallback(() => {
         const canvas = canvasRef.current;
-        if (!canvas || !image) return;
+        if (!canvas || !image || !currentImageUrl) return;
         const ctx = canvas.getContext('2d');
         if (!ctx) return;
 
         const img = new Image();
         img.crossOrigin = "anonymous";
-        img.src = currentImageUrl || '';
+        img.src = currentImageUrl;
         img.onload = () => {
-            ctx.filter = `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturation}%) ${filter !== 'none' ? filter : ''}`;
+            ctx.filter = canvasFilter;
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(img, 0, 0);
         };
-    }, [brightness, contrast, currentImageUrl, filter, image, saturation]);
-
-    useEffect(() => {
-        if (image) {
-            setCurrentImageUrl(image.url);
-
-            if (image.references && image.references.length > 0) {
-                const files = imageWorkflow.hydrateReferences(image.references);
-                setRefImages(files);
-                setRefPreviews(image.references);
-            }
-        }
-
-        if (!image) {
-            setRefImages([]);
-            setRefPreviews([]);
-        }
-    }, [image]);
-
-    useEffect(() => {
-        return () => {
-            // Cleanup previews - only revoke if they are object URLs
-            refPreviews.forEach((url: string) => {
-                if (url.startsWith('blob:')) URL.revokeObjectURL(url);
-            });
-        };
-    }, [refPreviews]);
+    }, [canvasFilter, currentImageUrl, image]);
 
     useEffect(() => {
         if (!image) return;
@@ -91,7 +75,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         if (!canvas) return;
         const dataUrl = canvas.toDataURL('image/png');
 
-        const refDataUrls = await imageWorkflow.serializeReferences(refImages);
+        const refDataUrls = await serializeReferences();
 
         onSave(dataUrl, isCopy, refDataUrls);
     };
@@ -112,7 +96,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                 apiKey,
                 prompt: aiPrompt,
                 sourceImage: blob,
-                referenceImages: refImages,
+                referenceImages,
                 quality: 'medium',
             });
 
@@ -141,9 +125,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
 
         const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
         if (files.length > 0) {
-            setRefImages(prev => [...prev, ...files]);
-            const newPreviews = files.map(file => URL.createObjectURL(file));
-            setRefPreviews(prev => [...prev, ...newPreviews]);
+            addReferenceFiles(files);
         }
     };
 
@@ -272,16 +254,12 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                             >
                                 <label>ADD VISUAL CONTEXT (OPTIONAL) {isDragging && '- DROP TO UPLOAD'}</label>
                                 <div className="reference-grid mini">
-                                    {refPreviews.map((url: string, idx: number) => (
+                                    {referencePreviews.map((url: string, idx: number) => (
                                         <div key={url} className="reference-preview mini glass-panel">
                                             <img src={url} alt="Reference" />
                                             <button
                                                 className="remove-ref"
-                                                onClick={() => {
-                                                    setRefImages((prev: File[]) => prev.filter((_, i) => i !== idx));
-                                                    setRefPreviews((prev: string[]) => prev.filter((_, i) => i !== idx));
-                                                    URL.revokeObjectURL(url);
-                                                }}
+                                                onClick={() => removeReferenceAt(idx)}
                                             >
                                                 <X size={12} />
                                             </button>
@@ -293,10 +271,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                                             multiple
                                             accept="image/*"
                                             onChange={(e) => {
-                                                const files = Array.from(e.target.files || []);
-                                                setRefImages((prev: File[]) => [...prev, ...files]);
-                                                const newPreviews = files.map(file => URL.createObjectURL(file));
-                                                setRefPreviews((prev: string[]) => [...prev, ...newPreviews]);
+                                                addReferenceFiles(Array.from(e.target.files || []));
                                             }}
                                             style={{ display: 'none' }}
                                         />
@@ -318,12 +293,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
                         <button className="aura-btn aura-btn--glass" onClick={() => handleExport(true)}>
                             <Copy size={18} /> Save as Copy
                         </button>
-                        <button className="aura-btn aura-btn--glass" onClick={() => {
-                            setBrightness(100);
-                            setContrast(100);
-                            setSaturation(100);
-                            setFilter('none');
-                        }}>
+                        <button className="aura-btn aura-btn--glass" onClick={resetAdjustments}>
                             <Undo2 size={18} /> Reset
                         </button>
                     </div>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
-import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useGenerateDraft } from '../generate-session/GenerateSession';
+import { useGenerateController } from '../generate-session/useGenerateController';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
@@ -11,8 +10,6 @@ interface GenerateViewProps {
     apiKey: string | null;
     onSaveImage: (image: ArchiveImage) => void;
 }
-
-const VALID_SIZES = ['1024x1024', '1536x1024', '1024x1536', 'auto'];
 
 const EXAMPLE_PROMPTS = [
     "a lobster piloting a vintage scooter",
@@ -62,9 +59,6 @@ const PALETTES = [
 
 const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [draft, setDraft] = useGenerateDraft();
-    const [currentResult, setCurrentResult] = useState<string | null>(null);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
@@ -73,12 +67,24 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const referencePreviews = referenceCollection.previews;
     const addReferenceFiles = referenceCollection.addFiles;
     const removeReferenceAt = referenceCollection.removeAt;
-    const replaceReferences = referenceCollection.replaceWithDataUrls;
-    const serializeReferences = referenceCollection.serialize;
-
-    const updateDraft = (patch: Partial<typeof draft>) => {
-        setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
-    };
+    const {
+        currentResult,
+        loading,
+        error,
+        updateDraft,
+        generate,
+        save,
+        download,
+        clear,
+    } = useGenerateController({
+        apiKey,
+        draft,
+        setDraft,
+        referenceImages,
+        replaceReferences: referenceCollection.replaceWithDataUrls,
+        serializeReferences: referenceCollection.serialize,
+        onSaveImage,
+    });
 
     const handleNextReference = () => {
         if (viewingReferenceIndex === null) return;
@@ -92,92 +98,6 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         setViewingReferenceIndex((prev) =>
             prev !== null && prev > 0 ? prev - 1 : prev
         );
-    };
-
-    useEffect(() => {
-        generateSessionStore.loadCurrentResult().then(val => {
-            if (val) setCurrentResult(val);
-        });
-
-        generateSessionStore.consumeTransferredReferences().then((refs) => {
-            if (refs.length > 0) {
-                replaceReferences(refs);
-            }
-        });
-
-    }, [replaceReferences]);
-
-    useEffect(() => {
-        if (!VALID_SIZES.includes(aspectRatio)) {
-            setDraft((currentDraft) => ({ ...currentDraft, aspectRatio: '1024x1024' }));
-        }
-    }, [aspectRatio, setDraft]);
-
-    const handleGenerate = async () => {
-        if (!apiKey) {
-            setError('Please set your OpenAI API Key in Settings first.');
-            return;
-        }
-        if (!prompt.trim()) return;
-
-        setLoading(true);
-        setError(null);
-        try {
-            const imageUrl = await imageWorkflow.generate({
-                apiKey,
-                prompt,
-                quality,
-                aspectRatio,
-                background,
-                style,
-                lighting,
-                palette,
-                referenceImages,
-            });
-
-            setCurrentResult(imageUrl);
-            updateDraft({ isSaved: false });
-            await generateSessionStore.saveCurrentResult(imageUrl);
-        } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : 'Failed to generate image');
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const handleDownload = () => {
-        if (!currentResult) return;
-        downloadGeneratedImage(currentResult);
-    };
-
-    const handleSave = () => {
-        if (!currentResult || isSaved) return;
-
-        const saveRefImages = async () => {
-            const refDataUrls = await serializeReferences();
-
-            const newImage: ArchiveImage = {
-                id: crypto.randomUUID(),
-                url: currentResult,
-                prompt,
-                model: 'gpt-image-1.5',
-                timestamp: new Date().toISOString(),
-                width: 1024,
-                height: 1024,
-                quality,
-                aspectRatio: aspectRatio,
-                background,
-                style,
-                lighting,
-                palette,
-                references: refDataUrls
-            };
-
-            onSaveImage(newImage);
-            updateDraft({ isSaved: true });
-        };
-
-        saveRefImages();
     };
 
     const handleDragOver = (e: React.DragEvent) => {
@@ -257,7 +177,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                         <div className="option-group">
                             <label>ASPECT RATIO</label>
                             <select
-                                value={VALID_SIZES.includes(aspectRatio) ? aspectRatio : '1024x1024'}
+                                value={aspectRatio}
                                 onChange={(e) => updateDraft({ aspectRatio: e.target.value })}
                                 className="select-input"
                             >
@@ -375,7 +295,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
                     <button
                         className="aura-btn aura-btn--primary"
-                        onClick={handleGenerate}
+                        onClick={() => { void generate(); }}
                         disabled={loading || !prompt.trim() || !apiKey}
                         style={{ width: '100%' }}
                     >
@@ -395,19 +315,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <img src={currentResult} alt="Generated result" className="result-image" />
                             <div className="result-actions">
                                 <button
-                                    onClick={handleSave}
+                                    onClick={() => { void save(); }}
                                     className={`aura-btn ${isSaved ? 'aura-btn--success' : 'aura-btn--primary'}`}
                                     disabled={isSaved}
                                 >
                                     <Archive size={18} /> {isSaved ? 'Saved to Archive' : 'Save to Archive'}
                                 </button>
-                                <button className="aura-btn aura-btn--glass" onClick={handleDownload}>
+                                <button className="aura-btn aura-btn--glass" onClick={download}>
                                     <Download size={18} /> Download
                                 </button>
-                                <button onClick={async () => {
-                                    setCurrentResult(null);
-                                    await generateSessionStore.clearCurrentResult();
-                                }} className="aura-btn aura-btn--danger">
+                                <button onClick={() => { void clear(); }} className="aura-btn aura-btn--danger">
                                     <Trash2 size={18} />
                                 </button>
                             </div>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
 interface GenerateViewProps {
@@ -63,16 +64,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [referenceImages, setReferenceImages] = useState<File[]>([]);
-    const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
-    const referencePreviewsRef = useRef(referencePreviews);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
-
-    useEffect(() => {
-        referencePreviewsRef.current = referencePreviews;
-    }, [referencePreviews]);
+    const referenceCollection = useReferenceImageCollection();
+    const referenceImages = referenceCollection.files;
+    const referencePreviews = referenceCollection.previews;
+    const addReferenceFiles = referenceCollection.addFiles;
+    const removeReferenceAt = referenceCollection.removeAt;
+    const replaceReferences = referenceCollection.replaceWithDataUrls;
+    const serializeReferences = referenceCollection.serialize;
 
     const updateDraft = (patch: Partial<typeof draft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -99,21 +100,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
         generateSessionStore.consumeTransferredReferences().then((refs) => {
             if (refs.length > 0) {
-                const files = imageWorkflow.hydrateReferences(refs);
-                setReferenceImages(files);
-                setReferencePreviews(refs);
+                replaceReferences(refs);
             }
         });
 
-    }, []);
-
-    useEffect(() => {
-        return () => {
-            referencePreviewsRef.current.forEach((url: string) => {
-                if (url.startsWith('blob:')) URL.revokeObjectURL(url);
-            });
-        };
-    }, []);
+    }, [replaceReferences]);
 
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {
@@ -165,7 +156,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         if (!currentResult || isSaved) return;
 
         const saveRefImages = async () => {
-            const refDataUrls = await imageWorkflow.serializeReferences(referenceImages);
+            const refDataUrls = await serializeReferences();
 
             const newImage: ArchiveImage = {
                 id: crypto.randomUUID(),
@@ -207,9 +198,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
         const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('image/'));
         if (files.length > 0) {
-            setReferenceImages(prev => [...prev, ...files]);
-            const newPreviews = files.map(file => URL.createObjectURL(file));
-            setReferencePreviews(prev => [...prev, ...newPreviews]);
+            addReferenceFiles(files);
         }
     };
 
@@ -362,9 +351,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                         className="remove-ref"
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            setReferenceImages((prev: File[]) => prev.filter((_, i) => i !== idx));
-                                            setReferencePreviews((prev: string[]) => prev.filter((_, i) => i !== idx));
-                                            URL.revokeObjectURL(url);
+                                            removeReferenceAt(idx);
                                             if (viewingReferenceIndex === idx) setViewingReferenceIndex(null);
                                         }}
                                     >
@@ -378,10 +365,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                     multiple
                                     accept="image/*"
                                     onChange={(e) => {
-                                        const files = Array.from(e.target.files || []);
-                                        setReferenceImages((prev: File[]) => [...prev, ...files]);
-                                        const newPreviews = files.map(file => URL.createObjectURL(file));
-                                        setReferencePreviews((prev: string[]) => [...prev, ...newPreviews]);
+                                        addReferenceFiles(Array.from(e.target.files || []));
                                     }}
                                     style={{ display: 'none' }}
                                 />

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
@@ -67,7 +67,12 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
+    const referencePreviewsRef = useRef(referencePreviews);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
+
+    useEffect(() => {
+        referencePreviewsRef.current = referencePreviews;
+    }, [referencePreviews]);
 
     const updateDraft = (patch: Partial<typeof draft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -104,15 +109,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
     useEffect(() => {
         return () => {
-            // Cleanup previews - only revoke if they are object URLs, not data URLs
-            // Actually, in this component we always use object URLs for new uploads, 
-            // but transferred refs might be data URLs.
-            // dataURL previews don't need revocation.
-            referencePreviews.forEach((url: string) => {
+            referencePreviewsRef.current.forEach((url: string) => {
                 if (url.startsWith('blob:')) URL.revokeObjectURL(url);
             });
         };
-    }, [referencePreviews]);
+    }, []);
 
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
-import { storage } from '../services/StorageService';
 import type { ArchiveImage } from '../db/types';
+import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 
@@ -60,21 +59,19 @@ const PALETTES = [
 ];
 
 const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
-    const [prompt, setPrompt] = useLocalStorage('aura_generate_prompt', '');
-    const [quality, setQuality] = useLocalStorage<'low' | 'medium' | 'high'>('aura_generate_quality', 'medium');
-    const [aspectRatio, setAspectRatio] = useLocalStorage('aura_generate_aspect_ratio', '1024x1024');
-    const [background, setBackground] = useLocalStorage<'opaque' | 'transparent' | 'auto'>('aura_generate_background', 'auto');
-    const [style, setStyle] = useLocalStorage('aura_generate_style', 'none');
-    const [lighting, setLighting] = useLocalStorage('aura_generate_lighting', 'none');
-    const [palette, setPalette] = useLocalStorage('aura_generate_palette', 'none');
+    const [draft, setDraft] = useGenerateDraft();
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [isSaved, setIsSaved] = useLocalStorage('aura_generate_is_saved', false);
     const [referenceImages, setReferenceImages] = useState<File[]>([]);
     const [referencePreviews, setReferencePreviews] = useState<string[]>([]);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
+    const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
+
+    const updateDraft = (patch: Partial<typeof draft>) => {
+        setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
+    };
 
     const handleNextReference = () => {
         if (viewingReferenceIndex === null) return;
@@ -91,22 +88,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     };
 
     useEffect(() => {
-        storage.load('generate_current_result').then(val => {
+        generateSessionStore.loadCurrentResult().then(val => {
             if (val) setCurrentResult(val);
         });
 
-        storage.load('generate_transferred_references').then(val => {
-            if (val) {
-                try {
-                    const refs = JSON.parse(val) as string[];
-                    const files = imageWorkflow.hydrateReferences(refs);
-                    setReferenceImages(files);
-                    setReferencePreviews(refs);
-                    // Clear it so it doesn't persist forever
-                    storage.remove('generate_transferred_references');
-                } catch (e) {
-                    console.error('Failed to load transferred references', e);
-                }
+        generateSessionStore.consumeTransferredReferences().then((refs) => {
+            if (refs.length > 0) {
+                const files = imageWorkflow.hydrateReferences(refs);
+                setReferenceImages(files);
+                setReferencePreviews(refs);
             }
         });
 
@@ -124,13 +114,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         };
     }, [referencePreviews]);
 
-    // Sanitize persistent state for GPT-Image-1.5 compatibility
     useEffect(() => {
         if (!VALID_SIZES.includes(aspectRatio)) {
-            console.warn(`Sanitizing invalid aspectRatio: ${aspectRatio}`);
-            setAspectRatio('1024x1024');
+            setDraft((currentDraft) => ({ ...currentDraft, aspectRatio: '1024x1024' }));
         }
-    }, [aspectRatio, setAspectRatio]);
+    }, [aspectRatio, setDraft]);
 
     const handleGenerate = async () => {
         if (!apiKey) {
@@ -155,8 +143,8 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
             });
 
             setCurrentResult(imageUrl);
-            setIsSaved(false);
-            await storage.save('generate_current_result', imageUrl);
+            updateDraft({ isSaved: false });
+            await generateSessionStore.saveCurrentResult(imageUrl);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to generate image');
         } finally {
@@ -196,7 +184,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
             };
 
             onSaveImage(newImage);
-            setIsSaved(true);
+            updateDraft({ isSaved: true });
         };
 
         saveRefImages();
@@ -241,7 +229,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <select
                                 value=""
                                 onChange={(e) => {
-                                    if (e.target.value) setPrompt(e.target.value);
+                                    if (e.target.value) updateDraft({ prompt: e.target.value });
                                 }}
                                 className="example-prompt-select"
                             >
@@ -254,7 +242,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                         <textarea
                             placeholder="Describe what you want to see... (e.g., 'A bioluminescent forest with crystal butterflies')"
                             value={prompt}
-                            onChange={(e) => setPrompt(e.target.value)}
+                            onChange={(e) => updateDraft({ prompt: e.target.value })}
                             className="prompt-input"
                         />
                     </div>
@@ -265,15 +253,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <div className="toggle-group">
                                 <button
                                     className={quality === 'low' ? 'active' : ''}
-                                    onClick={() => setQuality('low')}
+                                    onClick={() => updateDraft({ quality: 'low' })}
                                 >Low</button>
                                 <button
                                     className={quality === 'medium' ? 'active' : ''}
-                                    onClick={() => setQuality('medium')}
+                                    onClick={() => updateDraft({ quality: 'medium' })}
                                 >Medium</button>
                                 <button
                                     className={quality === 'high' ? 'active' : ''}
-                                    onClick={() => setQuality('high')}
+                                    onClick={() => updateDraft({ quality: 'high' })}
                                 >High</button>
                             </div>
                         </div>
@@ -282,7 +270,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>ASPECT RATIO</label>
                             <select
                                 value={VALID_SIZES.includes(aspectRatio) ? aspectRatio : '1024x1024'}
-                                onChange={(e) => setAspectRatio(e.target.value)}
+                                onChange={(e) => updateDraft({ aspectRatio: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="auto">Auto</option>
@@ -297,15 +285,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <div className="toggle-group">
                                 <button
                                     className={background === 'auto' ? 'active' : ''}
-                                    onClick={() => setBackground('auto')}
+                                    onClick={() => updateDraft({ background: 'auto' })}
                                 >Auto</button>
                                 <button
                                     className={background === 'opaque' ? 'active' : ''}
-                                    onClick={() => setBackground('opaque')}
+                                    onClick={() => updateDraft({ background: 'opaque' })}
                                 >Opaque</button>
                                 <button
                                     className={background === 'transparent' ? 'active' : ''}
-                                    onClick={() => setBackground('transparent')}
+                                    onClick={() => updateDraft({ background: 'transparent' })}
                                 >Transparent</button>
                             </div>
                         </div>
@@ -314,7 +302,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>STYLE</label>
                             <select
                                 value={style}
-                                onChange={(e) => setStyle(e.target.value)}
+                                onChange={(e) => updateDraft({ style: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -328,7 +316,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>LIGHTING</label>
                             <select
                                 value={lighting}
-                                onChange={(e) => setLighting(e.target.value)}
+                                onChange={(e) => updateDraft({ lighting: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -342,7 +330,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                             <label>PALETTE</label>
                             <select
                                 value={palette}
-                                onChange={(e) => setPalette(e.target.value)}
+                                onChange={(e) => updateDraft({ palette: e.target.value })}
                                 className="select-input"
                             >
                                 <option value="none">None</option>
@@ -435,7 +423,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                 </button>
                                 <button onClick={async () => {
                                     setCurrentResult(null);
-                                    await storage.remove('generate_current_result');
+                                    await generateSessionStore.clearCurrentResult();
                                 }} className="aura-btn aura-btn--danger">
                                     <Trash2 size={18} />
                                 </button>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
+import { downloadGeneratedImage } from '../download/download';
 import { generateSessionStore, useGenerateDraft } from '../generate-session/GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
@@ -146,10 +147,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
     const handleDownload = () => {
         if (!currentResult) return;
-        const link = document.createElement('a');
-        link.href = currentResult;
-        link.download = `aura-generation-${Date.now()}.png`;
-        link.click();
+        downloadGeneratedImage(currentResult);
     };
 
     const handleSave = () => {


### PR DESCRIPTION
## Summary
- merge the remaining refactor stack back into `main`, including generate/editor/archive/app controller extractions that were previously merged only into stacked branches
- include the follow-up hardening work for archive rollback/integrity, editor canvas readiness gating, per-image editor session state, app notifications/preferences splitting, and dedicated archive ZIP export
- make `main` contain the full refactor line so every `refactor/*` branch is ancestor-contained in `main`

## Testing
- npm run lint
- npm run build