### PR TITLE
Add creative lineage history and autopilot workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AURA AI
 
-AURA AI is a local-first browser studio for generating, organizing, and editing AI images with the OpenAI Images API.
+AURA AI is a local-first browser studio for generating, organizing, editing, and iterating on AI images with the OpenAI Images API.
 
 The app runs entirely in the browser. API keys, generated images, reference images, and archive metadata stay on the local device instead of passing through an application backend.
 
@@ -21,12 +21,15 @@ The app runs entirely in the browser. API keys, generated images, reference imag
 ## Highlights
 
 - Prompt-based image generation with `gpt-image-1.5`
+- Autopilot mode for goal-driven generate -> evaluate -> refine loops with GPT-4o
 - Prompt enhancement controls for style, lighting, palette, quality, aspect ratio, and background
 - Reference-image workflows for guided generation and AI-assisted edits
-- Local archive with search, image detail view, prompt copy, and keyboard navigation
-- Bulk archive actions including multi-select, ZIP export, and bulk delete
+- Creative lineage tracking across generate, create-similar, edit, overwrite, save-as-copy, and autopilot flows
+- Local archive with search, lineage-aware image detail view, replay/fork actions, prompt copy, and keyboard navigation
+- Bulk archive actions including multi-select, ZIP export with lineage manifests, and bulk delete
 - In-browser editor with brightness, contrast, saturation, filters, AI transforms, reset, overwrite, and save-as-copy flows
-- Persistent UI state for theme, prompts, generation options, and editor controls
+- ZIP import/export support for archive images plus lineage metadata
+- Persistent UI state for theme, prompts, generation options, autopilot settings, and editor controls
 - Local-first storage powered by SQLocal and IndexedDB
 
 ## Tech Stack
@@ -96,18 +99,25 @@ npm run preview
 
 The Generate view supports:
 
+- Mode toggle between `Single Shot` and `Autopilot`
 - Free-form text prompts
 - Example prompt presets
+- Goal-to-prompt translation for Autopilot mode
 - Quality options: `low`, `medium`, `high`
 - Aspect ratio options: `auto`, `1024x1024`, `1536x1024`, `1024x1536`
 - Background options: `auto`, `opaque`, `transparent`
 - Style presets
 - Lighting presets
 - Palette presets
+- Configurable Autopilot iteration count and satisfaction threshold
+- Cost disclosure before Autopilot runs
+- Live Autopilot iteration feedback, thumbnails, and cancel support
 - Multiple reference image uploads via file picker or drag-and-drop
 - Save-to-archive, download, and clear-result actions
 
 When reference images are attached, the app switches from the image generation endpoint to the image edit endpoint so the request can include uploaded image inputs.
+
+In Autopilot mode, the app uses the current generation settings for every iteration, evaluates results against the user's goal with GPT-4o, refines the prompt, and keeps the best-scoring result as the primary output.
 
 ### Archive
 
@@ -116,9 +126,14 @@ The Archive view supports:
 - Prompt-based search
 - Multi-select image management
 - Select-all and deselect-all actions
-- ZIP export for selected images
+- ZIP export for selected images plus lineage manifests
+- ZIP import/restore support for archive images and lineage metadata
 - Bulk deletion with confirmation
-- Image detail modal with prompt copy, metadata display, and reference preview
+- Image detail modal with prompt copy, metadata display, reference preview, and lineage timeline
+- Lineage replay into Generate and Editor
+- Lineage forking from any recorded step
+- Parent/descendant indicators and side-by-side lineage comparison
+- Autopilot lineage metadata including goal, iteration, score, and evaluator feedback
 - Previous and next navigation from the detail modal with keyboard arrow support
 - Create Similar to transfer prompt settings and references back into Generate
 
@@ -153,6 +168,8 @@ The application is designed as a local-first web app.
 - View state and generation/editor preferences are stored in browser `localStorage`
 - Generated images and reference image payloads are stored in IndexedDB via `idb-keyval`
 - Archive metadata is stored in a browser-local SQLite database via SQLocal
+- Lineage metadata is stored in a browser-local SQLite database via SQLocal
+- Exported archive bundles include `archive-manifest.json` and `lineage-manifest.json`
 
 There is no custom backend service in this repository.
 
@@ -162,7 +179,9 @@ The app calls the OpenAI Images API directly from the browser.
 
 - Prompt-only generations use `POST /v1/images/generations`
 - Reference-based generations and editor transforms use `POST /v1/images/edits`
+- Autopilot goal translation, evaluation, and prompt refinement use `POST /v1/responses`
 - The configured model is `gpt-image-1.5`
+- Autopilot language and vision reasoning uses `gpt-4o`
 - The app expects base64 image output and converts it to browser-safe data URLs for preview and persistence
 
 Additional implementation details live in:
@@ -183,9 +202,12 @@ If you fork this project, keep the same standard for your own commits and issues
 
 ```text
 src/
+  autopilot/       Autopilot orchestration and GPT-4o helpers
   components/      Reusable UI components
   db/              SQLocal adapter and archive types
+  generate-session Generate draft, save, replay, and autopilot session glue
   hooks/           Local state and archive hooks
+  lineage/         Lineage storage, replay, timeline, and export helpers
   services/        IndexedDB-backed storage service
   utils/           OpenAI and file helpers
   views/           Generate, Archive, Editor, and Settings views

--- a/docs/creative-lineage-autopilot-qa-plan.md
+++ b/docs/creative-lineage-autopilot-qa-plan.md
@@ -1,0 +1,128 @@
+# QA Plan: Creative Lineage + Agentic Creative Autopilot
+
+## Scope
+
+This checklist covers the shipped work from:
+
+- Creative Lineage Graph
+- Archive import/export with lineage manifests
+- Agentic Creative Autopilot
+
+## Preconditions
+
+- App loads locally with a valid OpenAI API key configured in `Settings`
+- Browser storage is available
+- At least one successful generation can be completed
+
+## 1. Single Shot Regression
+
+- Open `Generate` in `Single Shot` mode
+- Generate an image with a normal prompt
+- Save it to the archive
+- Confirm the preview, save, download, and clear actions still work
+- Open the saved image in archive detail
+- Confirm metadata still renders correctly and no Autopilot-only UI leaks into the normal flow
+- Use `Replay into Generate` from a normal generation step and confirm prompt/settings are restored
+
+## 2. Core Lineage Flows
+
+- From an archived image, use `Create Similar`
+- Generate and save the new result
+- Confirm the saved result has a lineage parent pointing back to the source branch
+- Open an archived image in `Editor`
+- Save one edit as `overwrite`
+- Save another edit as `save as copy`
+- Confirm archive detail shows:
+  - timeline entries in order
+  - parent indicator
+  - descendant badge
+  - replay actions
+  - fork action
+  - side-by-side comparison when selecting a prior step
+
+## 3. Replay and Fork Behavior
+
+- In archive detail, replay a generation step into `Generate`
+- Confirm prompt and generation settings are hydrated correctly
+- Replay an editor-compatible step into `Editor`
+- Confirm the correct image opens in the editor
+- Use `Fork from this step`
+- Save a subsequent generation or edit
+- Confirm the new lineage step uses the forked step as its parent
+
+## 4. ZIP Export and Import Round Trip
+
+- Select multiple related images in the archive
+- Export them as ZIP
+- Confirm the archive contains:
+  - image files
+  - `archive-manifest.json`
+  - `lineage-manifest.json`
+- Import or restore the exported ZIP
+- Confirm images are restored locally
+- Confirm lineage timeline and parent-child relationships are preserved
+- Confirm replay/fork still works on restored items
+
+## 5. Autopilot Happy Path
+
+- Switch `Generate` to `Autopilot`
+- Enter a goal in plain language
+- Use `Translate to Prompt`
+- Confirm the prompt field is populated and still editable
+- Set max iterations and satisfaction threshold
+- Start a run and confirm cost disclosure appears before execution
+- Confirm the live panel shows:
+  - iteration progress
+  - evaluator feedback
+  - intermediate thumbnails
+- Let the run complete successfully
+- Confirm the best-scoring result is shown as the primary output
+- Save the result to archive
+
+## 6. Autopilot Cancellation and Failure Handling
+
+- Start an Autopilot run
+- Click `Pause / Cancel` during the run
+- Confirm the run stops after the current iteration completes
+- Confirm the best result so far remains visible
+- Confirm completed intermediate iterations are still represented in lineage after save
+- If feasible, trigger an API failure during Autopilot
+- Confirm the UI shows a clear error and indicates which iteration failed
+- Confirm any completed iterations remain available as partial results
+
+## 7. Autopilot Lineage in Archive Detail
+
+- Open an archived image produced from Autopilot
+- Confirm the lineage timeline shows autopilot-specific metadata:
+  - goal text
+  - iteration number
+  - evaluator score
+  - evaluator feedback
+- Confirm steps from the same run are visually grouped or labelled consistently
+- Select an autopilot step and confirm comparison preview works
+
+## 8. Autopilot Replay
+
+- From archive detail, click `Replay into Generate` on an `autopilot-iteration` step
+- Confirm `Generate` opens with the iteration prompt and settings restored
+- Confirm the user can continue manually from that point
+- Save a new result and confirm it branches correctly from the replayed lineage step
+
+## 9. Persistence Checks
+
+- Refresh the app after using both Single Shot and Autopilot modes
+- Confirm persisted values survive refresh:
+  - selected generate mode
+  - goal text
+  - max iterations
+  - satisfaction threshold
+  - latest saved archive state
+  - lineage history
+
+## Exit Criteria
+
+- No regressions in normal Single Shot generation or editor save flows
+- Lineage timeline, replay, fork, and comparison work across normal and autopilot-generated assets
+- ZIP export/import preserves both archive images and lineage metadata
+- Autopilot runs, cancels, saves, and replays successfully
+- Archive detail correctly renders autopilot metadata without breaking non-autopilot history

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1425,6 +1426,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1781,6 +1800,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1844,6 +1978,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1906,6 +2050,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1937,6 +2091,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1952,6 +2123,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/coincident": {
@@ -2049,6 +2230,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2062,6 +2253,13 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -2302,6 +2500,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2310,6 +2518,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2712,6 +2930,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2720,6 +2945,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2862,6 +3097,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3097,6 +3349,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3149,6 +3408,20 @@
         }
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3171,6 +3444,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3183,6 +3476,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -3199,6 +3506,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3394,6 +3731,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3408,6 +3841,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
     "typecheck": "tsc -b",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
@@ -34,6 +35,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/plans/creative-lineage-and-autopilot.md
+++ b/plans/creative-lineage-and-autopilot.md
@@ -30,14 +30,14 @@ Graceful degradation is built in from the start: `getById` and `getChildren` ret
 
 ### Acceptance criteria
 
-- [ ] `lineage_steps` table is created on first storage init and persists across page refreshes
-- [ ] `LineageStore.save()` writes a step and returns it with a stable `id`
-- [ ] `LineageStore.getById()` returns `null` for unknown ids without throwing
-- [ ] `LineageStore.getByArchiveImageId()` returns all steps associated with an image, ordered by timestamp
-- [ ] `LineageStore.getChildren()` returns all steps whose `parentStepId` equals the given id
-- [ ] `LineageStore.remove()` deletes a step without affecting sibling or child steps
-- [ ] All operations tolerate a missing or empty table gracefully
-- [ ] Module-level tests cover save, read, children lookup, and missing-parent scenarios using injected storage dependencies
+- [x] `lineage_steps` table is created on first storage init and persists across page refreshes
+- [x] `LineageStore.save()` writes a step and returns it with a stable `id`
+- [x] `LineageStore.getById()` returns `null` for unknown ids without throwing
+- [x] `LineageStore.getByArchiveImageId()` returns all steps associated with an image, ordered by timestamp
+- [x] `LineageStore.getChildren()` returns all steps whose `parentStepId` equals the given id
+- [x] `LineageStore.remove()` deletes a step without affecting sibling or child steps
+- [x] All operations tolerate a missing or empty table gracefully
+- [x] Module-level tests cover save, read, children lookup, and missing-parent scenarios using injected storage dependencies
 
 ---
 
@@ -55,11 +55,11 @@ This phase adds no UI. Lineage steps are written silently in the background. The
 
 ### Acceptance criteria
 
-- [ ] Saving a generated image writes a `generation` lineage step linked to the new archive image id
-- [ ] A generation with reference images writes a `reference-generation` step that records reference ids in metadata
-- [ ] Saving a "Create Similar" result writes a step whose `parentStepId` points to the source image's prior step
-- [ ] A failed `archiveStore.save()` does not write a lineage step (provenance is not captured for failed saves)
-- [ ] Workflow-level tests assert that generate-and-save produces the correct step type, fields, and parent link
+- [x] Saving a generated image writes a `generation` lineage step linked to the new archive image id
+- [x] A generation with reference images writes a `reference-generation` step that records reference ids in metadata
+- [x] Saving a "Create Similar" result writes a step whose `parentStepId` points to the source image's prior step
+- [x] A failed `archiveStore.save()` does not write a lineage step (provenance is not captured for failed saves)
+- [x] Workflow-level tests assert that generate-and-save produces the correct step type, fields, and parent link
 
 ---
 
@@ -80,11 +80,11 @@ Each step records the editor adjustments that were applied where available (from
 
 ### Acceptance criteria
 
-- [ ] An AI edit saved as a new copy produces an `ai-edit` lineage step with the edit prompt and correct parent
-- [ ] A manual edit saved as a new copy produces a `save-as-copy` step branching from the source
-- [ ] An overwrite save produces a new lineage step pointing to the previous step for that image, leaving the archive image id unchanged
-- [ ] Each editor save path is covered by workflow-level tests asserting step type, parent link, and key metadata fields
-- [ ] A failed save does not write a lineage step
+- [x] An AI edit saved as a new copy produces an `ai-edit` lineage step with the edit prompt and correct parent
+- [x] A manual edit saved as a new copy produces a `save-as-copy` step branching from the source
+- [x] An overwrite save produces a new lineage step pointing to the previous step for that image, leaving the archive image id unchanged
+- [x] Each editor save path is covered by workflow-level tests asserting step type, parent link, and key metadata fields
+- [x] A failed save does not write a lineage step
 
 ---
 
@@ -106,13 +106,13 @@ Missing parents or broken references render as a muted "Origin unknown" entry ra
 
 ### Acceptance criteria
 
-- [ ] Archive detail modal shows a lineage panel for images that have lineage steps
-- [ ] Each step entry displays its type label, summary, and timestamp
-- [ ] A parent link indicator is shown when the image's earliest step has a `parentStepId`
-- [ ] A descendant count badge is shown when other steps reference this image's steps as parent
-- [ ] Missing or broken parent references render a graceful fallback, not an error
-- [ ] Images with no lineage steps show a neutral "No history recorded" state
-- [ ] The panel is readable and does not block or obscure the main image view
+- [x] Archive detail modal shows a lineage panel for images that have lineage steps
+- [x] Each step entry displays its type label, summary, and timestamp
+- [x] A parent link indicator is shown when the image's earliest step has a `parentStepId`
+- [x] A descendant count badge is shown when other steps reference this image's steps as parent
+- [x] Missing or broken parent references render a graceful fallback, not an error
+- [x] Images with no lineage steps show a neutral "No history recorded" state
+- [x] The panel is readable and does not block or obscure the main image view
 
 ---
 
@@ -132,12 +132,12 @@ Add a side-by-side comparison control to the detail modal: selecting any step in
 
 ### Acceptance criteria
 
-- [ ] "Replay into Generate" populates the Generate draft with the correct prompt, settings, and reference ids, then navigates to GenerateView
-- [ ] "Replay into Editor" loads the correct image into the Editor canvas and navigates to EditorView
-- [ ] "Fork from this step" marks the chosen step as the pending parent for the next save, and that parent link is written correctly when the user saves
-- [ ] Replay from a step with missing blobs shows a clear error message rather than loading a broken state
-- [ ] Comparison view shows the selected step's image alongside the current image
-- [ ] Workflow tests assert that replay correctly hydrates draft state and that fork correctly sets the parent link on the next save
+- [x] "Replay into Generate" populates the Generate draft with the correct prompt, settings, and reference ids, then navigates to GenerateView
+- [x] "Replay into Editor" loads the correct image into the Editor canvas and navigates to EditorView
+- [x] "Fork from this step" marks the chosen step as the pending parent for the next save, and that parent link is written correctly when the user saves
+- [x] Replay from a step with missing blobs shows a clear error message rather than loading a broken state
+- [x] Comparison view shows the selected step's image alongside the current image
+- [x] Workflow tests assert that replay correctly hydrates draft state and that fork correctly sets the parent link on the next save
 
 ---
 
@@ -153,11 +153,11 @@ Add an import/restore path that reads the manifest on ZIP import, validates that
 
 ### Acceptance criteria
 
-- [ ] Exported ZIP contains a `lineage-manifest.json` with `"version": 1` and a complete array of lineage steps for all exported images
-- [ ] Manifest includes all step fields: id, parentStepId, archiveImageId, stepType, timestamp, and metadata
-- [ ] A fresh import of an exported ZIP restores both images and their lineage steps, preserving all parent-child relationships
-- [ ] An import with broken parent references reports the broken links in a validation summary rather than failing silently
-- [ ] Export and import tests verify round-trip fidelity for generate, edit, overwrite, and save-as-copy step types
+- [x] Exported ZIP contains a `lineage-manifest.json` with `"version": 1` and a complete array of lineage steps for all exported images
+- [x] Manifest includes all step fields: id, parentStepId, archiveImageId, stepType, timestamp, and metadata
+- [x] A fresh import of an exported ZIP restores both images and their lineage steps, preserving all parent-child relationships
+- [x] An import with broken parent references reports the broken links in a validation summary rather than failing silently
+- [x] Export and import tests verify round-trip fidelity for generate, edit, overwrite, and save-as-copy step types
 
 ---
 
@@ -177,12 +177,12 @@ Neither module has any UI dependency. Both accept an injected API client so they
 
 ### Acceptance criteria
 
-- [ ] `SatisfactionEvaluator` returns a `{ score, feedback }` object for a valid GPT-4o response
-- [ ] `SatisfactionEvaluator` returns a graceful low-score result (no throw) when the response is malformed or missing required fields
-- [ ] `PromptRefiner` returns a non-empty string prompt given a goal and feedback
-- [ ] `PromptRefiner` propagates API errors correctly to the caller
-- [ ] Both modules have versioned system prompt constants that are reviewable as source-controlled strings
-- [ ] Module-level tests cover happy path, malformed response, and API error scenarios using injected mock clients
+- [x] `SatisfactionEvaluator` returns a `{ score, feedback }` object for a valid GPT-4o response
+- [x] `SatisfactionEvaluator` returns a graceful low-score result (no throw) when the response is malformed or missing required fields
+- [x] `PromptRefiner` returns a non-empty string prompt given a goal and feedback
+- [x] `PromptRefiner` propagates API errors correctly to the caller
+- [x] Both modules have versioned system prompt constants that are reviewable as source-controlled strings
+- [x] Module-level tests cover happy path, malformed response, and API error scenarios using injected mock clients
 
 ---
 
@@ -213,14 +213,14 @@ Wire `AutopilotSession` into `useGenerateController` as a new `runAutopilot()` a
 
 ### Acceptance criteria
 
-- [ ] `AutopilotSession` runs the full generate → evaluate → refine loop for the configured number of iterations
-- [ ] Early stopping halts the loop as soon as the satisfaction threshold is met, without proceeding to the next iteration
-- [ ] The session returns the highest-scoring iteration result, not necessarily the final one
-- [ ] Each completed iteration writes an `autopilot-iteration` lineage step with the correct `parentStepId` chain, iteration number, score, and feedback
-- [ ] Cancellation stops the loop after the current iteration, preserves all completed lineage steps, and returns the best result to date
-- [ ] A generation or evaluation failure stops the run, retains all prior lineage steps, and surfaces the error via callback without throwing unhandled exceptions
-- [ ] `AutopilotSession` tests use injected mock generate/evaluate/refine implementations and assert on the callback sequence, termination condition, and returned result
-- [ ] `useGenerateController.runAutopilot()` delegates to `AutopilotSession`; the existing `generate()` action is unmodified
+- [x] `AutopilotSession` runs the full generate → evaluate → refine loop for the configured number of iterations
+- [x] Early stopping halts the loop as soon as the satisfaction threshold is met, without proceeding to the next iteration
+- [x] The session returns the highest-scoring iteration result, not necessarily the final one
+- [x] Each completed iteration writes an `autopilot-iteration` lineage step with the correct `parentStepId` chain, iteration number, score, and feedback
+- [x] Cancellation stops the loop after the current iteration, preserves all completed lineage steps, and returns the best result to date
+- [x] A generation or evaluation failure stops the run, retains all prior lineage steps, and surfaces the error via callback without throwing unhandled exceptions
+- [x] `AutopilotSession` tests use injected mock generate/evaluate/refine implementations and assert on the callback sequence, termination condition, and returned result
+- [x] `useGenerateController.runAutopilot()` delegates to `AutopilotSession`; the existing `generate()` action is unmodified
 
 ---
 
@@ -257,16 +257,16 @@ Add a mode toggle to `GenerateView` with two options: **Single Shot** (existing 
 
 ### Acceptance criteria
 
-- [ ] Mode toggle switches between Single Shot and Autopilot; selection persists across sessions
-- [ ] Autopilot mode shows goal field, auto-populated prompt field, and settings controls
-- [ ] Goal text persists between sessions
-- [ ] Cost disclosure panel is shown before each run and requires explicit confirmation
-- [ ] Live iteration panel updates with iteration number, feedback, and thumbnails as the run progresses
-- [ ] Cancel button stops the run after the current iteration and presents the best result to date
-- [ ] Post-run state presents the highest-scoring result with a clear label
-- [ ] Runs that hit the iteration limit without converging display an explicit notice
-- [ ] Generation or evaluation errors surface a clear per-iteration error message
-- [ ] The existing Single Shot generate flow is completely unaffected
+- [x] Mode toggle switches between Single Shot and Autopilot; selection persists across sessions
+- [x] Autopilot mode shows goal field, auto-populated prompt field, and settings controls
+- [x] Goal text persists between sessions
+- [x] Cost disclosure panel is shown before each run and requires explicit confirmation
+- [x] Live iteration panel updates with iteration number, feedback, and thumbnails as the run progresses
+- [x] Cancel button stops the run after the current iteration and presents the best result to date
+- [x] Post-run state presents the highest-scoring result with a clear label
+- [x] Runs that hit the iteration limit without converging display an explicit notice
+- [x] Generation or evaluation errors surface a clear per-iteration error message
+- [x] The existing Single Shot generate flow is completely unaffected
 
 ---
 
@@ -284,9 +284,9 @@ Extend the `lineage-manifest.json` export schema to include autopilot metadata f
 
 ### Acceptance criteria
 
-- [ ] Archive detail lineage timeline shows goal text, iteration number, score, and feedback for `autopilot-iteration` steps
-- [ ] Steps belonging to the same autopilot run are visually grouped or labelled consistently
-- [ ] "Replay into Generate" on an autopilot iteration step loads the correct prompt and settings into the Generate draft
-- [ ] Exported `lineage-manifest.json` includes autopilot metadata fields for all `autopilot-iteration` steps
-- [ ] Import of a manifest containing autopilot steps restores the full metadata without error
-- [ ] Existing non-autopilot lineage behaviour is unaffected
+- [x] Archive detail lineage timeline shows goal text, iteration number, score, and feedback for `autopilot-iteration` steps
+- [x] Steps belonging to the same autopilot run are visually grouped or labelled consistently
+- [x] "Replay into Generate" on an autopilot iteration step loads the correct prompt and settings into the Generate draft
+- [x] Exported `lineage-manifest.json` includes autopilot metadata fields for all `autopilot-iteration` steps
+- [x] Import of a manifest containing autopilot steps restores the full metadata without error
+- [x] Existing non-autopilot lineage behaviour is unaffected

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ function App() {
         archiveViewProps,
         editorViewProps,
         settingsViewProps,
+        replayGenerateFromLineageStep,
+        replayEditorFromLineageStep,
+        forkFromLineageStep,
     } = useAppController()
 
     const renderView = () => {
@@ -55,10 +58,22 @@ function App() {
             {archiveController.selectedImage && (
                 <ImageDetailModal
                     image={archiveController.selectedImage}
+                    images={archiveViewProps.images}
                     onClose={archiveController.closeImage}
                     onEdit={() => archiveController.selectedImage && archiveController.editImage(archiveController.selectedImage)}
                     onDelete={() => archiveController.selectedImage && archiveController.requestDelete([archiveController.selectedImage.id])}
                     onCreateSimilar={archiveController.createSimilar}
+                    onReplayGenerate={(stepId) => {
+                        archiveController.closeImage()
+                        void replayGenerateFromLineageStep(stepId)
+                    }}
+                    onReplayEditor={(stepId) => {
+                        archiveController.closeImage()
+                        void replayEditorFromLineageStep(stepId)
+                    }}
+                    onForkFromStep={(stepId) => {
+                        void forkFromLineageStep(stepId)
+                    }}
                     onNext={archiveController.showNextImage}
                     onPrevious={archiveController.showPreviousImage}
                 />

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -26,8 +26,9 @@ export function useAppController() {
     }, [notifyError]);
 
     const saveImage = useCallback(async (image: ArchiveImage) => {
-        await addImage(image);
+        const savedImage = await addImage(image);
         addToast('Image saved to archive', 'success');
+        return savedImage;
     }, [addImage, addToast]);
 
     const deleteImages = useCallback(async (ids: string[]) => {

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -88,14 +88,14 @@ export function useAppController() {
                 return;
             }
 
-            const image = images.find((entry) => entry.id === step.archiveImageId);
-            if (!image) {
-                notifyError(new Error('Selected step image is missing from the local archive'), 'Replay unavailable');
-                return;
-            }
-
+            const image = images.find((entry) => entry.id === step.archiveImageId) ?? null;
             const replay = buildGenerateReplay(image, step);
-            await generateSessionStore.transferFromArchive(image, replay.lineageSource, replay.draft);
+            if (image) {
+                await generateSessionStore.transferFromArchive(image, replay.lineageSource, replay.draft);
+            } else {
+                generateSessionStore.writeDraft(replay.draft);
+                generateSessionStore.saveLineageSource(replay.lineageSource);
+            }
             changeView('generate');
             addToast('Lineage step loaded into Generate', 'info');
         } catch (error) {

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useArchiveController } from '../archive/useArchiveController';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore } from '../generate-session/GenerateSession';
 import { useAppNotifications } from './useAppNotifications';
 import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';
+import { initializeAuraPersistence } from '../db/AuraPersistence';
 
 export function useAppController() {
     const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
@@ -16,6 +17,13 @@ export function useAppController() {
         onError: handleArchiveError,
     });
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
+
+    useEffect(() => {
+        initializeAuraPersistence().catch((error) => {
+            const nextError = error instanceof Error ? error : new Error('Failed to initialize local storage');
+            notifyError(nextError, 'Storage initialization failed');
+        });
+    }, [notifyError]);
 
     const saveImage = useCallback(async (image: ArchiveImage) => {
         await addImage(image);

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -8,6 +8,7 @@ import { useImageArchive } from '../hooks/useImageArchive';
 import { initializeAuraPersistence } from '../db/AuraPersistence';
 import { saveEditedImage, type EditorSaveContext } from '../editor/saveEditedImage';
 import { lineageStore } from '../lineage/LineageStore';
+import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
 
 export function useAppController() {
     const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
@@ -54,7 +55,10 @@ export function useAppController() {
         const savedImage = await saveEditedImage(editingImage, updatedUrl, context, {
             saveImage: async (image) => addImage(image),
             lineageStore,
+            parentStepId: generateSessionStore.loadLineageSource()?.stepId ?? null,
         });
+
+        generateSessionStore.clearLineageSource();
 
         if (savedImage.id !== editingImage.id) {
             addToast('Design saved as new copy', 'success');
@@ -76,6 +80,73 @@ export function useAppController() {
         }
     }, [addToast, changeView, notifyError]);
 
+    const replayGenerateFromLineageStep = useCallback(async (stepId: string) => {
+        try {
+            const step = await lineageStore.getById(stepId);
+            if (!step || !isGenerateReplayable(step)) {
+                notifyError(new Error('This step cannot be replayed into Generate'), 'Replay unavailable');
+                return;
+            }
+
+            const image = images.find((entry) => entry.id === step.archiveImageId);
+            if (!image) {
+                notifyError(new Error('Selected step image is missing from the local archive'), 'Replay unavailable');
+                return;
+            }
+
+            const replay = buildGenerateReplay(image, step);
+            await generateSessionStore.transferFromArchive(image, replay.lineageSource, replay.draft);
+            changeView('generate');
+            addToast('Lineage step loaded into Generate', 'info');
+        } catch (error) {
+            notifyError(error, 'Failed to replay lineage step');
+        }
+    }, [addToast, changeView, images, notifyError]);
+
+    const replayEditorFromLineageStep = useCallback(async (stepId: string) => {
+        try {
+            const step = await lineageStore.getById(stepId);
+            if (!step || !isEditorReplayable(step)) {
+                notifyError(new Error('This step cannot be replayed into Editor'), 'Replay unavailable');
+                return;
+            }
+
+            const image = images.find((entry) => entry.id === step.archiveImageId);
+            if (!image) {
+                notifyError(new Error('Selected step image is missing from the local archive'), 'Replay unavailable');
+                return;
+            }
+
+            generateSessionStore.saveLineageSource({
+                archiveImageId: step.archiveImageId,
+                stepId: step.id,
+            });
+            setEditingImage(image);
+            changeView('editor');
+            addToast('Lineage step loaded into Editor', 'info');
+        } catch (error) {
+            notifyError(error, 'Failed to replay lineage step');
+        }
+    }, [addToast, changeView, images, notifyError]);
+
+    const forkFromLineageStep = useCallback(async (stepId: string) => {
+        try {
+            const step = await lineageStore.getById(stepId);
+            if (!step) {
+                notifyError(new Error('Selected lineage step no longer exists'), 'Fork unavailable');
+                return;
+            }
+
+            generateSessionStore.saveLineageSource({
+                archiveImageId: step.archiveImageId,
+                stepId: step.id,
+            });
+            addToast('Next save will branch from this lineage step', 'info');
+        } catch (error) {
+            notifyError(error, 'Failed to fork from lineage step');
+        }
+    }, [addToast, notifyError]);
+
     const archiveController = useArchiveController({
         images,
         onDeleteImages: deleteImages,
@@ -94,6 +165,9 @@ export function useAppController() {
         updateApiKey,
         toggleTheme,
         removeToast,
+        replayGenerateFromLineageStep,
+        replayEditorFromLineageStep,
+        forkFromLineageStep,
         generateViewProps: {
             apiKey,
             onSaveImage: saveImage,

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -6,6 +6,8 @@ import { useAppNotifications } from './useAppNotifications';
 import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';
 import { initializeAuraPersistence } from '../db/AuraPersistence';
+import { saveEditedImage, type EditorSaveContext } from '../editor/saveEditedImage';
+import { lineageStore } from '../lineage/LineageStore';
 
 export function useAppController() {
     const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
@@ -44,26 +46,19 @@ export function useAppController() {
         changeView('editor');
     }, [changeView]);
 
-    const saveEditedImage = useCallback(async (updatedUrl: string, isCopy: boolean = false, references?: string[]) => {
+    const handleSaveEditedImage = useCallback(async (updatedUrl: string, context: EditorSaveContext) => {
         if (!editingImage) {
             return;
         }
 
-        if (isCopy) {
-            await addImage({
-                ...editingImage,
-                id: crypto.randomUUID(),
-                url: updatedUrl,
-                timestamp: new Date().toISOString(),
-                references: references || editingImage.references,
-            });
+        const savedImage = await saveEditedImage(editingImage, updatedUrl, context, {
+            saveImage: async (image) => addImage(image),
+            lineageStore,
+        });
+
+        if (savedImage.id !== editingImage.id) {
             addToast('Design saved as new copy', 'success');
         } else {
-            await addImage({
-                ...editingImage,
-                url: updatedUrl,
-                references: references || editingImage.references,
-            });
             addToast('Masterpiece updated', 'success');
         }
 
@@ -119,7 +114,7 @@ export function useAppController() {
             key: editingImage?.id ?? 'empty-editor',
             image: editingImage,
             apiKey,
-            onSave: saveEditedImage,
+            onSave: handleSaveEditedImage,
         },
         settingsViewProps: {
             apiKey,

--- a/src/archive/ArchiveExport.ts
+++ b/src/archive/ArchiveExport.ts
@@ -1,32 +1,16 @@
 import JSZip from 'jszip';
 import type { ArchiveImage } from '../db/types';
 import { downloadBlob } from '../download/download';
+import { lineageStore } from '../lineage/LineageStore';
+import { buildArchiveZip } from './ArchiveTransfer';
 
 export async function downloadArchiveImagesAsZip(images: ArchiveImage[]) {
-    const zip = new JSZip();
-
-    for (const image of images) {
-        zip.file(`aura-${image.id}.png`, await imageUrlToBlob(image.url));
-    }
-
-    const content = await zip.generateAsync({ type: 'blob' });
+    const bytes = await buildArchiveZip(images, {
+        lineageStore,
+        createZip: () => new JSZip(),
+    });
+    const normalizedBytes = new Uint8Array(bytes.byteLength);
+    normalizedBytes.set(bytes);
+    const content = new Blob([normalizedBytes], { type: 'application/zip' });
     downloadBlob(content, `aura-collection-${Date.now()}.zip`);
-}
-
-async function imageUrlToBlob(url: string) {
-    if (!url.startsWith('data:')) {
-        const response = await fetch(url);
-        return response.blob();
-    }
-
-    const [metadata, base64Data] = url.split(',', 2);
-    if (!metadata || !base64Data) {
-        throw new Error('Invalid image data URL');
-    }
-
-    const mimeType = metadata.match(/data:(.*?);base64/)?.[1] ?? 'image/png';
-    const binary = atob(base64Data);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-
-    return new Blob([bytes], { type: mimeType });
 }

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -1,6 +1,6 @@
 import type { ArchiveImage } from '../db/types';
-import { SQLiteArchiveMetadataPort } from './SQLiteArchiveMetadataPort';
 import { storage, type StorageProvider } from '../services/StorageService';
+import { archiveMetadataPort } from '../db/AuraPersistence';
 
 export type SaveArchiveImageInput = Omit<ArchiveImage, 'id' | 'timestamp'> & {
     id?: string;
@@ -239,7 +239,7 @@ const getTouchedReferenceIds = (left: number[], right: number[]) => {
 
 export function createArchiveStore(deps: CreateArchiveStoreDeps = {}): ArchiveStore {
     return new LocalArchiveStore(
-        deps.metadata ?? new SQLiteArchiveMetadataPort(),
+        deps.metadata ?? archiveMetadataPort,
         deps.blobs ?? new StorageArchiveBlobPort(storage),
         deps.clock ?? (() => new Date().toISOString()),
         deps.makeId ?? (() => crypto.randomUUID()),

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -1,0 +1,233 @@
+import JSZip from 'jszip';
+import { describe, expect, it } from 'vitest';
+import type { ArchiveStore } from './ArchiveStore';
+import type { ArchiveImage } from '../db/types';
+import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE } from './ArchiveTransfer';
+import { createLineageStore, type LineageMetadataPort, type LineageStep, type LineageStore } from '../lineage/LineageStore';
+
+class InMemoryLineageMetadataPort implements LineageMetadataPort {
+    private readonly steps = new Map<string, LineageStep>();
+
+    async init(): Promise<void> {
+        return undefined;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        this.steps.set(step.id, step);
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        return this.steps.get(id) ?? null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.archiveImageId === archiveImageId)
+            .sort(compareSteps);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.parentStepId === parentStepId)
+            .sort(compareSteps);
+    }
+
+    async remove(id: string): Promise<void> {
+        this.steps.delete(id);
+    }
+}
+
+class InMemoryArchiveStore implements Pick<ArchiveStore, 'save'> {
+    readonly images = new Map<string, ArchiveImage>();
+
+    async save(input: ArchiveImage): Promise<ArchiveImage> {
+        this.images.set(input.id, input);
+        return input;
+    }
+}
+
+describe('ArchiveTransfer', () => {
+    it('exports a lineage manifest with every exported image step', async () => {
+        const lineage = createStore();
+        const images = createImages();
+
+        await seedLineage(lineage);
+
+        const zipBytes = await buildArchiveZip(images, { lineageStore: lineage });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const manifestText = await zip.file(LINEAGE_MANIFEST_FILE)?.async('text');
+
+        expect(manifestText).toBeTruthy();
+        expect(JSON.parse(manifestText ?? 'null')).toEqual({
+            version: 1,
+            steps: [
+                expect.objectContaining({ id: 'step-1', stepType: 'generation' }),
+                expect.objectContaining({ id: 'step-2', stepType: 'overwrite' }),
+                expect.objectContaining({ id: 'step-3', stepType: 'ai-edit' }),
+                expect.objectContaining({ id: 'step-4', stepType: 'save-as-copy' }),
+            ],
+        });
+    });
+
+    it('round-trips archive images and lineage relationships through ZIP import', async () => {
+        const sourceLineage = createStore();
+        const sourceImages = createImages();
+        await seedLineage(sourceLineage);
+
+        const zipBytes = await buildArchiveZip(sourceImages, { lineageStore: sourceLineage });
+        const archiveStore = new InMemoryArchiveStore();
+        const importedLineage = createStore();
+
+        const summary = await importArchiveZip(zipBytes, {
+            archiveStore,
+            lineageStore: importedLineage,
+        });
+
+        expect(summary.brokenParentReferences).toEqual([]);
+        expect(summary.missingAssetFiles).toEqual([]);
+        expect(summary.importedImageIds).toEqual(['image-1', 'image-2', 'image-3']);
+        expect(summary.importedStepIds).toEqual(['step-1', 'step-2', 'step-3', 'step-4']);
+        expect(Array.from(archiveStore.images.keys())).toEqual(['image-1', 'image-2', 'image-3']);
+
+        await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-1', stepType: 'generation', parentStepId: null }),
+            expect.objectContaining({ id: 'step-2', stepType: 'overwrite', parentStepId: 'step-1' }),
+        ]);
+        await expect(importedLineage.getByArchiveImageId('image-2')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-3', stepType: 'ai-edit', parentStepId: 'step-2' }),
+        ]);
+        await expect(importedLineage.getByArchiveImageId('image-3')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-4', stepType: 'save-as-copy', parentStepId: 'step-2' }),
+        ]);
+    });
+
+    it('reports broken parent references during import instead of dropping them', async () => {
+        const zip = new JSZip();
+        zip.file('aura-image-1.png', Uint8Array.from([105, 109, 103]));
+        zip.file('archive-manifest.json', JSON.stringify({
+            version: 1,
+            images: [
+                {
+                    id: 'image-1',
+                    prompt: 'broken import',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-04-04T09:00:00.000Z',
+                    imageFileName: 'aura-image-1.png',
+                    references: [],
+                },
+            ],
+        }));
+        zip.file('lineage-manifest.json', JSON.stringify({
+            version: 1,
+            steps: [
+                {
+                    id: 'step-1',
+                    archiveImageId: 'image-1',
+                    parentStepId: 'missing-parent',
+                    stepType: 'save-as-copy',
+                    timestamp: '2026-04-04T09:00:00.000Z',
+                    metadata: {},
+                },
+            ],
+        }));
+
+        const summary = await importArchiveZip(await zip.generateAsync({ type: 'uint8array' }), {
+            archiveStore: new InMemoryArchiveStore(),
+            lineageStore: createStore(),
+        });
+
+        expect(summary.brokenParentReferences).toEqual([
+            { stepId: 'step-1', parentStepId: 'missing-parent' },
+        ]);
+        expect(summary.importedStepIds).toEqual(['step-1']);
+    });
+});
+
+function createStore(): LineageStore {
+    return createLineageStore({ metadata: new InMemoryLineageMetadataPort() });
+}
+
+function createImages(): ArchiveImage[] {
+    return [
+        {
+            id: 'image-1',
+            url: 'data:image/png;base64,aaaa',
+            prompt: 'glass city at dawn',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            model: 'gpt-image-1.5',
+            width: 1024,
+            height: 1024,
+            references: ['data:image/png;base64,ref1'],
+        },
+        {
+            id: 'image-2',
+            url: 'data:image/png;base64,bbbb',
+            prompt: 'glass city with neon reflections',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            model: 'gpt-image-1.5',
+            width: 1024,
+            height: 1024,
+            references: [],
+        },
+        {
+            id: 'image-3',
+            url: 'data:image/png;base64,cccc',
+            prompt: 'glass city alternate branch',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-04-04T11:00:00.000Z',
+            model: 'gpt-image-1.5',
+            width: 1024,
+            height: 1024,
+            references: [],
+        },
+    ];
+}
+
+async function seedLineage(lineage: LineageStore) {
+    await lineage.save({
+        id: 'step-1',
+        archiveImageId: 'image-1',
+        parentStepId: null,
+        stepType: 'generation',
+        timestamp: '2026-04-04T09:00:00.000Z',
+        metadata: { prompt: 'glass city at dawn' },
+    });
+    await lineage.save({
+        id: 'step-2',
+        archiveImageId: 'image-1',
+        parentStepId: 'step-1',
+        stepType: 'overwrite',
+        timestamp: '2026-04-04T09:30:00.000Z',
+        metadata: { editorAdjustments: { brightness: 110, contrast: 100, saturation: 100, filter: 'none' } },
+    });
+    await lineage.save({
+        id: 'step-3',
+        archiveImageId: 'image-2',
+        parentStepId: 'step-2',
+        stepType: 'ai-edit',
+        timestamp: '2026-04-04T10:00:00.000Z',
+        metadata: { editPrompt: 'add neon reflections' },
+    });
+    await lineage.save({
+        id: 'step-4',
+        archiveImageId: 'image-3',
+        parentStepId: 'step-2',
+        stepType: 'save-as-copy',
+        timestamp: '2026-04-04T11:00:00.000Z',
+        metadata: { editorAdjustments: { brightness: 100, contrast: 120, saturation: 100, filter: 'none' } },
+    });
+}
+
+function compareSteps(left: LineageStep, right: LineageStep) {
+    return left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id);
+}

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -1,0 +1,351 @@
+import JSZip from 'jszip';
+import type { ArchiveStore } from './ArchiveStore';
+import type { ArchiveImage } from '../db/types';
+import type { LineageStep } from '../lineage/types';
+import type { LineageStore } from '../lineage/LineageStore';
+
+export const ARCHIVE_MANIFEST_FILE = 'archive-manifest.json';
+export const LINEAGE_MANIFEST_FILE = 'lineage-manifest.json';
+export const ARCHIVE_MANIFEST_VERSION = 1;
+export const LINEAGE_MANIFEST_VERSION = 1;
+
+interface ArchiveManifestReference {
+    fileName: string;
+}
+
+interface ArchiveManifestImage {
+    id: string;
+    prompt: string;
+    quality: string;
+    aspectRatio: string;
+    background: string;
+    timestamp: string;
+    model?: string;
+    width?: number;
+    height?: number;
+    style?: string;
+    lighting?: string;
+    palette?: string;
+    imageFileName: string;
+    references: ArchiveManifestReference[];
+}
+
+interface ArchiveManifest {
+    version: number;
+    images: ArchiveManifestImage[];
+}
+
+interface LineageManifest {
+    version: number;
+    steps: LineageStep[];
+}
+
+interface BuildArchiveZipDeps {
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId'>;
+    createZip?: () => JSZip;
+}
+
+interface ImportArchiveZipDeps {
+    archiveStore: Pick<ArchiveStore, 'save'>;
+    lineageStore: Pick<LineageStore, 'save'>;
+    loadZip?: (input: Blob | Uint8Array | ArrayBuffer) => Promise<JSZip>;
+}
+
+export interface ArchiveImportSummary {
+    importedImageIds: string[];
+    importedStepIds: string[];
+    brokenParentReferences: Array<{ stepId: string; parentStepId: string }>;
+    missingAssetFiles: string[];
+}
+
+export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchiveZipDeps): Promise<Uint8Array> {
+    const zip = deps.createZip?.() ?? new JSZip();
+    const lineageCollections = await Promise.all(images.map((image) => deps.lineageStore.getByArchiveImageId(image.id)));
+    const archiveManifestImages: ArchiveManifestImage[] = [];
+
+    for (const image of images) {
+        const imageFileName = getImageFileName(image.id);
+        zip.file(imageFileName, await imageUrlToBytes(image.url));
+
+        const references = await Promise.all((image.references ?? []).map(async (reference, index) => {
+            const fileName = getReferenceFileName(image.id, index);
+            zip.file(fileName, await imageUrlToBytes(reference));
+            return { fileName };
+        }));
+
+        archiveManifestImages.push({
+            id: image.id,
+            prompt: image.prompt,
+            quality: image.quality,
+            aspectRatio: image.aspectRatio,
+            background: image.background,
+            timestamp: image.timestamp,
+            model: image.model,
+            width: image.width,
+            height: image.height,
+            style: image.style,
+            lighting: image.lighting,
+            palette: image.palette,
+            imageFileName,
+            references,
+        });
+    }
+
+    zip.file(ARCHIVE_MANIFEST_FILE, JSON.stringify({
+        version: ARCHIVE_MANIFEST_VERSION,
+        images: archiveManifestImages,
+    }, null, 2));
+
+    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify({
+        version: LINEAGE_MANIFEST_VERSION,
+        steps: dedupeLineageSteps(lineageCollections),
+    }, null, 2));
+
+    return zip.generateAsync({ type: 'uint8array' });
+}
+
+export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer, deps: ImportArchiveZipDeps): Promise<ArchiveImportSummary> {
+    const normalizedZipInput = zipInput instanceof Blob ? await zipInput.arrayBuffer() : zipInput;
+    const zip = await (deps.loadZip?.(normalizedZipInput) ?? JSZip.loadAsync(normalizedZipInput));
+    const archiveManifest = parseArchiveManifest(await readJsonFile(zip, ARCHIVE_MANIFEST_FILE));
+    const lineageManifest = parseLineageManifest(await readOptionalJsonFile(zip, LINEAGE_MANIFEST_FILE));
+    const missingAssetFiles: string[] = [];
+    const importedImageIds: string[] = [];
+
+    for (const image of archiveManifest.images) {
+        const imageFile = zip.file(image.imageFileName);
+        if (!imageFile) {
+            missingAssetFiles.push(image.imageFileName);
+            continue;
+        }
+
+        const imageUrl = await blobToDataUrl(await imageFile.async('blob'));
+        const references: string[] = [];
+
+        for (const reference of image.references) {
+            const referenceFile = zip.file(reference.fileName);
+            if (!referenceFile) {
+                missingAssetFiles.push(reference.fileName);
+                continue;
+            }
+
+            references.push(await blobToDataUrl(await referenceFile.async('blob')));
+        }
+
+        await deps.archiveStore.save({
+            id: image.id,
+            url: imageUrl,
+            prompt: image.prompt,
+            quality: image.quality,
+            aspectRatio: image.aspectRatio,
+            background: image.background,
+            timestamp: image.timestamp,
+            model: image.model,
+            width: image.width,
+            height: image.height,
+            style: image.style,
+            lighting: image.lighting,
+            palette: image.palette,
+            references,
+        });
+        importedImageIds.push(image.id);
+    }
+
+    const stepIds = new Set(lineageManifest.steps.map((step) => step.id));
+    const brokenParentReferences = lineageManifest.steps
+        .filter((step) => step.parentStepId && !stepIds.has(step.parentStepId))
+        .map((step) => ({ stepId: step.id, parentStepId: step.parentStepId! }));
+
+    const importedStepIds: string[] = [];
+    for (const step of lineageManifest.steps) {
+        await deps.lineageStore.save(step);
+        importedStepIds.push(step.id);
+    }
+
+    return {
+        importedImageIds,
+        importedStepIds,
+        brokenParentReferences,
+        missingAssetFiles,
+    };
+}
+
+function dedupeLineageSteps(stepCollections: LineageStep[][]) {
+    const stepsById = new Map<string, LineageStep>();
+
+    for (const collection of stepCollections) {
+        for (const step of collection) {
+            stepsById.set(step.id, step);
+        }
+    }
+
+    return Array.from(stepsById.values()).sort(compareLineageSteps);
+}
+
+function compareLineageSteps(left: LineageStep, right: LineageStep) {
+    return left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id);
+}
+
+async function readJsonFile(zip: JSZip, fileName: string): Promise<unknown> {
+    const file = zip.file(fileName);
+    if (!file) {
+        throw new Error(`Missing ${fileName} in archive ZIP`);
+    }
+
+    return JSON.parse(await file.async('text')) as unknown;
+}
+
+async function readOptionalJsonFile(zip: JSZip, fileName: string): Promise<unknown> {
+    const file = zip.file(fileName);
+    if (!file) {
+        return { version: LINEAGE_MANIFEST_VERSION, steps: [] };
+    }
+
+    return JSON.parse(await file.async('text')) as unknown;
+}
+
+function parseArchiveManifest(value: unknown): ArchiveManifest {
+    if (!isRecord(value) || !Array.isArray(value.images) || typeof value.version !== 'number') {
+        throw new Error('Invalid archive manifest');
+    }
+
+    return {
+        version: value.version,
+        images: value.images.map(parseArchiveManifestImage),
+    };
+}
+
+function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
+    if (!isRecord(value)) {
+        throw new Error('Invalid archive image manifest entry');
+    }
+
+    return {
+        id: requireString(value.id, 'archive image id'),
+        prompt: requireString(value.prompt, 'archive image prompt'),
+        quality: requireString(value.quality, 'archive image quality'),
+        aspectRatio: requireString(value.aspectRatio, 'archive image aspectRatio'),
+        background: requireString(value.background, 'archive image background'),
+        timestamp: requireString(value.timestamp, 'archive image timestamp'),
+        model: optionalString(value.model),
+        width: optionalNumber(value.width),
+        height: optionalNumber(value.height),
+        style: optionalString(value.style),
+        lighting: optionalString(value.lighting),
+        palette: optionalString(value.palette),
+        imageFileName: requireString(value.imageFileName, 'archive image fileName'),
+        references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
+    };
+}
+
+function parseArchiveManifestReference(value: unknown): ArchiveManifestReference {
+    if (!isRecord(value)) {
+        throw new Error('Invalid archive reference manifest entry');
+    }
+
+    return {
+        fileName: requireString(value.fileName, 'archive reference fileName'),
+    };
+}
+
+function parseLineageManifest(value: unknown): LineageManifest {
+    if (!isRecord(value) || !Array.isArray(value.steps) || typeof value.version !== 'number') {
+        throw new Error('Invalid lineage manifest');
+    }
+
+    return {
+        version: value.version,
+        steps: value.steps.map(parseLineageStep),
+    };
+}
+
+function parseLineageStep(value: unknown): LineageStep {
+    if (!isRecord(value)) {
+        throw new Error('Invalid lineage step entry');
+    }
+
+    const metadata = value.metadata;
+    if (!isRecord(metadata)) {
+        throw new Error('Invalid lineage metadata');
+    }
+
+    return {
+        id: requireString(value.id, 'lineage step id'),
+        archiveImageId: requireString(value.archiveImageId, 'lineage archiveImageId'),
+        parentStepId: value.parentStepId === null ? null : optionalString(value.parentStepId) ?? null,
+        stepType: requireLineageStepType(value.stepType),
+        timestamp: requireString(value.timestamp, 'lineage timestamp'),
+        metadata,
+    };
+}
+
+function requireLineageStepType(value: unknown): LineageStep['stepType'] {
+    if (
+        value === 'generation'
+        || value === 'reference-generation'
+        || value === 'ai-edit'
+        || value === 'manual-edit'
+        || value === 'overwrite'
+        || value === 'save-as-copy'
+        || value === 'autopilot-iteration'
+    ) {
+        return value;
+    }
+
+    throw new Error('Invalid lineage step type');
+}
+
+function requireString(value: unknown, label: string) {
+    if (typeof value !== 'string') {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return value;
+}
+
+function optionalString(value: unknown) {
+    return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNumber(value: unknown) {
+    return typeof value === 'number' ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function getImageFileName(id: string) {
+    return `aura-${id}.png`;
+}
+
+function getReferenceFileName(id: string, index: number) {
+    return `aura-${id}-reference-${index}.png`;
+}
+
+async function blobToDataUrl(blob: Blob) {
+    const mimeType = blob.type || 'image/png';
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    let binary = '';
+
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+
+    return `data:${mimeType};base64,${btoa(binary)}`;
+}
+
+async function imageUrlToBytes(url: string) {
+    if (!url.startsWith('data:')) {
+        const response = await fetch(url);
+        return new Uint8Array(await response.arrayBuffer());
+    }
+
+    const [metadata, base64Data] = url.split(',', 2);
+    if (!metadata || !base64Data) {
+        throw new Error('Invalid image data URL');
+    }
+
+    const binary = atob(base64Data);
+    return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAutopilotSession } from './AutopilotSession';
+import type { LineageMetadataPort, LineageStep } from '../lineage/LineageStore';
+import { createLineageStore, type LineageStore } from '../lineage/LineageStore';
+
+class InMemoryLineageMetadataPort implements LineageMetadataPort {
+    private readonly steps = new Map<string, LineageStep>();
+
+    async init(): Promise<void> {
+        return undefined;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        this.steps.set(step.id, step);
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        return this.steps.get(id) ?? null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values()).filter((step) => step.archiveImageId === archiveImageId);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values()).filter((step) => step.parentStepId === parentStepId);
+    }
+
+    async remove(id: string): Promise<void> {
+        this.steps.delete(id);
+    }
+}
+
+describe('AutopilotSession', () => {
+    it('runs the full generate evaluate refine loop and returns the highest score', async () => {
+        const lineage = createStore();
+        const callbacks = { onIterationComplete: vi.fn(), onError: vi.fn() };
+        const generate = vi.fn()
+            .mockResolvedValueOnce('data:image/png;base64,one')
+            .mockResolvedValueOnce('data:image/png;base64,two')
+            .mockResolvedValueOnce('data:image/png;base64,three');
+        const evaluate = vi.fn()
+            .mockResolvedValueOnce({ score: 40, feedback: ['Needs stronger lighting.'] })
+            .mockResolvedValueOnce({ score: 88, feedback: ['Closer, but improve composition.'] })
+            .mockResolvedValueOnce({ score: 72, feedback: ['Lost some atmosphere.'] });
+        const refine = vi.fn()
+            .mockResolvedValueOnce('prompt 2')
+            .mockResolvedValueOnce('prompt 3');
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 3,
+            satisfactionThreshold: 90,
+            generate,
+            evaluate,
+            refine,
+            lineageStore: lineage,
+            callbacks,
+            makeRunId: () => 'run-1',
+        }).run();
+
+        expect(result.status).toBe('max-iterations');
+        expect(result.bestIteration).toEqual(expect.objectContaining({ iterationNumber: 2, score: 88, prompt: 'prompt 2' }));
+        expect(generate).toHaveBeenCalledTimes(3);
+        expect(refine).toHaveBeenCalledTimes(2);
+        expect(callbacks.onIterationComplete).toHaveBeenCalledTimes(3);
+        await expect(lineage.getChildren('step-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-2', parentStepId: 'step-1' }),
+        ]);
+        await expect(lineage.getChildren('step-2')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-3', parentStepId: 'step-2' }),
+        ]);
+    });
+
+    it('stops early when the satisfaction threshold is met', async () => {
+        const lineage = createStore();
+        const generate = vi.fn().mockResolvedValueOnce('data:image/png;base64,one');
+        const evaluate = vi.fn().mockResolvedValueOnce({ score: 95, feedback: ['Strong match.'] });
+        const refine = vi.fn();
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 4,
+            satisfactionThreshold: 90,
+            generate,
+            evaluate,
+            refine,
+            lineageStore: lineage,
+        }).run();
+
+        expect(result.status).toBe('satisfied');
+        expect(result.iterations).toHaveLength(1);
+        expect(refine).not.toHaveBeenCalled();
+    });
+
+    it('cancels after the current iteration completes and preserves completed lineage', async () => {
+        const lineage = createStore();
+        let sessionRef: ReturnType<typeof createAutopilotSession> | null = null;
+        const session = createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 4,
+            satisfactionThreshold: 90,
+            generate: vi.fn().mockResolvedValueOnce('data:image/png;base64,one'),
+            evaluate: vi.fn().mockImplementationOnce(async () => {
+                sessionRef?.cancel();
+                return { score: 60, feedback: ['Keep refining.'] };
+            }),
+            refine: vi.fn(),
+            lineageStore: lineage,
+        });
+        sessionRef = session;
+
+        const result = await session.run();
+
+        expect(result.status).toBe('cancelled');
+        expect(result.iterations).toHaveLength(1);
+        await expect(lineage.getById('step-1')).resolves.toEqual(expect.objectContaining({ stepType: 'autopilot-iteration' }));
+    });
+
+    it('stops on generation failure, preserves prior steps, and reports the error via callback', async () => {
+        const lineage = createStore();
+        const callbacks = { onIterationComplete: vi.fn(), onError: vi.fn() };
+        const error = new Error('generation failed');
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 3,
+            satisfactionThreshold: 90,
+            generate: vi.fn()
+                .mockResolvedValueOnce('data:image/png;base64,one')
+                .mockRejectedValueOnce(error),
+            evaluate: vi.fn().mockResolvedValueOnce({ score: 55, feedback: ['Push the framing further.'] }),
+            refine: vi.fn().mockResolvedValueOnce('prompt 2'),
+            lineageStore: lineage,
+            callbacks,
+        }).run();
+
+        expect(result.status).toBe('failed');
+        expect(result.error).toBe(error);
+        expect(result.iterations).toHaveLength(1);
+        expect(callbacks.onError).toHaveBeenCalledWith(error, 2);
+        await expect(lineage.getById('step-1')).resolves.toEqual(expect.objectContaining({ stepType: 'autopilot-iteration' }));
+    });
+});
+
+function createStore(): LineageStore {
+    let nextId = 0;
+
+    return createLineageStore({
+        metadata: new InMemoryLineageMetadataPort(),
+        makeId: () => {
+            nextId += 1;
+            return `step-${nextId}`;
+        },
+    });
+}
+
+function createSettings() {
+    return {
+        quality: 'high' as const,
+        aspectRatio: '1024x1024',
+        background: 'transparent' as const,
+        style: 'risograph poster',
+        lighting: 'golden hour',
+        palette: 'copper + teal + cream',
+        referenceImages: [],
+    };
+}

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -1,0 +1,185 @@
+import { promptRefiner } from './PromptRefiner';
+import { satisfactionEvaluator } from './SatisfactionEvaluator';
+import type { LineageStore } from '../lineage/LineageStore';
+import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+
+export const DEFAULT_AUTOPILOT_MAX_ITERATIONS = 4;
+export const MAX_AUTOPILOT_ITERATIONS = 8;
+export const DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD = 90;
+
+export interface AutopilotIteration {
+    stepId: string;
+    archiveImageId: string;
+    iterationNumber: number;
+    prompt: string;
+    imageDataUrl: string;
+    score: number;
+    feedback: string[];
+}
+
+export interface AutopilotSessionResult {
+    status: 'satisfied' | 'max-iterations' | 'cancelled' | 'failed';
+    iterations: AutopilotIteration[];
+    bestIteration: AutopilotIteration | null;
+    error: Error | null;
+}
+
+interface ProgressCallbacks {
+    onIterationComplete?: (iteration: AutopilotIteration) => void;
+    onError?: (error: Error, iterationNumber: number) => void;
+}
+
+export interface AutopilotSession {
+    run(): Promise<AutopilotSessionResult>;
+    cancel(): void;
+}
+
+interface CreateAutopilotSessionInput {
+    goal: string;
+    initialPrompt: string;
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>;
+    apiKey: string;
+    initialParentStepId?: string | null;
+    maxIterations?: number;
+    satisfactionThreshold?: number;
+    generate?: (input: GenerateImageInput) => Promise<string>;
+    evaluate?: (input: { imageDataUrl: string; goal: string; apiKey: string }) => Promise<{ score: number; feedback: string[] }>;
+    refine?: (input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }) => Promise<string>;
+    lineageStore: Pick<LineageStore, 'save'>;
+    callbacks?: ProgressCallbacks;
+    makeRunId?: () => string;
+}
+
+class DefaultAutopilotSession implements AutopilotSession {
+    private readonly input: CreateAutopilotSessionInput;
+    private cancelled = false;
+
+    constructor(input: CreateAutopilotSessionInput) {
+        this.input = input;
+    }
+
+    cancel(): void {
+        this.cancelled = true;
+    }
+
+    async run(): Promise<AutopilotSessionResult> {
+        const generate = this.input.generate ?? ((input) => imageWorkflow.generate(input));
+        const evaluate = this.input.evaluate ?? ((input) => satisfactionEvaluator.evaluate(input));
+        const refine = this.input.refine ?? ((input) => promptRefiner.refine(input));
+        const maxIterations = Math.max(1, Math.min(MAX_AUTOPILOT_ITERATIONS, this.input.maxIterations ?? DEFAULT_AUTOPILOT_MAX_ITERATIONS));
+        const satisfactionThreshold = Math.max(0, Math.min(100, this.input.satisfactionThreshold ?? DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD));
+        const iterations: AutopilotIteration[] = [];
+        const runId = this.input.makeRunId?.() ?? crypto.randomUUID();
+        let currentPrompt = this.input.initialPrompt;
+        let parentStepId = this.input.initialParentStepId ?? null;
+
+        for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
+            try {
+                const imageDataUrl = await generate({
+                    ...this.input.settings,
+                    apiKey: this.input.apiKey,
+                    prompt: currentPrompt,
+                });
+
+                const evaluation = await evaluate({
+                    imageDataUrl,
+                    goal: this.input.goal,
+                    apiKey: this.input.apiKey,
+                });
+
+                const archiveImageId = `autopilot:${runId}:iteration:${iterationNumber}`;
+                const step = await this.input.lineageStore.save({
+                    archiveImageId,
+                    parentStepId,
+                    stepType: 'autopilot-iteration',
+                    timestamp: new Date().toISOString(),
+                    metadata: {
+                        goalText: this.input.goal,
+                        iterationNumber,
+                        evaluatorScore: evaluation.score,
+                        evaluatorFeedback: evaluation.feedback,
+                        prompt: currentPrompt,
+                        quality: this.input.settings.quality,
+                        aspectRatio: this.input.settings.aspectRatio,
+                        background: this.input.settings.background,
+                        style: this.input.settings.style,
+                        lighting: this.input.settings.lighting,
+                        palette: this.input.settings.palette,
+                        outputImageDataUrl: imageDataUrl,
+                    },
+                });
+
+                const completedIteration: AutopilotIteration = {
+                    stepId: step.id,
+                    archiveImageId,
+                    iterationNumber,
+                    prompt: currentPrompt,
+                    imageDataUrl,
+                    score: evaluation.score,
+                    feedback: evaluation.feedback,
+                };
+
+                iterations.push(completedIteration);
+                this.input.callbacks?.onIterationComplete?.(completedIteration);
+                parentStepId = step.id;
+
+                if (evaluation.score >= satisfactionThreshold) {
+                    return buildResult('satisfied', iterations, null);
+                }
+
+                if (this.cancelled) {
+                    return buildResult('cancelled', iterations, null);
+                }
+
+                if (iterationNumber === maxIterations) {
+                    return buildResult('max-iterations', iterations, null);
+                }
+
+                currentPrompt = await refine({
+                    goal: this.input.goal,
+                    currentPrompt,
+                    feedback: evaluation.feedback,
+                    apiKey: this.input.apiKey,
+                });
+            } catch (error) {
+                const normalizedError = error instanceof Error ? error : new Error('Autopilot run failed');
+                this.input.callbacks?.onError?.(normalizedError, iterationNumber);
+                return buildResult('failed', iterations, normalizedError);
+            }
+        }
+
+        return buildResult('max-iterations', iterations, null);
+    }
+}
+
+function buildResult(status: AutopilotSessionResult['status'], iterations: AutopilotIteration[], error: Error | null): AutopilotSessionResult {
+    return {
+        status,
+        iterations,
+        bestIteration: getBestIteration(iterations),
+        error,
+    };
+}
+
+function getBestIteration(iterations: AutopilotIteration[]) {
+    return iterations.reduce<AutopilotIteration | null>((best, iteration) => {
+        if (!best) {
+            return iteration;
+        }
+
+        if (iteration.score > best.score) {
+            return iteration;
+        }
+
+        if (iteration.score === best.score && iteration.iterationNumber < best.iterationNumber) {
+            return iteration;
+        }
+
+        return best;
+    }, null);
+}
+
+export function createAutopilotSession(input: CreateAutopilotSessionInput): AutopilotSession {
+    return new DefaultAutopilotSession(input);
+}

--- a/src/autopilot/GoalPromptTranslator.test.ts
+++ b/src/autopilot/GoalPromptTranslator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGoalPromptTranslator } from './GoalPromptTranslator';
+
+describe('GoalPromptTranslator', () => {
+    it('returns a prompt translated from the goal', async () => {
+        const translator = createGoalPromptTranslator({
+            createResponse: vi.fn(async () => ({
+                outputText: 'Cinematic portrait of a jazz singer in deep blue haze, gold rim light, smoky club interior',
+            })),
+        });
+
+        await expect(translator.translate({
+            apiKey: 'key',
+            goal: 'I want a moody jazz singer portrait in a smoky club with dramatic gold light',
+        })).resolves.toBe('Cinematic portrait of a jazz singer in deep blue haze, gold rim light, smoky club interior');
+    });
+
+    it('propagates API errors', async () => {
+        const translator = createGoalPromptTranslator({
+            createResponse: vi.fn(async () => {
+                throw new Error('translator failed');
+            }),
+        });
+
+        await expect(translator.translate({
+            apiKey: 'key',
+            goal: 'A brutalist hotel lobby at dawn',
+        })).rejects.toThrow('translator failed');
+    });
+});

--- a/src/autopilot/GoalPromptTranslator.ts
+++ b/src/autopilot/GoalPromptTranslator.ts
@@ -1,0 +1,35 @@
+import { openAiResponsesClient, type OpenAiResponsesClient } from '../utils/openai';
+
+export const GOAL_PROMPT_TRANSLATOR_PROMPT_VERSION = 'goal-prompt-translator.v1';
+
+export const GOAL_PROMPT_TRANSLATOR_SYSTEM_PROMPT = [
+    `Version: ${GOAL_PROMPT_TRANSLATOR_PROMPT_VERSION}`,
+    'You convert a creative goal into a single concise image generation prompt.',
+    'Return only the prompt text.',
+    'Keep it visually specific, concrete, and ready for direct image generation.',
+].join('\n');
+
+export interface GoalPromptTranslator {
+    translate(input: { goal: string; apiKey: string }): Promise<string>;
+}
+
+export function createGoalPromptTranslator(client: OpenAiResponsesClient = openAiResponsesClient): GoalPromptTranslator {
+    return {
+        async translate(input) {
+            const response = await client.createResponse({
+                apiKey: input.apiKey,
+                systemPrompt: GOAL_PROMPT_TRANSLATOR_SYSTEM_PROMPT,
+                userText: `Creative goal:\n${input.goal.trim()}`,
+            });
+
+            const prompt = response.outputText.trim();
+            if (!prompt) {
+                throw new Error('Goal prompt translator returned an empty prompt');
+            }
+
+            return prompt;
+        },
+    };
+}
+
+export const goalPromptTranslator = createGoalPromptTranslator();

--- a/src/autopilot/PromptRefiner.test.ts
+++ b/src/autopilot/PromptRefiner.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPromptRefiner } from './PromptRefiner';
+
+describe('PromptRefiner', () => {
+    it('returns a non-empty refined prompt', async () => {
+        const refiner = createPromptRefiner({
+            createResponse: vi.fn(async () => ({
+                outputText: 'Cinematic fashion portrait, strong rim lighting, tailored black coat, moody editorial studio backdrop',
+            })),
+        });
+
+        await expect(refiner.refine({
+            apiKey: 'test-key',
+            goal: 'A cinematic editorial portrait',
+            currentPrompt: 'portrait',
+            feedback: ['The lighting should be more dramatic.'],
+        })).resolves.toBe('Cinematic fashion portrait, strong rim lighting, tailored black coat, moody editorial studio backdrop');
+    });
+
+    it('propagates API errors to the caller', async () => {
+        const refiner = createPromptRefiner({
+            createResponse: vi.fn(async () => {
+                throw new Error('upstream unavailable');
+            }),
+        });
+
+        await expect(refiner.refine({
+            apiKey: 'test-key',
+            goal: 'An interior still life',
+            currentPrompt: 'still life',
+            feedback: ['The composition should feel more intentional.'],
+        })).rejects.toThrow('upstream unavailable');
+    });
+});

--- a/src/autopilot/PromptRefiner.ts
+++ b/src/autopilot/PromptRefiner.ts
@@ -1,0 +1,39 @@
+import { openAiResponsesClient, type OpenAiResponsesClient } from '../utils/openai';
+
+export const PROMPT_REFINER_PROMPT_VERSION = 'prompt-refiner.v1';
+
+export const PROMPT_REFINER_SYSTEM_PROMPT = [
+    `Version: ${PROMPT_REFINER_PROMPT_VERSION}`,
+    'You refine image generation prompts using critique feedback.',
+    'Return a single improved prompt and nothing else.',
+    'Keep the prompt concrete, visually specific, and ready for direct image generation.',
+].join('\n');
+
+export interface PromptRefiner {
+    refine(input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }): Promise<string>;
+}
+
+export function createPromptRefiner(client: OpenAiResponsesClient = openAiResponsesClient): PromptRefiner {
+    return {
+        async refine(input) {
+            const response = await client.createResponse({
+                apiKey: input.apiKey,
+                systemPrompt: PROMPT_REFINER_SYSTEM_PROMPT,
+                userText: [
+                    `Goal:\n${input.goal.trim()}`,
+                    `Current prompt:\n${input.currentPrompt.trim()}`,
+                    `Feedback:\n${input.feedback.map((entry) => `- ${entry}`).join('\n')}`,
+                ].join('\n\n'),
+            });
+
+            const prompt = response.outputText.trim();
+            if (!prompt) {
+                throw new Error('Prompt refiner returned an empty prompt');
+            }
+
+            return prompt;
+        },
+    };
+}
+
+export const promptRefiner = createPromptRefiner();

--- a/src/autopilot/SatisfactionEvaluator.test.ts
+++ b/src/autopilot/SatisfactionEvaluator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSatisfactionEvaluator } from './SatisfactionEvaluator';
+
+describe('SatisfactionEvaluator', () => {
+    it('returns score and feedback from a valid GPT response', async () => {
+        const evaluator = createSatisfactionEvaluator({
+            createResponse: vi.fn(async () => ({
+                outputText: JSON.stringify({
+                    score: 91,
+                    feedback: ['The lighting matches the goal well.', 'The subject needs a stronger silhouette.'],
+                }),
+            })),
+        });
+
+        await expect(evaluator.evaluate({
+            apiKey: 'test-key',
+            goal: 'A cinematic portrait with strong rim lighting',
+            imageDataUrl: 'data:image/png;base64,abc',
+        })).resolves.toEqual({
+            score: 91,
+            feedback: ['The lighting matches the goal well.', 'The subject needs a stronger silhouette.'],
+        });
+    });
+
+    it('returns a graceful low score when the response is malformed', async () => {
+        const evaluator = createSatisfactionEvaluator({
+            createResponse: vi.fn(async () => ({ outputText: '{"score":"high"}' })),
+        });
+
+        await expect(evaluator.evaluate({
+            apiKey: 'test-key',
+            goal: 'An editorial fashion photo',
+            imageDataUrl: 'data:image/png;base64,abc',
+        })).resolves.toEqual({
+            score: 0,
+            feedback: ['Unable to evaluate the image against the goal. Try another iteration.'],
+        });
+    });
+
+    it('propagates API errors from the client', async () => {
+        const evaluator = createSatisfactionEvaluator({
+            createResponse: vi.fn(async () => {
+                throw new Error('rate limited');
+            }),
+        });
+
+        await expect(evaluator.evaluate({
+            apiKey: 'test-key',
+            goal: 'A brutalist lobby with soft daylight',
+            imageDataUrl: 'data:image/png;base64,abc',
+        })).rejects.toThrow('rate limited');
+    });
+});

--- a/src/autopilot/SatisfactionEvaluator.ts
+++ b/src/autopilot/SatisfactionEvaluator.ts
@@ -1,0 +1,87 @@
+import { openAiResponsesClient, type OpenAiResponsesClient } from '../utils/openai';
+
+export const SATISFACTION_EVALUATOR_PROMPT_VERSION = 'satisfaction-evaluator.v1';
+
+export const SATISFACTION_EVALUATOR_SYSTEM_PROMPT = [
+    `Version: ${SATISFACTION_EVALUATOR_PROMPT_VERSION}`,
+    'You evaluate how well an image satisfies a creative goal.',
+    'Return strict JSON with this shape:',
+    '{"score": number, "feedback": string[]}',
+    'Rules:',
+    '- score must be an integer from 0 to 100',
+    '- feedback must contain 1 to 4 specific, visual, actionable sentences',
+    '- focus on observable mismatches between the image and the goal',
+    '- do not include markdown fences or commentary outside the JSON',
+].join('\n');
+
+const FALLBACK_EVALUATION = {
+    score: 0,
+    feedback: ['Unable to evaluate the image against the goal. Try another iteration.'],
+};
+
+export interface SatisfactionEvaluation {
+    score: number;
+    feedback: string[];
+}
+
+export interface SatisfactionEvaluator {
+    evaluate(input: { imageDataUrl: string; goal: string; apiKey: string }): Promise<SatisfactionEvaluation>;
+}
+
+export function createSatisfactionEvaluator(client: OpenAiResponsesClient = openAiResponsesClient): SatisfactionEvaluator {
+    return {
+        async evaluate(input) {
+            const response = await client.createResponse({
+                apiKey: input.apiKey,
+                systemPrompt: SATISFACTION_EVALUATOR_SYSTEM_PROMPT,
+                userText: `Goal:\n${input.goal.trim()}\n\nEvaluate how well the image satisfies this goal.`,
+                imageDataUrl: input.imageDataUrl,
+            });
+
+            return parseEvaluation(response.outputText);
+        },
+    };
+}
+
+function parseEvaluation(outputText: string): SatisfactionEvaluation {
+    try {
+        const parsed = JSON.parse(outputText) as unknown;
+        if (!parsed || typeof parsed !== 'object') {
+            return FALLBACK_EVALUATION;
+        }
+
+        const record = parsed as { score?: unknown; feedback?: unknown };
+        const score = clampScore(record.score);
+        const feedback = normalizeFeedback(record.feedback);
+
+        if (feedback.length === 0) {
+            return FALLBACK_EVALUATION;
+        }
+
+        return { score, feedback };
+    } catch {
+        return FALLBACK_EVALUATION;
+    }
+}
+
+function clampScore(value: unknown) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return 0;
+    }
+
+    return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function normalizeFeedback(value: unknown) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .slice(0, 4);
+}
+
+export const satisfactionEvaluator = createSatisfactionEvaluator();

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -5,6 +5,7 @@ import { downloadArchiveImage } from '../download/download';
 import { lineageStore } from '../lineage/LineageStore';
 import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLineageTimeline';
 import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -28,6 +29,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     const [timeline, setTimeline] = useState<LineageTimelineData | null>(null);
     const [timelineLoading, setTimelineLoading] = useState(true);
     const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+    const [lineageCollapsed, setLineageCollapsed] = useLocalStorage('archive_detail_lineage_collapsed', false);
 
     const dateStr = new Date(image.timestamp).toLocaleString();
 
@@ -59,7 +61,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
             .then((nextTimeline) => {
                 if (!cancelled) {
                     setTimeline(nextTimeline);
-                    setSelectedStepId(nextTimeline.entries[0]?.id ?? null);
+                    setSelectedStepId(nextTimeline.entries.at(-1)?.id ?? null);
                 }
             })
             .catch(() => {
@@ -84,9 +86,10 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     }, [image.id]);
 
     const selectedEntry = timeline?.entries.find((entry) => entry.id === selectedStepId) ?? null;
-    const comparisonImage = selectedEntry ? images.find((entryImage) => entryImage.id === selectedEntry.archiveImageId) ?? null : null;
-    const comparisonPreviewUrl = comparisonImage?.url ?? selectedEntry?.replayImageDataUrl ?? null;
-    const comparisonError = selectedEntry && !comparisonPreviewUrl
+    const selectedImage = selectedEntry ? images.find((entryImage) => entryImage.id === selectedEntry.archiveImageId) ?? null : null;
+    const displayedImageUrl = selectedImage?.url ?? selectedEntry?.replayImageDataUrl ?? image.url;
+    const displayedImageLabel = selectedEntry?.label ?? 'Current Image';
+    const comparisonError = selectedEntry && !selectedImage && !selectedEntry.replayImageDataUrl
         ? 'Selected step image is no longer available locally.'
         : null;
 
@@ -99,20 +102,8 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
                 <div className="modal-main">
                     <div className="modal-image-viewport">
-                        {selectedEntry && comparisonPreviewUrl && selectedEntry.archiveImageId !== image.id ? (
-                            <div className="comparison-view">
-                                <div className="comparison-pane">
-                                    <span className="comparison-label">Selected Step</span>
-                                    <img src={comparisonPreviewUrl} alt={selectedEntry.summary} className="modal-image comparison-image" />
-                                </div>
-                                <div className="comparison-pane">
-                                    <span className="comparison-label">Current Image</span>
-                                    <img src={image.url} alt={image.prompt} className="modal-image comparison-image" />
-                                </div>
-                            </div>
-                        ) : (
-                            <img src={image.url} alt={image.prompt} className="modal-image" />
-                        )}
+                        <span className="comparison-label single-image-label">{displayedImageLabel}</span>
+                        <img src={displayedImageUrl} alt={selectedEntry?.summary ?? image.prompt} className="modal-image" />
 
                         {comparisonError && <div className="comparison-error glass-panel">{comparisonError}</div>}
 
@@ -198,13 +189,27 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
                         <div className="sidebar-section">
                             <div className="lineage-header-row">
-                                <label className="section-label" style={{ marginBottom: 0 }}>LINEAGE</label>
-                                {timeline && timeline.descendantCount > 0 && (
-                                    <span className="status-badge lineage-badge">{timeline.descendantCount} version{timeline.descendantCount === 1 ? '' : 's'} from this image</span>
-                                )}
+                                <button
+                                    className="lineage-section-toggle"
+                                    onClick={() => setLineageCollapsed((current) => !current)}
+                                    type="button"
+                                >
+                                    <label className="section-label" style={{ marginBottom: 0, cursor: 'pointer' }}>LINEAGE</label>
+                                    <div className="lineage-header-actions">
+                                        {timeline && timeline.entries.length > 0 && (
+                                            <span className="status-badge lineage-badge">{timeline.entries.length} step{timeline.entries.length === 1 ? '' : 's'} in history</span>
+                                        )}
+                                        <ChevronRight size={16} className={lineageCollapsed ? '' : 'lineage-chevron-open'} />
+                                    </div>
+                                </button>
                             </div>
 
-                            {timelineLoading ? (
+                            {lineageCollapsed ? (
+                                <div className="lineage-empty glass-inset">
+                                    <History size={16} />
+                                    <span>History hidden</span>
+                                </div>
+                            ) : timelineLoading ? (
                                 <div className="lineage-empty glass-inset">Loading history...</div>
                             ) : timeline && timeline.entries.length > 0 ? (
                                 <div className="lineage-panel glass-inset">
@@ -215,12 +220,16 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                         </div>
                                     )}
 
-                                    <div className="lineage-list">
-                                        {timeline.entries.map((entry) => (
-                                            <article key={entry.id} className={`lineage-entry ${selectedStepId === entry.id ? 'selected' : ''}`}>
+                                        <div className="lineage-list">
+                                            {timeline.entries.map((entry) => (
+                                            <article
+                                                key={entry.id}
+                                                className={`lineage-entry ${selectedStepId === entry.id ? 'selected' : ''}`}
+                                                onClick={() => setSelectedStepId(entry.id)}
+                                            >
                                                 {entry.runLabel && <div className="lineage-run-label">{entry.runLabel}</div>}
                                                 <div className="lineage-entry-header">
-                                                    <button className="status-badge lineage-type lineage-select" onClick={() => setSelectedStepId(entry.id)}>{entry.label}</button>
+                                                    <button className="status-badge lineage-type lineage-select" type="button">{entry.label}</button>
                                                     <span className="lineage-time">{new Date(entry.timestamp).toLocaleString()}</span>
                                                 </div>
                                                 <p className="lineage-summary">{entry.summary}</p>
@@ -243,12 +252,21 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                                 )}
                                                 <div className="lineage-actions-row">
                                                     {isGenerateReplayable(entry) && (
-                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onReplayGenerate(entry.id)}>Replay into Generate</button>
+                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" type="button" onClick={(event) => {
+                                                            event.stopPropagation();
+                                                            onReplayGenerate(entry.id);
+                                                        }}>Replay into Generate</button>
                                                     )}
                                                     {isEditorReplayable(entry) && (
-                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onReplayEditor(entry.id)}>Replay into Editor</button>
+                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" type="button" onClick={(event) => {
+                                                            event.stopPropagation();
+                                                            onReplayEditor(entry.id);
+                                                        }}>Replay into Editor</button>
                                                     )}
-                                                    <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onForkFromStep(entry.id)}>Fork from this step</button>
+                                                    <button className="aura-btn aura-btn--glass lineage-action-btn" type="button" onClick={(event) => {
+                                                        event.stopPropagation();
+                                                        onForkFromStep(entry.id);
+                                                    }}>Fork from this step</button>
                                                 </div>
                                             </article>
                                         ))}

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -85,7 +85,8 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
     const selectedEntry = timeline?.entries.find((entry) => entry.id === selectedStepId) ?? null;
     const comparisonImage = selectedEntry ? images.find((entryImage) => entryImage.id === selectedEntry.archiveImageId) ?? null : null;
-    const comparisonError = selectedEntry && !comparisonImage
+    const comparisonPreviewUrl = comparisonImage?.url ?? selectedEntry?.replayImageDataUrl ?? null;
+    const comparisonError = selectedEntry && !comparisonPreviewUrl
         ? 'Selected step image is no longer available locally.'
         : null;
 
@@ -98,11 +99,11 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
                 <div className="modal-main">
                     <div className="modal-image-viewport">
-                        {selectedEntry && comparisonImage && comparisonImage.id !== image.id ? (
+                        {selectedEntry && comparisonPreviewUrl && selectedEntry.archiveImageId !== image.id ? (
                             <div className="comparison-view">
                                 <div className="comparison-pane">
                                     <span className="comparison-label">Selected Step</span>
-                                    <img src={comparisonImage.url} alt={selectedEntry.summary} className="modal-image comparison-image" />
+                                    <img src={comparisonPreviewUrl} alt={selectedEntry.summary} className="modal-image comparison-image" />
                                 </div>
                                 <div className="comparison-pane">
                                     <span className="comparison-label">Current Image</span>
@@ -217,11 +218,29 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                     <div className="lineage-list">
                                         {timeline.entries.map((entry) => (
                                             <article key={entry.id} className={`lineage-entry ${selectedStepId === entry.id ? 'selected' : ''}`}>
+                                                {entry.runLabel && <div className="lineage-run-label">{entry.runLabel}</div>}
                                                 <div className="lineage-entry-header">
                                                     <button className="status-badge lineage-type lineage-select" onClick={() => setSelectedStepId(entry.id)}>{entry.label}</button>
                                                     <span className="lineage-time">{new Date(entry.timestamp).toLocaleString()}</span>
                                                 </div>
                                                 <p className="lineage-summary">{entry.summary}</p>
+                                                {entry.goalText && (
+                                                    <div className="lineage-meta-block">
+                                                        <strong>Goal</strong>
+                                                        <p>{entry.goalText}</p>
+                                                    </div>
+                                                )}
+                                                {(entry.iterationNumber !== null || entry.evaluatorScore !== null || entry.evaluatorFeedback.length > 0) && (
+                                                    <div className="lineage-meta-block">
+                                                        <strong>Autopilot</strong>
+                                                        <p>
+                                                            {entry.iterationNumber !== null && `Iteration ${entry.iterationNumber}`}
+                                                            {entry.iterationNumber !== null && entry.evaluatorScore !== null && ' · '}
+                                                            {entry.evaluatorScore !== null && `Score ${entry.evaluatorScore}`}
+                                                        </p>
+                                                        {entry.evaluatorFeedback.length > 0 && <p>{entry.evaluatorFeedback.join(' ')}</p>}
+                                                    </div>
+                                                )}
                                                 <div className="lineage-actions-row">
                                                     {isGenerateReplayable(entry) && (
                                                         <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onReplayGenerate(entry.id)}>Replay into Generate</button>

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -4,24 +4,30 @@ import type { ArchiveImage } from '../db/types';
 import { downloadArchiveImage } from '../download/download';
 import { lineageStore } from '../lineage/LineageStore';
 import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLineageTimeline';
+import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
+    images: ArchiveImage[];
     onClose: () => void;
     onEdit: () => void;
     onDelete: () => void;
     onCreateSimilar: () => void;
+    onReplayGenerate: (stepId: string) => void;
+    onReplayEditor: (stepId: string) => void;
+    onForkFromStep: (stepId: string) => void;
     onNext: () => void;
     onPrevious: () => void;
 }
 
 const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
-    image, onClose, onEdit, onDelete, onCreateSimilar, onNext, onPrevious
+    image, images, onClose, onEdit, onDelete, onCreateSimilar, onReplayGenerate, onReplayEditor, onForkFromStep, onNext, onPrevious
 }) => {
     const [sidebarOpen, setSidebarOpen] = useState(true);
     const [copied, setCopied] = useState(false);
     const [timeline, setTimeline] = useState<LineageTimelineData | null>(null);
     const [timelineLoading, setTimelineLoading] = useState(true);
+    const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
 
     const dateStr = new Date(image.timestamp).toLocaleString();
 
@@ -53,6 +59,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
             .then((nextTimeline) => {
                 if (!cancelled) {
                     setTimeline(nextTimeline);
+                    setSelectedStepId(nextTimeline.entries[0]?.id ?? null);
                 }
             })
             .catch(() => {
@@ -62,6 +69,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                         parent: null,
                         descendantCount: 0,
                     });
+                    setSelectedStepId(null);
                 }
             })
             .finally(() => {
@@ -75,6 +83,12 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
         };
     }, [image.id]);
 
+    const selectedEntry = timeline?.entries.find((entry) => entry.id === selectedStepId) ?? null;
+    const comparisonImage = selectedEntry ? images.find((entryImage) => entryImage.id === selectedEntry.archiveImageId) ?? null : null;
+    const comparisonError = selectedEntry && !comparisonImage
+        ? 'Selected step image is no longer available locally.'
+        : null;
+
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className={`modal-content glass-panel ${sidebarOpen ? 'sidebar-open' : 'sidebar-closed'}`} onClick={(e) => e.stopPropagation()}>
@@ -84,7 +98,22 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
                 <div className="modal-main">
                     <div className="modal-image-viewport">
-                        <img src={image.url} alt={image.prompt} className="modal-image" />
+                        {selectedEntry && comparisonImage && comparisonImage.id !== image.id ? (
+                            <div className="comparison-view">
+                                <div className="comparison-pane">
+                                    <span className="comparison-label">Selected Step</span>
+                                    <img src={comparisonImage.url} alt={selectedEntry.summary} className="modal-image comparison-image" />
+                                </div>
+                                <div className="comparison-pane">
+                                    <span className="comparison-label">Current Image</span>
+                                    <img src={image.url} alt={image.prompt} className="modal-image comparison-image" />
+                                </div>
+                            </div>
+                        ) : (
+                            <img src={image.url} alt={image.prompt} className="modal-image" />
+                        )}
+
+                        {comparisonError && <div className="comparison-error glass-panel">{comparisonError}</div>}
 
                         <div className="floating-actions">
                             <button className="aura-btn aura-btn--primary" onClick={downloadImage}>
@@ -187,12 +216,21 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 
                                     <div className="lineage-list">
                                         {timeline.entries.map((entry) => (
-                                            <article key={entry.id} className="lineage-entry">
+                                            <article key={entry.id} className={`lineage-entry ${selectedStepId === entry.id ? 'selected' : ''}`}>
                                                 <div className="lineage-entry-header">
-                                                    <span className="status-badge lineage-type">{entry.label}</span>
+                                                    <button className="status-badge lineage-type lineage-select" onClick={() => setSelectedStepId(entry.id)}>{entry.label}</button>
                                                     <span className="lineage-time">{new Date(entry.timestamp).toLocaleString()}</span>
                                                 </div>
                                                 <p className="lineage-summary">{entry.summary}</p>
+                                                <div className="lineage-actions-row">
+                                                    {isGenerateReplayable(entry) && (
+                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onReplayGenerate(entry.id)}>Replay into Generate</button>
+                                                    )}
+                                                    {isEditorReplayable(entry) && (
+                                                        <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onReplayEditor(entry.id)}>Replay into Editor</button>
+                                                    )}
+                                                    <button className="aura-btn aura-btn--glass lineage-action-btn" onClick={() => onForkFromStep(entry.id)}>Fork from this step</button>
+                                                </div>
                                             </article>
                                         ))}
                                     </div>

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
-import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2 } from 'lucide-react';
+import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2, GitBranch, History } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { downloadArchiveImage } from '../download/download';
+import { lineageStore } from '../lineage/LineageStore';
+import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLineageTimeline';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -18,6 +20,8 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
 }) => {
     const [sidebarOpen, setSidebarOpen] = useState(true);
     const [copied, setCopied] = useState(false);
+    const [timeline, setTimeline] = useState<LineageTimelineData | null>(null);
+    const [timelineLoading, setTimelineLoading] = useState(true);
 
     const dateStr = new Date(image.timestamp).toLocaleString();
 
@@ -40,6 +44,36 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, [onNext, onPrevious, onClose]);
+
+    React.useEffect(() => {
+        let cancelled = false;
+
+        setTimelineLoading(true);
+        loadLineageTimeline(image.id, lineageStore)
+            .then((nextTimeline) => {
+                if (!cancelled) {
+                    setTimeline(nextTimeline);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setTimeline({
+                        entries: [],
+                        parent: null,
+                        descendantCount: 0,
+                    });
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setTimelineLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [image.id]);
 
     return (
         <div className="modal-overlay" onClick={onClose}>
@@ -131,6 +165,45 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                 </div>
                             </div>
                         )}
+
+                        <div className="sidebar-section">
+                            <div className="lineage-header-row">
+                                <label className="section-label" style={{ marginBottom: 0 }}>LINEAGE</label>
+                                {timeline && timeline.descendantCount > 0 && (
+                                    <span className="status-badge lineage-badge">{timeline.descendantCount} version{timeline.descendantCount === 1 ? '' : 's'} from this image</span>
+                                )}
+                            </div>
+
+                            {timelineLoading ? (
+                                <div className="lineage-empty glass-inset">Loading history...</div>
+                            ) : timeline && timeline.entries.length > 0 ? (
+                                <div className="lineage-panel glass-inset">
+                                    {timeline.parent && (
+                                        <div className={`lineage-origin ${timeline.parent.missing ? 'missing' : ''}`}>
+                                            <GitBranch size={14} />
+                                            <span>From: {timeline.parent.label}</span>
+                                        </div>
+                                    )}
+
+                                    <div className="lineage-list">
+                                        {timeline.entries.map((entry) => (
+                                            <article key={entry.id} className="lineage-entry">
+                                                <div className="lineage-entry-header">
+                                                    <span className="status-badge lineage-type">{entry.label}</span>
+                                                    <span className="lineage-time">{new Date(entry.timestamp).toLocaleString()}</span>
+                                                </div>
+                                                <p className="lineage-summary">{entry.summary}</p>
+                                            </article>
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="lineage-empty glass-inset">
+                                    <History size={16} />
+                                    <span>No history recorded</span>
+                                </div>
+                            )}
+                        </div>
 
                         <div className="sidebar-actions">
                             <button className="aura-btn aura-btn--primary" onClick={onCreateSimilar} style={{ width: '100%', padding: '1rem' }}>

--- a/src/db/AuraPersistence.ts
+++ b/src/db/AuraPersistence.ts
@@ -1,0 +1,18 @@
+import { SQLiteArchiveMetadataPort } from '../archive/SQLiteArchiveMetadataPort';
+import { SQLiteLineageMetadataPort } from '../lineage/SQLiteLineageMetadataPort';
+
+export const archiveMetadataPort = new SQLiteArchiveMetadataPort();
+export const lineageMetadataPort = new SQLiteLineageMetadataPort();
+
+let initializationPromise: Promise<void> | null = null;
+
+export function initializeAuraPersistence(): Promise<void> {
+    if (!initializationPromise) {
+        initializationPromise = Promise.all([
+            archiveMetadataPort.init(),
+            lineageMetadataPort.init(),
+        ]).then(() => undefined);
+    }
+
+    return initializationPromise;
+}

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ArchiveImage } from '../db/types';
+import { createLineageStore, type LineageMetadataPort, type LineageStep } from '../lineage/LineageStore';
+import { saveEditedImage, type EditorSaveContext } from './saveEditedImage';
+
+class InMemoryLineageMetadataPort implements LineageMetadataPort {
+    private readonly steps = new Map<string, LineageStep>();
+
+    async init(): Promise<void> {
+        return undefined;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        this.steps.set(step.id, step);
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        return this.steps.get(id) ?? null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.archiveImageId === archiveImageId)
+            .sort(compareSteps);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.parentStepId === parentStepId)
+            .sort(compareSteps);
+    }
+
+    async remove(id: string): Promise<void> {
+        this.steps.delete(id);
+    }
+}
+
+describe('saveEditedImage', () => {
+    it('writes an ai-edit step when an AI edit is saved as a copy', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        const savedImage = await saveEditedImage(createArchiveImage(), 'data:image/png;base64,edited-copy', {
+            ...createSaveContext(),
+            isCopy: true,
+            aiEditPrompt: 'add a moonlit skyline',
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            clock: () => '2026-04-04T12:00:00.000Z',
+            makeId: () => 'branch-image',
+        });
+
+        await expect(lineage.getByArchiveImageId(savedImage.id)).resolves.toEqual([
+            expect.objectContaining({
+                archiveImageId: 'branch-image',
+                parentStepId: 'step-2',
+                stepType: 'ai-edit',
+                timestamp: '2026-04-04T12:00:00.000Z',
+                metadata: expect.objectContaining({
+                    sourceArchiveImageId: 'source-image',
+                    outputArchiveImageId: 'branch-image',
+                    editPrompt: 'add a moonlit skyline',
+                    overwrite: false,
+                    editorAdjustments: expect.objectContaining({
+                        brightness: 110,
+                        contrast: 95,
+                        saturation: 125,
+                        filter: 'sepia(100%)',
+                    }),
+                }),
+            }),
+        ]);
+    });
+
+    it('writes a save-as-copy step branching from the source image', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        await saveEditedImage(createArchiveImage(), 'data:image/png;base64,manual-copy', {
+            ...createSaveContext(),
+            isCopy: true,
+            aiEditPrompt: null,
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            clock: () => '2026-04-04T12:30:00.000Z',
+            makeId: () => 'manual-branch',
+        });
+
+        await expect(lineage.getByArchiveImageId('manual-branch')).resolves.toEqual([
+            expect.objectContaining({
+                archiveImageId: 'manual-branch',
+                parentStepId: 'step-2',
+                stepType: 'save-as-copy',
+                metadata: expect.objectContaining({
+                    sourceArchiveImageId: 'source-image',
+                    outputArchiveImageId: 'manual-branch',
+                    overwrite: false,
+                    editPrompt: null,
+                }),
+            }),
+        ]);
+    });
+
+    it('writes an overwrite step pointing to the previous step for that image', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        await saveEditedImage(createArchiveImage(), 'data:image/png;base64,manual-overwrite', {
+            ...createSaveContext(),
+            isCopy: false,
+            aiEditPrompt: null,
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            clock: () => '2026-04-04T13:00:00.000Z',
+        });
+
+        await expect(lineage.getByArchiveImageId('source-image')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-1', stepType: 'generation' }),
+            expect.objectContaining({ id: 'step-2', stepType: 'ai-edit' }),
+            expect.objectContaining({
+                parentStepId: 'step-2',
+                stepType: 'overwrite',
+                timestamp: '2026-04-04T13:00:00.000Z',
+                metadata: expect.objectContaining({
+                    sourceArchiveImageId: 'source-image',
+                    outputArchiveImageId: 'source-image',
+                    overwrite: true,
+                    editPrompt: null,
+                }),
+            }),
+        ]);
+    });
+
+    it('marks AI overwrite saves as ai-edit lineage steps', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        await saveEditedImage(createArchiveImage(), 'data:image/png;base64,ai-overwrite', {
+            ...createSaveContext(),
+            isCopy: false,
+            aiEditPrompt: 'make the nebula denser',
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            clock: () => '2026-04-04T13:30:00.000Z',
+        });
+
+        const steps = await lineage.getByArchiveImageId('source-image');
+        expect(steps.at(-1)).toEqual(expect.objectContaining({
+            parentStepId: 'step-2',
+            stepType: 'ai-edit',
+            metadata: expect.objectContaining({
+                editPrompt: 'make the nebula denser',
+                overwrite: true,
+            }),
+        }));
+    });
+
+    it('does not write provenance when archive save fails', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+        const error = new Error('disk full');
+
+        await expect(saveEditedImage(createArchiveImage(), 'data:image/png;base64,failed', {
+            ...createSaveContext(),
+            isCopy: true,
+            aiEditPrompt: 'make it cinematic',
+        }, {
+            saveImage: vi.fn(async () => {
+                throw error;
+            }),
+            lineageStore: lineage,
+        })).rejects.toThrow(error);
+
+        const steps = await lineage.getByArchiveImageId('source-image');
+        expect(steps).toHaveLength(2);
+        await expect(lineage.getByArchiveImageId('failed-copy')).resolves.toEqual([]);
+    });
+});
+
+function createStore() {
+    let nextId = 0;
+
+    return createLineageStore({
+        metadata: new InMemoryLineageMetadataPort(),
+        makeId: () => {
+            nextId += 1;
+            return `step-${nextId}`;
+        },
+    });
+}
+
+async function seedSourceLineage(lineage: ReturnType<typeof createStore>) {
+    await lineage.save({
+        archiveImageId: 'source-image',
+        parentStepId: null,
+        stepType: 'generation',
+        timestamp: '2026-04-04T09:00:00.000Z',
+        metadata: { prompt: 'cosmic koi pond' },
+    });
+    await lineage.save({
+        archiveImageId: 'source-image',
+        parentStepId: 'step-1',
+        stepType: 'ai-edit',
+        timestamp: '2026-04-04T10:00:00.000Z',
+        metadata: { editPrompt: 'add aurora reflections' },
+    });
+}
+
+function createArchiveImage(overrides: Partial<ArchiveImage> = {}): ArchiveImage {
+    return {
+        id: 'source-image',
+        url: 'data:image/png;base64,source',
+        prompt: 'cosmic koi pond',
+        model: 'gpt-image-1.5',
+        timestamp: '2026-04-04T08:00:00.000Z',
+        width: 1024,
+        height: 1024,
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        style: 'dreamlike',
+        lighting: 'moonlit',
+        palette: 'indigo + gold',
+        references: ['data:image/png;base64,ref1'],
+        ...overrides,
+    };
+}
+
+function createSaveContext(overrides: Partial<EditorSaveContext> = {}): EditorSaveContext {
+    return {
+        isCopy: false,
+        references: ['data:image/png;base64,ref2'],
+        adjustments: {
+            brightness: 110,
+            contrast: 95,
+            saturation: 125,
+            filter: 'sepia(100%)',
+        },
+        aiEditPrompt: null,
+        ...overrides,
+    };
+}
+
+function compareSteps(left: LineageStep, right: LineageStep) {
+    return left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id);
+}

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -159,6 +159,27 @@ describe('saveEditedImage', () => {
         }));
     });
 
+    it('uses an explicit parent step id when forking from an older lineage step', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        await saveEditedImage(createArchiveImage(), 'data:image/png;base64,forked-overwrite', {
+            ...createSaveContext(),
+            isCopy: false,
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            parentStepId: 'step-1',
+            clock: () => '2026-04-04T14:00:00.000Z',
+        });
+
+        const steps = await lineage.getByArchiveImageId('source-image');
+        expect(steps.at(-1)).toEqual(expect.objectContaining({
+            parentStepId: 'step-1',
+            timestamp: '2026-04-04T14:00:00.000Z',
+        }));
+    });
+
     it('does not write provenance when archive save fails', async () => {
         const lineage = createStore();
         await seedSourceLineage(lineage);

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -18,6 +18,7 @@ export interface EditorSaveContext {
 export interface SaveEditedImageDeps {
     saveImage: (image: ArchiveImage) => Promise<ArchiveImage>;
     lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    parentStepId?: string | null;
     clock?: () => string;
     makeId?: () => string;
 }
@@ -30,7 +31,7 @@ export async function saveEditedImage(
 ): Promise<ArchiveImage> {
     const timestamp = deps.clock?.() ?? new Date().toISOString();
     const savedImage = await deps.saveImage(buildSavedImage(sourceImage, updatedUrl, context, timestamp, deps.makeId));
-    const parentStepId = await resolveParentStepId(sourceImage.id, deps.lineageStore);
+    const parentStepId = deps.parentStepId ?? await resolveParentStepId(sourceImage.id, deps.lineageStore);
 
     await deps.lineageStore.save({
         archiveImageId: savedImage.id,

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -1,0 +1,100 @@
+import type { ArchiveImage } from '../db/types';
+import type { LineageStore } from '../lineage/LineageStore';
+
+export interface EditorAdjustments {
+    brightness: number;
+    contrast: number;
+    saturation: number;
+    filter: string;
+}
+
+export interface EditorSaveContext {
+    isCopy: boolean;
+    references?: string[];
+    adjustments: EditorAdjustments;
+    aiEditPrompt?: string | null;
+}
+
+export interface SaveEditedImageDeps {
+    saveImage: (image: ArchiveImage) => Promise<ArchiveImage>;
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    clock?: () => string;
+    makeId?: () => string;
+}
+
+export async function saveEditedImage(
+    sourceImage: ArchiveImage,
+    updatedUrl: string,
+    context: EditorSaveContext,
+    deps: SaveEditedImageDeps,
+): Promise<ArchiveImage> {
+    const timestamp = deps.clock?.() ?? new Date().toISOString();
+    const savedImage = await deps.saveImage(buildSavedImage(sourceImage, updatedUrl, context, timestamp, deps.makeId));
+    const parentStepId = await resolveParentStepId(sourceImage.id, deps.lineageStore);
+
+    await deps.lineageStore.save({
+        archiveImageId: savedImage.id,
+        parentStepId,
+        stepType: resolveStepType(context),
+        timestamp,
+        metadata: buildMetadata(sourceImage, savedImage, context),
+    });
+
+    return savedImage;
+}
+
+function buildSavedImage(
+    sourceImage: ArchiveImage,
+    updatedUrl: string,
+    context: EditorSaveContext,
+    timestamp: string,
+    makeId?: () => string,
+): ArchiveImage {
+    if (context.isCopy) {
+        return {
+            ...sourceImage,
+            id: makeId?.() ?? crypto.randomUUID(),
+            url: updatedUrl,
+            timestamp,
+            references: context.references ?? sourceImage.references,
+        };
+    }
+
+    return {
+        ...sourceImage,
+        url: updatedUrl,
+        references: context.references ?? sourceImage.references,
+    };
+}
+
+async function resolveParentStepId(
+    archiveImageId: string,
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId'>,
+) {
+    const sourceSteps = await lineageStore.getByArchiveImageId(archiveImageId);
+    return sourceSteps.at(-1)?.id ?? null;
+}
+
+function resolveStepType(context: EditorSaveContext) {
+    if (context.aiEditPrompt?.trim()) {
+        return 'ai-edit' as const;
+    }
+
+    return context.isCopy ? 'save-as-copy' as const : 'overwrite' as const;
+}
+
+function buildMetadata(sourceImage: ArchiveImage, savedImage: ArchiveImage, context: EditorSaveContext) {
+    return {
+        sourceArchiveImageId: sourceImage.id,
+        outputArchiveImageId: savedImage.id,
+        overwrite: !context.isCopy,
+        editPrompt: context.aiEditPrompt?.trim() || null,
+        referenceCount: savedImage.references?.length ?? 0,
+        editorAdjustments: {
+            brightness: context.adjustments.brightness,
+            contrast: context.adjustments.contrast,
+            saturation: context.adjustments.saturation,
+            filter: context.adjustments.filter,
+        },
+    } satisfies Record<string, unknown>;
+}

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import type { EditorAdjustments, EditorSaveContext } from './saveEditedImage';
 
 interface UseEditorControllerOptions {
     apiKey: string | null;
@@ -11,7 +12,8 @@ interface UseEditorControllerOptions {
     serializeReferences: () => Promise<string[]>;
     exportDataUrl: () => string;
     exportBlob: () => Promise<Blob>;
-    onSave: (updatedUrl: string, isCopy?: boolean, references?: string[]) => void | Promise<void>;
+    adjustments: EditorAdjustments;
+    onSave: (updatedUrl: string, context: EditorSaveContext) => void | Promise<void>;
 }
 
 export function useEditorController({
@@ -24,12 +26,14 @@ export function useEditorController({
     serializeReferences,
     exportDataUrl,
     exportBlob,
+    adjustments,
     onSave,
 }: UseEditorControllerOptions) {
     const [aiPrompt, setAiPrompt] = useState('');
     const [aiLoading, setAiLoading] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
     const [isDragging, setIsDragging] = useState(false);
+    const [lastAiEditPrompt, setLastAiEditPrompt] = useState<string | null>(null);
 
     const save = useCallback(async (isCopy: boolean = false) => {
         if (!isCanvasReady) {
@@ -39,11 +43,16 @@ export function useEditorController({
         try {
             const dataUrl = exportDataUrl();
             const references = await serializeReferences();
-            await Promise.resolve(onSave(dataUrl, isCopy, references));
+            await Promise.resolve(onSave(dataUrl, {
+                isCopy,
+                references,
+                adjustments,
+                aiEditPrompt: lastAiEditPrompt,
+            }));
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [exportDataUrl, isCanvasReady, onSave, serializeReferences]);
+    }, [adjustments, exportDataUrl, isCanvasReady, lastAiEditPrompt, onSave, serializeReferences]);
 
     const applyAiEdit = useCallback(async () => {
         if (!apiKey || !aiPrompt.trim() || !currentImageUrl || !isCanvasReady) {
@@ -64,6 +73,7 @@ export function useEditorController({
             });
 
             setCurrentImageUrl(newUrl);
+            setLastAiEditPrompt(aiPrompt.trim());
             setAiPrompt('');
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'AI Edit failed');

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -41,6 +41,12 @@ export function useEditorSession(image: ArchiveImage | null) {
         setSaturation,
         filter,
         setFilter,
+        adjustments: {
+            brightness,
+            contrast,
+            saturation,
+            filter,
+        },
         canvasFilter,
         currentImageUrl,
         setCurrentImageUrl,

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -33,13 +33,15 @@ export interface GenerateDraft {
 
 export interface GenerateLineageSource {
     archiveImageId: string;
+    stepId?: string | null;
 }
 
 export interface GenerateSessionStore {
     readDraft(): GenerateDraft;
     writeDraft(draft: GenerateDraft): void;
-    transferFromArchive(image: ArchiveImage): Promise<void>;
+    transferFromArchive(image: ArchiveImage, lineageSource?: GenerateLineageSource | null, draftOverrides?: Partial<GenerateDraft>): Promise<void>;
     loadLineageSource(): GenerateLineageSource | null;
+    saveLineageSource(source: GenerateLineageSource): void;
     clearLineageSource(): void;
     loadCurrentResult(): Promise<string | null>;
     saveCurrentResult(result: string): Promise<void>;
@@ -96,7 +98,7 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         this.clearLegacyDraftKeys();
     }
 
-    async transferFromArchive(image: ArchiveImage): Promise<void> {
+    async transferFromArchive(image: ArchiveImage, lineageSource: GenerateLineageSource | null = { archiveImageId: image.id }, draftOverrides: Partial<GenerateDraft> = {}): Promise<void> {
         this.writeDraft({
             prompt: image.prompt,
             quality: coerceQuality(image.quality),
@@ -106,8 +108,13 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
             lighting: image.lighting || 'none',
             palette: image.palette || 'none',
             isSaved: false,
+            ...draftOverrides,
         });
-        this.localStorage.setItem(GENERATE_LINEAGE_SOURCE_KEY, JSON.stringify({ archiveImageId: image.id }));
+        if (lineageSource) {
+            this.saveLineageSource(lineageSource);
+        } else {
+            this.clearLineageSource();
+        }
 
         if (image.references && image.references.length > 0) {
             await this.blobStorage.save(GENERATE_TRANSFERRED_REFERENCES_KEY, JSON.stringify(image.references));
@@ -119,6 +126,10 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
 
     loadLineageSource(): GenerateLineageSource | null {
         return this.readJson<GenerateLineageSource>(GENERATE_LINEAGE_SOURCE_KEY);
+    }
+
+    saveLineageSource(source: GenerateLineageSource): void {
+        this.localStorage.setItem(GENERATE_LINEAGE_SOURCE_KEY, JSON.stringify(source));
     }
 
     clearLineageSource(): void {

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -6,6 +6,7 @@ import type { ImageBackground, ImageQuality } from '../utils/openai';
 const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
+const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 const VALID_ASPECT_RATIOS = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
 
 const LEGACY_KEYS = {
@@ -30,10 +31,16 @@ export interface GenerateDraft {
     isSaved: boolean;
 }
 
+export interface GenerateLineageSource {
+    archiveImageId: string;
+}
+
 export interface GenerateSessionStore {
     readDraft(): GenerateDraft;
     writeDraft(draft: GenerateDraft): void;
     transferFromArchive(image: ArchiveImage): Promise<void>;
+    loadLineageSource(): GenerateLineageSource | null;
+    clearLineageSource(): void;
     loadCurrentResult(): Promise<string | null>;
     saveCurrentResult(result: string): Promise<void>;
     clearCurrentResult(): Promise<void>;
@@ -100,6 +107,7 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
             palette: image.palette || 'none',
             isSaved: false,
         });
+        this.localStorage.setItem(GENERATE_LINEAGE_SOURCE_KEY, JSON.stringify({ archiveImageId: image.id }));
 
         if (image.references && image.references.length > 0) {
             await this.blobStorage.save(GENERATE_TRANSFERRED_REFERENCES_KEY, JSON.stringify(image.references));
@@ -107,6 +115,14 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         }
 
         await this.blobStorage.remove(GENERATE_TRANSFERRED_REFERENCES_KEY);
+    }
+
+    loadLineageSource(): GenerateLineageSource | null {
+        return this.readJson<GenerateLineageSource>(GENERATE_LINEAGE_SOURCE_KEY);
+    }
+
+    clearLineageSource(): void {
+        this.localStorage.removeItem(GENERATE_LINEAGE_SOURCE_KEY);
     }
 
     loadCurrentResult(): Promise<string | null> {

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runGenerateAutopilot } from './runGenerateAutopilot';
+
+describe('runGenerateAutopilot', () => {
+    it('delegates to AutopilotSession and persists the best result', async () => {
+        const run = vi.fn(async () => ({
+            status: 'satisfied' as const,
+            error: null,
+            iterations: [
+                {
+                    stepId: 'step-1',
+                    archiveImageId: 'autopilot:run:iteration:1',
+                    iterationNumber: 1,
+                    prompt: 'refined prompt',
+                    imageDataUrl: 'data:image/png;base64,best',
+                    score: 97,
+                    feedback: ['Great match.'],
+                },
+            ],
+            bestIteration: {
+                stepId: 'step-1',
+                archiveImageId: 'autopilot:run:iteration:1',
+                iterationNumber: 1,
+                prompt: 'refined prompt',
+                imageDataUrl: 'data:image/png;base64,best',
+                score: 97,
+                feedback: ['Great match.'],
+            },
+        }));
+        const cancel = vi.fn();
+        const createSession = vi.fn(() => ({ run, cancel }));
+        const saveCurrentResult = vi.fn(async () => undefined);
+        const saveLineageSource = vi.fn();
+        const onSessionCreated = vi.fn();
+
+        const outcome = await runGenerateAutopilot({
+            goal: 'A cinematic portrait',
+            apiKey: 'key',
+            draft: {
+                prompt: 'prompt 1',
+                quality: 'high',
+                aspectRatio: '1024x1024',
+                background: 'transparent',
+                style: 'risograph poster',
+                lighting: 'golden hour',
+                palette: 'copper + teal + cream',
+                isSaved: false,
+            },
+            referenceImages: [],
+            sessionStore: {
+                loadLineageSource: () => ({ archiveImageId: 'source-image', stepId: 'step-parent' }),
+                saveCurrentResult,
+                saveLineageSource,
+            },
+            lineageStore: {
+                save: vi.fn(),
+            },
+            createSession,
+            onSessionCreated,
+        });
+
+        expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            initialParentStepId: 'step-parent',
+        }));
+        expect(run).toHaveBeenCalledOnce();
+        expect(onSessionCreated).toHaveBeenCalledWith(expect.objectContaining({ run, cancel }));
+        expect(saveCurrentResult).toHaveBeenCalledWith('data:image/png;base64,best');
+        expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'autopilot:run:iteration:1', stepId: 'step-1' });
+        expect(outcome.session.cancel).toBe(cancel);
+    });
+});

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -1,0 +1,74 @@
+import { createAutopilotSession, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
+import type { GenerateDraft, GenerateSessionStore } from './GenerateSession';
+import type { LineageStore } from '../lineage/LineageStore';
+import type { ImageWorkflow } from '../image-workflow/ImageWorkflow';
+import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { promptRefiner } from '../autopilot/PromptRefiner';
+import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
+
+interface RunGenerateAutopilotInput {
+    goal: string;
+    apiKey: string;
+    draft: GenerateDraft;
+    referenceImages: File[];
+    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'saveCurrentResult' | 'saveLineageSource'>;
+    lineageStore: Pick<LineageStore, 'save'>;
+    createSession?: typeof createAutopilotSession;
+    workflow?: Pick<ImageWorkflow, 'generate'>;
+    evaluate?: typeof satisfactionEvaluator.evaluate;
+    refine?: typeof promptRefiner.refine;
+    maxIterations?: number;
+    satisfactionThreshold?: number;
+    onSessionCreated?: (session: ReturnType<typeof createAutopilotSession>) => void;
+    onIterationComplete?: (iteration: AutopilotSessionResult['iterations'][number]) => void;
+    onError?: (error: Error, iterationNumber: number) => void;
+}
+
+export interface RunGenerateAutopilotOutcome {
+    session: ReturnType<typeof createAutopilotSession>;
+    result: AutopilotSessionResult;
+}
+
+export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Promise<RunGenerateAutopilotOutcome> {
+    const createSession = input.createSession ?? createAutopilotSession;
+    const session = createSession({
+        goal: input.goal,
+        initialPrompt: input.draft.prompt,
+        settings: {
+            quality: input.draft.quality,
+            aspectRatio: input.draft.aspectRatio,
+            background: input.draft.background,
+            style: input.draft.style,
+            lighting: input.draft.lighting,
+            palette: input.draft.palette,
+            referenceImages: input.referenceImages,
+        },
+        apiKey: input.apiKey,
+        initialParentStepId: input.sessionStore.loadLineageSource()?.stepId ?? null,
+        maxIterations: input.maxIterations,
+        satisfactionThreshold: input.satisfactionThreshold,
+        generate: (request) => (input.workflow ?? imageWorkflow).generate(request),
+        evaluate: input.evaluate,
+        refine: input.refine,
+        lineageStore: input.lineageStore,
+        callbacks: {
+            onIterationComplete: input.onIterationComplete,
+            onError: input.onError,
+        },
+    });
+    input.onSessionCreated?.(session);
+    const result = await session.run();
+
+    if (result.bestIteration) {
+        await input.sessionStore.saveCurrentResult(result.bestIteration.imageDataUrl);
+        input.sessionStore.saveLineageSource({
+            archiveImageId: result.bestIteration.archiveImageId,
+            stepId: result.bestIteration.stepId,
+        });
+    }
+
+    return {
+        session,
+        result,
+    };
+}

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLineageStore, type LineageMetadataPort, type LineageStep } from '../lineage/LineageStore';
+import { saveGeneratedImage } from './saveGeneratedImage';
+import type { ArchiveImage } from '../db/types';
+import type { GenerateLineageSource } from './GenerateSession';
+
+class InMemoryLineageMetadataPort implements LineageMetadataPort {
+    private readonly steps = new Map<string, LineageStep>();
+
+    async init(): Promise<void> {
+        return undefined;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        this.steps.set(step.id, step);
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        return this.steps.get(id) ?? null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.archiveImageId === archiveImageId)
+            .sort(compareSteps);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        return Array.from(this.steps.values())
+            .filter((step) => step.parentStepId === parentStepId)
+            .sort(compareSteps);
+    }
+
+    async remove(id: string): Promise<void> {
+        this.steps.delete(id);
+    }
+}
+
+describe('saveGeneratedImage', () => {
+    it('writes a generation step after a successful archive save', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const image = createArchiveImage();
+
+        const savedImage = await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        const steps = await lineage.getByArchiveImageId(savedImage.id);
+
+        expect(steps).toEqual([
+            expect.objectContaining({
+                archiveImageId: savedImage.id,
+                parentStepId: null,
+                stepType: 'generation',
+                timestamp: savedImage.timestamp,
+                metadata: expect.objectContaining({
+                    prompt: savedImage.prompt,
+                    quality: savedImage.quality,
+                    aspectRatio: savedImage.aspectRatio,
+                    sourceArchiveImageId: null,
+                    referenceIds: [],
+                }),
+            }),
+        ]);
+        expect(sessionStore.clearLineageSource).toHaveBeenCalledOnce();
+    });
+
+    it('writes a reference-generation step with stable reference ids', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const image = createArchiveImage({
+            id: 'generated-2',
+            references: ['data:image/png;base64,aaa', 'data:image/png;base64,bbb'],
+        });
+
+        await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        await expect(lineage.getByArchiveImageId('generated-2')).resolves.toEqual([
+            expect.objectContaining({
+                stepType: 'reference-generation',
+                metadata: expect.objectContaining({
+                    referenceCount: 2,
+                    referenceIds: [
+                        'generated-2:reference:0',
+                        'generated-2:reference:1',
+                    ],
+                }),
+            }),
+        ]);
+    });
+
+    it('links create-similar saves to the source image latest lineage step', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore({ archiveImageId: 'source-image' });
+        await lineage.save({
+            archiveImageId: 'source-image',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: { prompt: 'first prompt' },
+        });
+        await lineage.save({
+            archiveImageId: 'source-image',
+            parentStepId: 'step-1',
+            stepType: 'overwrite',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: { prompt: 'refined prompt' },
+        });
+
+        await saveGeneratedImage(createArchiveImage({ id: 'branch-image' }), {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        await expect(lineage.getByArchiveImageId('branch-image')).resolves.toEqual([
+            expect.objectContaining({
+                parentStepId: 'step-2',
+                metadata: expect.objectContaining({
+                    sourceArchiveImageId: 'source-image',
+                }),
+            }),
+        ]);
+    });
+
+    it('does not write provenance when archive save fails', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore({ archiveImageId: 'source-image' });
+        const error = new Error('disk full');
+
+        await expect(saveGeneratedImage(createArchiveImage(), {
+            saveImage: vi.fn(async () => {
+                throw error;
+            }),
+            lineageStore: lineage,
+            sessionStore,
+        })).rejects.toThrow(error);
+
+        await expect(lineage.getByArchiveImageId('generated-1')).resolves.toEqual([]);
+        expect(sessionStore.clearLineageSource).not.toHaveBeenCalled();
+    });
+});
+
+function createStore() {
+    let nextId = 0;
+
+    return createLineageStore({
+        metadata: new InMemoryLineageMetadataPort(),
+        makeId: () => {
+            nextId += 1;
+            return `step-${nextId}`;
+        },
+    });
+}
+
+function createSessionStore(lineageSource: GenerateLineageSource | null = null) {
+    return {
+        loadLineageSource: vi.fn(() => lineageSource),
+        clearLineageSource: vi.fn(),
+    };
+}
+
+function createArchiveImage(overrides: Partial<ArchiveImage> = {}): ArchiveImage {
+    return {
+        id: 'generated-1',
+        url: 'data:image/png;base64,abc123',
+        prompt: 'bioluminescent forest',
+        model: 'gpt-image-1.5',
+        timestamp: '2026-04-04T12:00:00.000Z',
+        width: 1024,
+        height: 1024,
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        style: 'risograph poster',
+        lighting: 'golden hour',
+        palette: 'copper + teal + cream',
+        references: [],
+        ...overrides,
+    };
+}
+
+function compareSteps(left: LineageStep, right: LineageStep) {
+    return left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id);
+}

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -130,6 +130,36 @@ describe('saveGeneratedImage', () => {
         ]);
     });
 
+    it('uses the explicitly selected lineage step id for forked saves', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore({ archiveImageId: 'source-image', stepId: 'step-1' });
+        await lineage.save({
+            archiveImageId: 'source-image',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: { prompt: 'first prompt' },
+        });
+        await lineage.save({
+            archiveImageId: 'source-image',
+            parentStepId: 'step-1',
+            stepType: 'overwrite',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: { prompt: 'newest prompt' },
+        });
+
+        await saveGeneratedImage(createArchiveImage({ id: 'forked-image' }), {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        const steps = await lineage.getByArchiveImageId('forked-image');
+        expect(steps.at(-1)).toEqual(expect.objectContaining({
+            parentStepId: 'step-1',
+        }));
+    });
+
     it('does not write provenance when archive save fails', async () => {
         const lineage = createStore();
         const sessionStore = createSessionStore({ archiveImageId: 'source-image' });

--- a/src/generate-session/saveGeneratedImage.ts
+++ b/src/generate-session/saveGeneratedImage.ts
@@ -1,0 +1,58 @@
+import type { ArchiveImage } from '../db/types';
+import type { LineageStore } from '../lineage/LineageStore';
+import type { GenerateLineageSource, GenerateSessionStore } from './GenerateSession';
+
+export interface SaveGeneratedImageDeps {
+    saveImage: (image: ArchiveImage) => Promise<ArchiveImage>;
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'clearLineageSource'>;
+}
+
+export async function saveGeneratedImage(image: ArchiveImage, deps: SaveGeneratedImageDeps): Promise<ArchiveImage> {
+    const lineageSource = deps.sessionStore.loadLineageSource();
+    const savedImage = await deps.saveImage(image);
+
+    await deps.lineageStore.save({
+        archiveImageId: savedImage.id,
+        parentStepId: await resolveParentStepId(lineageSource, deps.lineageStore),
+        stepType: savedImage.references && savedImage.references.length > 0 ? 'reference-generation' : 'generation',
+        timestamp: savedImage.timestamp,
+        metadata: buildGenerationMetadata(savedImage, lineageSource),
+    });
+
+    deps.sessionStore.clearLineageSource();
+
+    return savedImage;
+}
+
+async function resolveParentStepId(
+    lineageSource: GenerateLineageSource | null,
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId'>,
+) {
+    if (!lineageSource) {
+        return null;
+    }
+
+    const sourceSteps = await lineageStore.getByArchiveImageId(lineageSource.archiveImageId);
+    return sourceSteps.at(-1)?.id ?? null;
+}
+
+function buildGenerationMetadata(image: ArchiveImage, lineageSource: GenerateLineageSource | null) {
+    return {
+        prompt: image.prompt,
+        model: image.model ?? null,
+        quality: image.quality,
+        aspectRatio: image.aspectRatio,
+        background: image.background,
+        style: image.style ?? 'none',
+        lighting: image.lighting ?? 'none',
+        palette: image.palette ?? 'none',
+        referenceIds: (image.references ?? []).map((_, index) => createReferenceId(image.id, index)),
+        referenceCount: image.references?.length ?? 0,
+        sourceArchiveImageId: lineageSource?.archiveImageId ?? null,
+    } satisfies Record<string, unknown>;
+}
+
+function createReferenceId(archiveImageId: string, index: number) {
+    return `${archiveImageId}:reference:${index}`;
+}

--- a/src/generate-session/saveGeneratedImage.ts
+++ b/src/generate-session/saveGeneratedImage.ts
@@ -33,6 +33,10 @@ async function resolveParentStepId(
         return null;
     }
 
+    if (lineageSource.stepId) {
+        return lineageSource.stepId;
+    }
+
     const sourceSteps = await lineageStore.getByArchiveImageId(lineageSource.archiveImageId);
     return sourceSteps.at(-1)?.id ?? null;
 }

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, type GenerateDraft } from './GenerateSession';
+import { generateSessionStore, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { lineageStore, type LineageStore } from '../lineage/LineageStore';
+import { saveGeneratedImage } from './saveGeneratedImage';
 
 interface UseGenerateControllerOptions {
     apiKey: string | null;
@@ -11,7 +13,9 @@ interface UseGenerateControllerOptions {
     referenceImages: File[];
     replaceReferences: (dataUrls: string[]) => void;
     serializeReferences: () => Promise<string[]>;
-    onSaveImage: (image: ArchiveImage) => void | Promise<void>;
+    onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
+    lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'clearLineageSource'>;
 }
 
 const VALID_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
@@ -24,6 +28,8 @@ export function useGenerateController({
     replaceReferences,
     serializeReferences,
     onSaveImage,
+    lineage = lineageStore,
+    session = generateSessionStore,
 }: UseGenerateControllerOptions) {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
@@ -34,18 +40,18 @@ export function useGenerateController({
     }, [setDraft]);
 
     useEffect(() => {
-        generateSessionStore.loadCurrentResult().then((value) => {
+        session.loadCurrentResult().then((value) => {
             if (value) {
                 setCurrentResult(value);
             }
         });
 
-        generateSessionStore.consumeTransferredReferences().then((references) => {
+        session.consumeTransferredReferences().then((references) => {
             if (references.length > 0) {
                 replaceReferences(references);
             }
         });
-    }, [replaceReferences]);
+    }, [replaceReferences, session]);
 
     useEffect(() => {
         if (!VALID_SIZES.has(draft.aspectRatio)) {
@@ -81,13 +87,13 @@ export function useGenerateController({
 
             setCurrentResult(imageUrl);
             updateDraft({ isSaved: false });
-            await generateSessionStore.saveCurrentResult(imageUrl);
+            await session.saveCurrentResult(imageUrl);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to generate image');
         } finally {
             setLoading(false);
         }
-    }, [apiKey, draft, referenceImages, updateDraft]);
+    }, [apiKey, draft, referenceImages, session, updateDraft]);
 
     const save = useCallback(async () => {
         if (!currentResult || draft.isSaved) {
@@ -97,7 +103,7 @@ export function useGenerateController({
         try {
             const references = await serializeReferences();
             const { width, height } = getImageDimensions(draft.aspectRatio);
-            await Promise.resolve(onSaveImage({
+            await saveGeneratedImage({
                 id: crypto.randomUUID(),
                 url: currentResult,
                 prompt: draft.prompt,
@@ -112,12 +118,16 @@ export function useGenerateController({
                 lighting: draft.lighting,
                 palette: draft.palette,
                 references,
-            }));
+            }, {
+                saveImage: async (image) => Promise.resolve(onSaveImage(image)),
+                lineageStore: lineage,
+                sessionStore: session,
+            });
             updateDraft({ isSaved: true });
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [currentResult, draft, onSaveImage, serializeReferences, updateDraft]);
+    }, [currentResult, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
 
     const download = useCallback(() => {
         if (!currentResult) {
@@ -129,8 +139,8 @@ export function useGenerateController({
 
     const clear = useCallback(async () => {
         setCurrentResult(null);
-        await generateSessionStore.clearCurrentResult();
-    }, []);
+        await session.clearCurrentResult();
+    }, [session]);
 
     return {
         currentResult,

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,10 +1,28 @@
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
 import { generateSessionStore, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { imageWorkflow, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
+import { runGenerateAutopilot } from './runGenerateAutopilot';
+import { createAutopilotSession, type AutopilotSession } from '../autopilot/AutopilotSession';
+
+interface AutopilotProgressState {
+    running: boolean;
+    iterations: Array<{
+        stepId: string;
+        archiveImageId: string;
+        iterationNumber: number;
+        prompt: string;
+        imageDataUrl: string;
+        score: number;
+        feedback: string[];
+    }>;
+    status: 'idle' | 'running' | 'satisfied' | 'max-iterations' | 'cancelled' | 'failed';
+    bestIterationNumber: number | null;
+    lastErrorIteration: number | null;
+}
 
 interface UseGenerateControllerOptions {
     apiKey: string | null;
@@ -15,7 +33,9 @@ interface UseGenerateControllerOptions {
     serializeReferences: () => Promise<string[]>;
     onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
     lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
-    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'clearLineageSource'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
+    workflow?: Pick<ImageWorkflow, 'generate'>;
+    createAutopilot?: typeof createAutopilotSession;
 }
 
 const VALID_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
@@ -30,10 +50,20 @@ export function useGenerateController({
     onSaveImage,
     lineage = lineageStore,
     session = generateSessionStore,
+    workflow = imageWorkflow,
+    createAutopilot = createAutopilotSession,
 }: UseGenerateControllerOptions) {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [autopilot, setAutopilot] = useState<AutopilotProgressState>({
+        running: false,
+        iterations: [],
+        status: 'idle',
+        bestIterationNumber: null,
+        lastErrorIteration: null,
+    });
+    const autopilotSessionRef = useRef<AutopilotSession | null>(null);
 
     const updateDraft = useCallback((patch: Partial<GenerateDraft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -71,9 +101,13 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        setAutopilot((current) => ({
+            ...current,
+            running: false,
+        }));
 
         try {
-            const imageUrl = await imageWorkflow.generate({
+            const imageUrl = await workflow.generate({
                 apiKey,
                 prompt: draft.prompt,
                 quality: draft.quality,
@@ -93,7 +127,104 @@ export function useGenerateController({
         } finally {
             setLoading(false);
         }
-    }, [apiKey, draft, referenceImages, session, updateDraft]);
+    }, [apiKey, draft, referenceImages, session, updateDraft, workflow]);
+
+    const runAutopilot = useCallback(async (input: { goal: string; maxIterations?: number; satisfactionThreshold?: number }) => {
+        if (!apiKey) {
+            setError('Please set your OpenAI API Key in Settings first.');
+            return null;
+        }
+
+        if (!draft.prompt.trim() || !input.goal.trim()) {
+            return null;
+        }
+
+        setLoading(true);
+        setError(null);
+        setAutopilot({
+            running: true,
+            iterations: [],
+            status: 'running',
+            bestIterationNumber: null,
+            lastErrorIteration: null,
+        });
+
+        try {
+            const outcome = await runGenerateAutopilot({
+                goal: input.goal,
+                apiKey,
+                draft,
+                referenceImages,
+                sessionStore: session,
+                lineageStore: lineage,
+                workflow,
+                createSession: createAutopilot,
+                onSessionCreated: (sessionInstance) => {
+                    autopilotSessionRef.current = sessionInstance;
+                },
+                maxIterations: input.maxIterations,
+                satisfactionThreshold: input.satisfactionThreshold,
+                onIterationComplete: (iteration) => {
+                    setAutopilot((current) => {
+                        const iterations = [...current.iterations, iteration];
+                        const bestIteration = iterations.reduce<typeof iteration | null>((best, candidate) => {
+                            if (!best || candidate.score > best.score) {
+                                return candidate;
+                            }
+
+                            if (candidate.score === best.score && candidate.iterationNumber < best.iterationNumber) {
+                                return candidate;
+                            }
+
+                            return best;
+                        }, null);
+
+                        return {
+                            ...current,
+                            iterations,
+                            bestIterationNumber: bestIteration?.iterationNumber ?? null,
+                        };
+                    });
+                    setCurrentResult(iteration.imageDataUrl);
+                },
+                onError: (error, iterationNumber) => {
+                    setError(error.message);
+                    setAutopilot((current) => ({
+                        ...current,
+                        lastErrorIteration: iterationNumber,
+                    }));
+                },
+            });
+
+            if (outcome.result.bestIteration) {
+                setCurrentResult(outcome.result.bestIteration.imageDataUrl);
+                updateDraft({
+                    prompt: outcome.result.bestIteration.prompt,
+                    isSaved: false,
+                });
+            }
+
+            if (outcome.result.status === 'failed' && outcome.result.error) {
+                setError(outcome.result.error.message);
+            }
+
+            setAutopilot((current) => ({
+                ...current,
+                running: false,
+                status: outcome.result.status,
+                bestIterationNumber: outcome.result.bestIteration?.iterationNumber ?? current.bestIterationNumber,
+            }));
+
+            return outcome.result;
+        } finally {
+            autopilotSessionRef.current = null;
+            setLoading(false);
+        }
+    }, [apiKey, createAutopilot, draft, lineage, referenceImages, session, updateDraft, workflow]);
+
+    const cancelAutopilot = useCallback(() => {
+        autopilotSessionRef.current?.cancel();
+    }, []);
 
     const save = useCallback(async () => {
         if (!currentResult || draft.isSaved) {
@@ -146,8 +277,11 @@ export function useGenerateController({
         currentResult,
         loading,
         error,
+        autopilot,
         updateDraft,
         generate,
+        runAutopilot,
+        cancelAutopilot,
         save,
         download,
         clear,

--- a/src/hooks/useImageArchive.ts
+++ b/src/hooks/useImageArchive.ts
@@ -34,13 +34,14 @@ export function useImageArchive(options: UseImageArchiveOptions = {}) {
         }
     }, [onError, store]);
 
-    const addImage = async (image: ArchiveImage) => {
+    const addImage = async (image: ArchiveImage): Promise<ArchiveImage> => {
         try {
             const savedImage = await store.save(image);
             setImages((current) => sortImagesByTimestamp([
                 savedImage,
                 ...current.filter((entry) => entry.id !== savedImage.id),
             ]));
+            return savedImage;
         } catch (err) {
             const nextError = err instanceof Error ? err : new Error('Failed to save image');
             setError(nextError);

--- a/src/index.css
+++ b/src/index.css
@@ -1119,6 +1119,7 @@ textarea {
     border-left: 1px solid rgba(255, 255, 255, 0.05);
     display: flex;
     flex-direction: column;
+    min-height: 0;
     transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s ease;
 }
 
@@ -1131,10 +1132,22 @@ textarea {
 
 .sidebar-inner {
     width: 400px;
+    height: 100%;
     padding: 40px;
     display: flex;
     flex-direction: column;
     gap: 32px;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.sidebar-inner {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+.sidebar-inner::-webkit-scrollbar {
+    display: none;
 }
 
 .sidebar-toggle {
@@ -1227,15 +1240,30 @@ textarea {
 }
 
 .lineage-header-row {
+    margin-bottom: 12px;
+}
+
+.lineage-section-toggle {
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    margin-bottom: 12px;
+    text-align: left;
+}
+
+.lineage-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
 .lineage-badge {
     text-align: right;
+}
+
+.lineage-chevron-open {
+    transform: rotate(90deg);
 }
 
 .lineage-panel {
@@ -1270,11 +1298,18 @@ textarea {
     border-radius: 14px;
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid rgba(255, 255, 255, 0.05);
+    cursor: pointer;
+    transition: var(--transition-smooth);
 }
 
 .lineage-entry.selected {
     border-color: rgba(168, 85, 247, 0.45);
     background: rgba(168, 85, 247, 0.08);
+}
+
+.lineage-entry:hover {
+    border-color: rgba(168, 85, 247, 0.22);
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .lineage-run-label {
@@ -1385,6 +1420,21 @@ textarea {
     text-transform: uppercase;
     color: var(--text-dim);
     font-weight: 700;
+}
+
+.single-image-label {
+    position: absolute;
+    top: 20px;
+    left: 68px;
+    z-index: 2;
+    padding: 8px 12px;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    max-width: min(320px, calc(100% - 140px));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .comparison-image {

--- a/src/index.css
+++ b/src/index.css
@@ -982,6 +982,7 @@ textarea {
     align-items: center;
     justify-content: center;
     padding: 40px;
+    position: relative;
 }
 
 .modal-image {
@@ -1162,6 +1163,11 @@ textarea {
     border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
+.lineage-entry.selected {
+    border-color: rgba(168, 85, 247, 0.45);
+    background: rgba(168, 85, 247, 0.08);
+}
+
 .lineage-entry-header {
     display: flex;
     align-items: center;
@@ -1172,6 +1178,11 @@ textarea {
 
 .lineage-type {
     white-space: nowrap;
+}
+
+.lineage-select {
+    border: none;
+    cursor: pointer;
 }
 
 .lineage-time {
@@ -1187,6 +1198,18 @@ textarea {
     font-size: 0.92rem;
 }
 
+.lineage-actions-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.lineage-action-btn {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+}
+
 .lineage-empty {
     display: flex;
     align-items: center;
@@ -1195,6 +1218,48 @@ textarea {
     color: var(--text-dim);
     background: rgba(0, 0, 0, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.comparison-view {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+    align-items: stretch;
+}
+
+.comparison-pane {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.comparison-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    font-weight: 700;
+}
+
+.comparison-image {
+    max-height: calc(100% - 32px);
+}
+
+.comparison-error {
+    position: absolute;
+    bottom: 24px;
+    left: 24px;
+    right: 24px;
+    padding: 12px 16px;
+    text-align: center;
+    color: #fca5a5;
+    background: rgba(127, 29, 29, 0.7);
+    border: 1px solid rgba(248, 113, 113, 0.35);
 }
 
 .danger-text {

--- a/src/index.css
+++ b/src/index.css
@@ -1116,6 +1116,87 @@ textarea {
     gap: 12px;
 }
 
+.lineage-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.lineage-badge {
+    text-align: right;
+}
+
+.lineage-panel {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.lineage-origin {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.lineage-origin.missing {
+    color: var(--text-dim);
+}
+
+.lineage-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.lineage-entry {
+    padding: 14px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.lineage-entry-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+}
+
+.lineage-type {
+    white-space: nowrap;
+}
+
+.lineage-time {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    text-align: right;
+}
+
+.lineage-summary {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.5;
+    font-size: 0.92rem;
+}
+
+.lineage-empty {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px;
+    color: var(--text-dim);
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
 .danger-text {
     background: transparent;
     color: #f87171;

--- a/src/index.css
+++ b/src/index.css
@@ -1064,9 +1064,9 @@ textarea {
 }
 
 .modal-content {
-    width: 95vw;
-    max-width: 1400px;
-    height: 85vh;
+    width: 100vw;
+    max-width: none;
+    height: 99vh;
     display: flex;
     position: relative;
     overflow: hidden;
@@ -1152,9 +1152,9 @@ textarea {
 
 .sidebar-toggle {
     position: absolute;
-    top: 50%;
+    top: 20px;
     right: 0;
-    transform: translate(50%, -50%);
+    transform: translateX(50%);
     width: 32px;
     height: 64px;
     background: var(--accent-primary);
@@ -1174,7 +1174,7 @@ textarea {
 .sidebar-closed .sidebar-toggle {
     right: 0;
     border-radius: 8px;
-    transform: translate(0, -50%);
+    transform: translateX(0);
     margin-right: 12px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -464,6 +464,15 @@ textarea {
     font-size: 0.85rem;
 }
 
+.info-message {
+    padding: 1rem;
+    border-radius: 10px;
+    background: rgba(59, 130, 246, 0.12);
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    color: #93c5fd;
+    font-size: 0.9rem;
+}
+
 /* Common */
 .placeholder-view {
     display: flex;
@@ -491,6 +500,97 @@ textarea {
     display: flex;
     flex-direction: column;
     gap: var(--space-xl);
+}
+
+.autopilot-panel {
+    padding: 1rem;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background: rgba(59, 130, 246, 0.07);
+    border: 1px solid rgba(59, 130, 246, 0.18);
+}
+
+.autopilot-inline-btn {
+    padding: 0.45rem 0.75rem;
+    font-size: 0.8rem;
+}
+
+.autopilot-goal-input {
+    height: 120px;
+}
+
+.autopilot-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.range-input {
+    width: 100%;
+}
+
+.autopilot-metric {
+    display: inline-block;
+    margin-top: 0.5rem;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+}
+
+.autopilot-disclosure,
+.autopilot-confirmation,
+.autopilot-live-panel,
+.autopilot-result-banner {
+    padding: 1rem;
+    border-radius: 14px;
+}
+
+.autopilot-disclosure p,
+.autopilot-confirmation p,
+.autopilot-result-banner span,
+.autopilot-live-feedback {
+    color: var(--text-dim);
+    margin-top: 0.5rem;
+    line-height: 1.5;
+}
+
+.autopilot-confirmation-actions,
+.autopilot-live-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.autopilot-thumbnail-strip {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+}
+
+.autopilot-thumbnail {
+    min-width: 96px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    color: var(--text-dim);
+    font-size: 0.75rem;
+}
+
+.autopilot-thumbnail img {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 10px;
+    border: 1px solid var(--border-glass);
+}
+
+.autopilot-thumbnail.best img {
+    border-color: rgba(59, 130, 246, 0.6);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.18);
 }
 
 .input-section label,
@@ -628,6 +728,15 @@ textarea {
     height: 100%;
     display: flex;
     flex-direction: column;
+}
+
+.autopilot-result-banner {
+    position: absolute;
+    top: 1.5rem;
+    left: 1.5rem;
+    right: 1.5rem;
+    background: rgba(0, 0, 0, 0.58);
+    border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
 .result-image {
@@ -1168,6 +1277,14 @@ textarea {
     background: rgba(168, 85, 247, 0.08);
 }
 
+.lineage-run-label {
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #93c5fd;
+    margin-bottom: 0.5rem;
+}
+
 .lineage-entry-header {
     display: flex;
     align-items: center;
@@ -1196,6 +1313,30 @@ textarea {
     color: var(--text-muted);
     line-height: 1.5;
     font-size: 0.92rem;
+}
+
+.lineage-meta-block {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.lineage-meta-block strong {
+    display: block;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin-bottom: 0.4rem;
+}
+
+.lineage-meta-block p {
+    margin: 0;
+    color: var(--text-main);
+    line-height: 1.45;
+    font-size: 0.88rem;
 }
 
 .lineage-actions-row {

--- a/src/lineage/LineageStore.test.ts
+++ b/src/lineage/LineageStore.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { createLineageStore, type LineageMetadataPort, type LineageStep } from './LineageStore';
+
+class InMemoryLineageMetadataPort implements LineageMetadataPort {
+    private readonly steps = new Map<string, LineageStep>();
+    private initialized = false;
+
+    async init(): Promise<void> {
+        this.initialized = true;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+
+        this.steps.set(step.id, step);
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        if (!this.initialized) {
+            await this.init();
+        }
+
+        return this.steps.get(id) ?? null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        if (!this.initialized) {
+            await this.init();
+        }
+
+        return Array.from(this.steps.values())
+            .filter((step) => step.archiveImageId === archiveImageId)
+            .sort(compareSteps);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        if (!this.initialized) {
+            await this.init();
+        }
+
+        return Array.from(this.steps.values())
+            .filter((step) => step.parentStepId === parentStepId)
+            .sort(compareSteps);
+    }
+
+    async remove(id: string): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+
+        this.steps.delete(id);
+    }
+}
+
+describe('LineageStore', () => {
+    it('saves a step with a stable generated id', async () => {
+        const store = createStore();
+
+        const step = await store.save({
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: { prompt: 'Studio portrait' },
+        });
+
+        expect(step.id).toBe('step-1');
+        await expect(store.getById('step-1')).resolves.toEqual(step);
+    });
+
+    it('returns null and empty collections for unknown lineage references', async () => {
+        const store = createStore();
+
+        await expect(store.getById('missing-step')).resolves.toBeNull();
+        await expect(store.getByArchiveImageId('missing-image')).resolves.toEqual([]);
+        await expect(store.getChildren('missing-parent')).resolves.toEqual([]);
+    });
+
+    it('returns image steps ordered by timestamp', async () => {
+        const store = createStore();
+
+        await store.save({
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: {},
+        });
+
+        await store.save({
+            archiveImageId: 'image-1',
+            parentStepId: 'step-1',
+            stepType: 'overwrite',
+            timestamp: '2026-04-04T11:00:00.000Z',
+            metadata: {},
+        });
+
+        const steps = await store.getByArchiveImageId('image-1');
+
+        expect(steps.map((step) => step.id)).toEqual(['step-1', 'step-2']);
+    });
+
+    it('returns children for a parent without failing when the parent record is absent', async () => {
+        const store = createStore();
+
+        await store.save({
+            archiveImageId: 'image-1',
+            parentStepId: 'missing-parent',
+            stepType: 'save-as-copy',
+            timestamp: '2026-04-04T12:00:00.000Z',
+            metadata: {},
+        });
+
+        const children = await store.getChildren('missing-parent');
+
+        expect(children).toHaveLength(1);
+        expect(children[0]?.id).toBe('step-1');
+    });
+
+    it('removes only the targeted step', async () => {
+        const store = createStore();
+
+        await store.save({
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: {},
+        });
+
+        await store.save({
+            archiveImageId: 'image-2',
+            parentStepId: 'step-1',
+            stepType: 'save-as-copy',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {},
+        });
+
+        await store.save({
+            archiveImageId: 'image-3',
+            parentStepId: 'step-1',
+            stepType: 'save-as-copy',
+            timestamp: '2026-04-04T11:00:00.000Z',
+            metadata: {},
+        });
+
+        await store.remove('step-2');
+
+        await expect(store.getById('step-2')).resolves.toBeNull();
+        await expect(store.getById('step-3')).resolves.toMatchObject({ id: 'step-3', parentStepId: 'step-1' });
+        await expect(store.getChildren('step-1')).resolves.toEqual([
+            expect.objectContaining({ id: 'step-3' }),
+        ]);
+    });
+});
+
+function createStore() {
+    let nextId = 0;
+
+    return createLineageStore({
+        metadata: new InMemoryLineageMetadataPort(),
+        makeId: () => {
+            nextId += 1;
+            return `step-${nextId}`;
+        },
+    });
+}
+
+function compareSteps(left: LineageStep, right: LineageStep) {
+    return left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id);
+}

--- a/src/lineage/LineageStore.ts
+++ b/src/lineage/LineageStore.ts
@@ -1,0 +1,88 @@
+import { lineageMetadataPort } from '../db/AuraPersistence';
+import { SQLiteLineageMetadataPort } from './SQLiteLineageMetadataPort';
+import type { LineageStep, SaveLineageStepInput } from './types';
+
+interface LineageMetadataPort {
+    init(): Promise<void>;
+    save(step: LineageStep): Promise<void>;
+    getById(id: string): Promise<LineageStep | null>;
+    getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]>;
+    getChildren(parentStepId: string): Promise<LineageStep[]>;
+    remove(id: string): Promise<void>;
+}
+
+interface CreateLineageStoreDeps {
+    metadata?: LineageMetadataPort;
+    clock?: () => string;
+    makeId?: () => string;
+}
+
+export interface LineageStore {
+    init(): Promise<void>;
+    save(input: SaveLineageStepInput): Promise<LineageStep>;
+    getById(id: string): Promise<LineageStep | null>;
+    getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]>;
+    getChildren(parentStepId: string): Promise<LineageStep[]>;
+    remove(id: string): Promise<void>;
+}
+
+class LocalLineageStore implements LineageStore {
+    private readonly metadata: LineageMetadataPort;
+    private readonly clock: () => string;
+    private readonly makeId: () => string;
+
+    constructor(metadata: LineageMetadataPort, clock: () => string, makeId: () => string) {
+        this.metadata = metadata;
+        this.clock = clock;
+        this.makeId = makeId;
+    }
+
+    init(): Promise<void> {
+        return this.metadata.init();
+    }
+
+    async save(input: SaveLineageStepInput): Promise<LineageStep> {
+        const step: LineageStep = {
+            id: input.id ?? this.makeId(),
+            archiveImageId: input.archiveImageId,
+            parentStepId: input.parentStepId ?? null,
+            stepType: input.stepType,
+            timestamp: input.timestamp ?? this.clock(),
+            metadata: input.metadata,
+        };
+
+        await this.metadata.save(step);
+
+        return step;
+    }
+
+    getById(id: string): Promise<LineageStep | null> {
+        return this.metadata.getById(id);
+    }
+
+    getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        return this.metadata.getByArchiveImageId(archiveImageId);
+    }
+
+    getChildren(parentStepId: string): Promise<LineageStep[]> {
+        return this.metadata.getChildren(parentStepId);
+    }
+
+    remove(id: string): Promise<void> {
+        return this.metadata.remove(id);
+    }
+}
+
+export function createLineageStore(deps: CreateLineageStoreDeps = {}): LineageStore {
+    return new LocalLineageStore(
+        deps.metadata ?? lineageMetadataPort,
+        deps.clock ?? (() => new Date().toISOString()),
+        deps.makeId ?? (() => crypto.randomUUID()),
+    );
+}
+
+export const lineageStore = createLineageStore();
+
+export { SQLiteLineageMetadataPort };
+export type { LineageMetadataPort };
+export type { LineageStep, SaveLineageStepInput };

--- a/src/lineage/SQLiteLineageMetadataPort.ts
+++ b/src/lineage/SQLiteLineageMetadataPort.ts
@@ -1,0 +1,129 @@
+import { SQLocal } from 'sqlocal';
+import type { LineageStep } from './types';
+
+type LineageStepRow = Omit<LineageStep, 'metadata'> & {
+    metadata: string | null;
+};
+
+export class SQLiteLineageMetadataPort {
+    private readonly sql: SQLocal;
+    private initialized = false;
+
+    constructor(databaseName: string = 'aura_database.sqlite3') {
+        this.sql = new SQLocal(databaseName);
+    }
+
+    async init(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+
+        await this.sql.sql`
+            CREATE TABLE IF NOT EXISTS lineage_steps (
+                id TEXT PRIMARY KEY,
+                archiveImageId TEXT NOT NULL,
+                parentStepId TEXT,
+                stepType TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                metadata TEXT
+            );
+        `;
+
+        await this.sql.sql`
+            CREATE INDEX IF NOT EXISTS idx_lineage_steps_archive_image_id
+            ON lineage_steps (archiveImageId, timestamp);
+        `;
+
+        await this.sql.sql`
+            CREATE INDEX IF NOT EXISTS idx_lineage_steps_parent_step_id
+            ON lineage_steps (parentStepId);
+        `;
+
+        this.initialized = true;
+    }
+
+    async save(step: LineageStep): Promise<void> {
+        await this.init();
+
+        await this.sql.sql`
+            INSERT OR REPLACE INTO lineage_steps (id, archiveImageId, parentStepId, stepType, timestamp, metadata)
+            VALUES (
+                ${step.id},
+                ${step.archiveImageId},
+                ${step.parentStepId},
+                ${step.stepType},
+                ${step.timestamp},
+                ${JSON.stringify(step.metadata)}
+            )
+        `;
+    }
+
+    async getById(id: string): Promise<LineageStep | null> {
+        await this.init();
+
+        const result = await this.sql.sql`SELECT * FROM lineage_steps WHERE id = ${id}`;
+        const row = (result as LineageStepRow[])[0];
+
+        return row ? hydrateLineageStep(row) : null;
+    }
+
+    async getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]> {
+        await this.init();
+
+        const result = await this.sql.sql`
+            SELECT *
+            FROM lineage_steps
+            WHERE archiveImageId = ${archiveImageId}
+            ORDER BY timestamp ASC, id ASC
+        `;
+
+        return (result as LineageStepRow[]).map(hydrateLineageStep);
+    }
+
+    async getChildren(parentStepId: string): Promise<LineageStep[]> {
+        await this.init();
+
+        const result = await this.sql.sql`
+            SELECT *
+            FROM lineage_steps
+            WHERE parentStepId = ${parentStepId}
+            ORDER BY timestamp ASC, id ASC
+        `;
+
+        return (result as LineageStepRow[]).map(hydrateLineageStep);
+    }
+
+    async remove(id: string): Promise<void> {
+        await this.init();
+        await this.sql.sql`DELETE FROM lineage_steps WHERE id = ${id}`;
+    }
+}
+
+function hydrateLineageStep(row: LineageStepRow): LineageStep {
+    return {
+        id: row.id,
+        archiveImageId: row.archiveImageId,
+        parentStepId: row.parentStepId,
+        stepType: row.stepType,
+        timestamp: row.timestamp,
+        metadata: parseMetadata(row.metadata),
+    };
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> {
+    if (!value) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(value) as unknown;
+
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+
+        return {};
+    } catch {
+        return {};
+    }
+}

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { LineageStep } from './LineageStore';
+import { loadLineageTimeline } from './loadLineageTimeline';
+
+describe('loadLineageTimeline', () => {
+    it('builds readable entries, parent indicator, and descendant count', async () => {
+        const step1 = createStep({
+            id: 'step-1',
+            archiveImageId: 'image-1',
+            parentStepId: 'parent-1',
+            stepType: 'save-as-copy',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: {
+                editorAdjustments: {
+                    brightness: 100,
+                    contrast: 90,
+                    saturation: 120,
+                    filter: 'none',
+                },
+            },
+        });
+        const step2 = createStep({
+            id: 'step-2',
+            archiveImageId: 'image-1',
+            stepType: 'overwrite',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                editorAdjustments: {
+                    brightness: 115,
+                    contrast: 100,
+                    saturation: 125,
+                    filter: 'sepia(100%)',
+                },
+            },
+        });
+        const child = createStep({
+            id: 'step-3',
+            archiveImageId: 'image-2',
+            parentStepId: 'step-2',
+            stepType: 'save-as-copy',
+            timestamp: '2026-04-04T11:00:00.000Z',
+            metadata: {},
+        });
+
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [step1, step2],
+            },
+            byId: {
+                'parent-1': createStep({
+                    id: 'parent-1',
+                    archiveImageId: 'image-0',
+                    stepType: 'ai-edit',
+                    timestamp: '2026-04-04T08:00:00.000Z',
+                    metadata: { editPrompt: 'add a brighter horizon glow' },
+                }),
+            },
+            children: {
+                'step-1': [],
+                'step-2': [child],
+            },
+        }));
+
+        expect(timeline).toEqual({
+            entries: [
+                {
+                    id: 'step-1',
+                    stepType: 'save-as-copy',
+                    label: 'Saved as Copy',
+                    summary: 'Adjusted contrast, saturation',
+                    timestamp: '2026-04-04T09:00:00.000Z',
+                },
+                {
+                    id: 'step-2',
+                    stepType: 'overwrite',
+                    label: 'Overwrite Save',
+                    summary: 'Adjusted brightness, saturation, filter',
+                    timestamp: '2026-04-04T10:00:00.000Z',
+                },
+            ],
+            parent: {
+                label: 'AI edit: add a brighter horizon glow',
+                archiveImageId: 'image-0',
+                missing: false,
+            },
+            descendantCount: 1,
+        });
+    });
+
+    it('returns an origin unknown parent when the parent step is missing', async () => {
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [createStep({
+                    id: 'step-1',
+                    archiveImageId: 'image-1',
+                    parentStepId: 'missing-parent',
+                    stepType: 'save-as-copy',
+                    timestamp: '2026-04-04T09:00:00.000Z',
+                    metadata: {},
+                })],
+            },
+            byId: {},
+            children: {
+                'step-1': [],
+            },
+        }));
+
+        expect(timeline.parent).toEqual({
+            label: 'Origin unknown',
+            archiveImageId: null,
+            missing: true,
+        });
+    });
+
+    it('returns an empty state when the image has no lineage steps', async () => {
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [],
+            },
+            byId: {},
+            children: {},
+        }));
+
+        expect(timeline).toEqual({
+            entries: [],
+            parent: null,
+            descendantCount: 0,
+        });
+    });
+});
+
+function createStore(data: {
+    byArchiveImageId: Record<string, LineageStep[]>;
+    byId: Record<string, LineageStep>;
+    children: Record<string, LineageStep[]>;
+}) {
+    return {
+        getByArchiveImageId: async (archiveImageId: string) => data.byArchiveImageId[archiveImageId] ?? [],
+        getById: async (id: string) => data.byId[id] ?? null,
+        getChildren: async (parentStepId: string) => data.children[parentStepId] ?? [],
+    };
+}
+
+function createStep(overrides: Partial<LineageStep> & Pick<LineageStep, 'id' | 'archiveImageId' | 'stepType' | 'timestamp'>): LineageStep {
+    return {
+        parentStepId: null,
+        metadata: {},
+        ...overrides,
+    };
+}

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -64,12 +64,32 @@ describe('loadLineageTimeline', () => {
         expect(timeline).toEqual({
             entries: [
                 {
+                    id: 'parent-1',
+                    archiveImageId: 'image-0',
+                    stepType: 'ai-edit',
+                    label: 'AI Edit',
+                    summary: 'AI edit: add a brighter horizon glow',
+                    timestamp: '2026-04-04T08:00:00.000Z',
+                    goalText: null,
+                    iterationNumber: null,
+                    evaluatorScore: null,
+                    evaluatorFeedback: [],
+                    replayImageDataUrl: null,
+                    runLabel: null,
+                },
+                {
                     id: 'step-1',
                     archiveImageId: 'image-1',
                     stepType: 'save-as-copy',
                     label: 'Saved as Copy',
                     summary: 'Adjusted contrast, saturation',
                     timestamp: '2026-04-04T09:00:00.000Z',
+                    goalText: null,
+                    iterationNumber: null,
+                    evaluatorScore: null,
+                    evaluatorFeedback: [],
+                    replayImageDataUrl: null,
+                    runLabel: null,
                 },
                 {
                     id: 'step-2',
@@ -78,6 +98,12 @@ describe('loadLineageTimeline', () => {
                     label: 'Overwrite Save',
                     summary: 'Adjusted brightness, saturation, filter',
                     timestamp: '2026-04-04T10:00:00.000Z',
+                    goalText: null,
+                    iterationNumber: null,
+                    evaluatorScore: null,
+                    evaluatorFeedback: [],
+                    replayImageDataUrl: null,
+                    runLabel: null,
                 },
             ],
             parent: {
@@ -128,6 +154,62 @@ describe('loadLineageTimeline', () => {
             parent: null,
             descendantCount: 0,
         });
+    });
+
+    it('includes autopilot ancestor metadata for saved images', async () => {
+        const autopilotStep = createStep({
+            id: 'auto-1',
+            archiveImageId: 'autopilot:run:iteration:1',
+            stepType: 'autopilot-iteration',
+            timestamp: '2026-04-04T08:00:00.000Z',
+            metadata: {
+                goalText: 'A moody editorial portrait with electric blue haze',
+                iterationNumber: 1,
+                evaluatorScore: 84,
+                evaluatorFeedback: ['Push the rim light harder.'],
+                outputImageDataUrl: 'data:image/png;base64,auto1',
+            },
+        });
+        const savedStep = createStep({
+            id: 'saved-1',
+            archiveImageId: 'image-1',
+            parentStepId: 'auto-1',
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: {
+                prompt: 'editorial portrait, electric blue haze',
+            },
+        });
+
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [savedStep],
+            },
+            byId: {
+                'auto-1': autopilotStep,
+            },
+            children: {
+                'saved-1': [],
+            },
+        }));
+
+        expect(timeline.entries).toEqual([
+            expect.objectContaining({
+                id: 'auto-1',
+                stepType: 'autopilot-iteration',
+                goalText: 'A moody editorial portrait with electric blue haze',
+                iterationNumber: 1,
+                evaluatorScore: 84,
+                evaluatorFeedback: ['Push the rim light harder.'],
+                replayImageDataUrl: 'data:image/png;base64,auto1',
+                runLabel: 'Autopilot Run · A moody editorial portrait with ele...',
+            }),
+            expect.objectContaining({
+                id: 'saved-1',
+                stepType: 'generation',
+                runLabel: null,
+            }),
+        ]);
     });
 });
 

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -65,6 +65,7 @@ describe('loadLineageTimeline', () => {
             entries: [
                 {
                     id: 'step-1',
+                    archiveImageId: 'image-1',
                     stepType: 'save-as-copy',
                     label: 'Saved as Copy',
                     summary: 'Adjusted contrast, saturation',
@@ -72,6 +73,7 @@ describe('loadLineageTimeline', () => {
                 },
                 {
                     id: 'step-2',
+                    archiveImageId: 'image-1',
                     stepType: 'overwrite',
                     label: 'Overwrite Save',
                     summary: 'Adjusted brightness, saturation, filter',

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -7,6 +7,12 @@ export interface LineageTimelineEntry {
     label: string;
     summary: string;
     timestamp: string;
+    goalText: string | null;
+    iterationNumber: number | null;
+    evaluatorScore: number | null;
+    evaluatorFeedback: string[];
+    replayImageDataUrl: string | null;
+    runLabel: string | null;
 }
 
 export interface LineageTimelineParent {
@@ -31,10 +37,11 @@ export async function loadLineageTimeline(
     archiveImageId: string,
     store: TimelineStore,
 ): Promise<LineageTimelineData> {
-    const steps = await store.getByArchiveImageId(archiveImageId);
+    const directSteps = await store.getByArchiveImageId(archiveImageId);
+    const steps = await expandWithAncestors(directSteps, store);
     const [parent, descendantCount] = await Promise.all([
-        loadParent(steps, store),
-        countDescendants(steps, store),
+        loadParent(directSteps, store),
+        countDescendants(directSteps, store),
     ]);
 
     return {
@@ -42,6 +49,25 @@ export async function loadLineageTimeline(
         parent,
         descendantCount,
     };
+}
+
+async function expandWithAncestors(steps: LineageStep[], store: Pick<LineageStore, 'getById'>) {
+    const orderedSteps = [...steps];
+    const seen = new Set(orderedSteps.map((step) => step.id));
+    let parentStepId = orderedSteps[0]?.parentStepId ?? null;
+
+    while (parentStepId) {
+        const parentStep = await store.getById(parentStepId);
+        if (!parentStep || seen.has(parentStep.id)) {
+            break;
+        }
+
+        orderedSteps.unshift(parentStep);
+        seen.add(parentStep.id);
+        parentStepId = parentStep.parentStepId;
+    }
+
+    return orderedSteps;
 }
 
 async function loadParent(steps: LineageStep[], store: Pick<LineageStore, 'getById'>): Promise<LineageTimelineParent | null> {
@@ -79,6 +105,12 @@ function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
         label: getStepLabel(step),
         summary: getStepSummary(step),
         timestamp: step.timestamp,
+        goalText: asString(step.metadata.goalText),
+        iterationNumber: asNumberOrNull(step.metadata.iterationNumber),
+        evaluatorScore: asNumberOrNull(step.metadata.evaluatorScore),
+        evaluatorFeedback: asStringArray(step.metadata.evaluatorFeedback),
+        replayImageDataUrl: asString(step.metadata.outputImageDataUrl),
+        runLabel: getRunLabel(step),
     };
 }
 
@@ -130,8 +162,30 @@ function getStepSummary(step: LineageStep) {
         case 'save-as-copy':
             return summarizeAdjustments(metadata.editorAdjustments) ?? 'Branched from previous version';
         case 'autopilot-iteration':
-            return 'Autopilot iteration recorded';
+            return summarizeAutopilot(metadata);
     }
+}
+
+function summarizeAutopilot(metadata: Record<string, unknown>) {
+    const iterationNumber = asNumberOrNull(metadata.iterationNumber);
+    const score = asNumberOrNull(metadata.evaluatorScore);
+    const goalText = excerpt(asString(metadata.goalText), 56);
+    const parts = [
+        iterationNumber !== null ? `Iteration ${iterationNumber}` : null,
+        score !== null ? `score ${score}` : null,
+        goalText ? `goal: ${goalText}` : null,
+    ].filter(Boolean);
+
+    return parts.length > 0 ? parts.join(' · ') : 'Autopilot iteration recorded';
+}
+
+function getRunLabel(step: LineageStep) {
+    if (step.stepType !== 'autopilot-iteration') {
+        return null;
+    }
+
+    const goalText = excerpt(asString(step.metadata.goalText), 36);
+    return goalText ? `Autopilot Run · ${goalText}` : 'Autopilot Run';
 }
 
 function summarizeAdjustments(value: unknown) {
@@ -181,4 +235,14 @@ function asString(value: unknown) {
 
 function asNumber(value: unknown) {
     return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function asNumberOrNull(value: unknown) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asStringArray(value: unknown) {
+    return Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+        : [];
 }

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -1,0 +1,182 @@
+import type { LineageStore, LineageStep } from './LineageStore';
+
+export interface LineageTimelineEntry {
+    id: string;
+    stepType: LineageStep['stepType'];
+    label: string;
+    summary: string;
+    timestamp: string;
+}
+
+export interface LineageTimelineParent {
+    label: string;
+    archiveImageId: string | null;
+    missing: boolean;
+}
+
+export interface LineageTimelineData {
+    entries: LineageTimelineEntry[];
+    parent: LineageTimelineParent | null;
+    descendantCount: number;
+}
+
+interface TimelineStore {
+    getByArchiveImageId(archiveImageId: string): Promise<LineageStep[]>;
+    getById(id: string): Promise<LineageStep | null>;
+    getChildren(parentStepId: string): Promise<LineageStep[]>;
+}
+
+export async function loadLineageTimeline(
+    archiveImageId: string,
+    store: TimelineStore,
+): Promise<LineageTimelineData> {
+    const steps = await store.getByArchiveImageId(archiveImageId);
+    const [parent, descendantCount] = await Promise.all([
+        loadParent(steps, store),
+        countDescendants(steps, store),
+    ]);
+
+    return {
+        entries: steps.map(toTimelineEntry),
+        parent,
+        descendantCount,
+    };
+}
+
+async function loadParent(steps: LineageStep[], store: Pick<LineageStore, 'getById'>): Promise<LineageTimelineParent | null> {
+    const parentStepId = steps[0]?.parentStepId;
+    if (!parentStepId) {
+        return null;
+    }
+
+    const parentStep = await store.getById(parentStepId);
+    if (!parentStep) {
+        return {
+            label: 'Origin unknown',
+            archiveImageId: null,
+            missing: true,
+        };
+    }
+
+    return {
+        label: summarizeParent(parentStep),
+        archiveImageId: parentStep.archiveImageId,
+        missing: false,
+    };
+}
+
+async function countDescendants(steps: LineageStep[], store: Pick<LineageStore, 'getChildren'>) {
+    const childCollections = await Promise.all(steps.map((step) => store.getChildren(step.id)));
+    return new Set(childCollections.flat().map((child) => child.id)).size;
+}
+
+function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
+    return {
+        id: step.id,
+        stepType: step.stepType,
+        label: getStepLabel(step),
+        summary: getStepSummary(step),
+        timestamp: step.timestamp,
+    };
+}
+
+function summarizeParent(step: LineageStep) {
+    const summary = getStepSummary(step);
+    return summary === 'No details recorded' ? getStepLabel(step) : summary;
+}
+
+function getStepLabel(step: LineageStep) {
+    switch (step.stepType) {
+        case 'generation':
+            return 'Generated';
+        case 'reference-generation':
+            return 'Reference Generation';
+        case 'ai-edit':
+            return 'AI Edit';
+        case 'manual-edit':
+            return 'Manual Edit';
+        case 'overwrite':
+            return 'Overwrite Save';
+        case 'save-as-copy':
+            return 'Saved as Copy';
+        case 'autopilot-iteration':
+            return 'Autopilot Iteration';
+    }
+}
+
+function getStepSummary(step: LineageStep) {
+    const metadata = step.metadata;
+    const prompt = excerpt(asString(metadata.prompt));
+    const editPrompt = excerpt(asString(metadata.editPrompt));
+    const referenceCount = asNumber(metadata.referenceCount);
+
+    switch (step.stepType) {
+        case 'generation':
+            return prompt ? `Prompt: ${prompt}` : 'Generated from saved settings';
+        case 'reference-generation':
+            if (prompt && referenceCount > 0) {
+                return `Prompt: ${prompt} with ${referenceCount} reference${referenceCount === 1 ? '' : 's'}`;
+            }
+
+            return prompt ? `Prompt: ${prompt}` : 'Generated from saved references';
+        case 'ai-edit':
+            return editPrompt ? `AI edit: ${editPrompt}` : 'AI edit applied';
+        case 'manual-edit':
+            return summarizeAdjustments(metadata.editorAdjustments) ?? 'Manual adjustments applied';
+        case 'overwrite':
+            return summarizeAdjustments(metadata.editorAdjustments) ?? 'Saved over current image';
+        case 'save-as-copy':
+            return summarizeAdjustments(metadata.editorAdjustments) ?? 'Branched from previous version';
+        case 'autopilot-iteration':
+            return 'Autopilot iteration recorded';
+    }
+}
+
+function summarizeAdjustments(value: unknown) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const adjustments = value as Record<string, unknown>;
+    const changed: string[] = [];
+
+    if (adjustments.brightness !== 100) {
+        changed.push('brightness');
+    }
+    if (adjustments.contrast !== 100) {
+        changed.push('contrast');
+    }
+    if (adjustments.saturation !== 100) {
+        changed.push('saturation');
+    }
+    if (adjustments.filter && adjustments.filter !== 'none') {
+        changed.push('filter');
+    }
+
+    if (changed.length === 0) {
+        return null;
+    }
+
+    return `Adjusted ${changed.join(', ')}`;
+}
+
+function excerpt(value: string | null, maxLength: number = 72) {
+    if (!value) {
+        return null;
+    }
+
+    const normalized = value.trim().replace(/\s+/g, ' ');
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength - 1)}...`;
+}
+
+function asString(value: unknown) {
+    return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function asNumber(value: unknown) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -2,6 +2,7 @@ import type { LineageStore, LineageStep } from './LineageStore';
 
 export interface LineageTimelineEntry {
     id: string;
+    archiveImageId: string;
     stepType: LineageStep['stepType'];
     label: string;
     summary: string;
@@ -73,6 +74,7 @@ async function countDescendants(steps: LineageStep[], store: Pick<LineageStore, 
 function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
     return {
         id: step.id,
+        archiveImageId: step.archiveImageId,
         stepType: step.stepType,
         label: getStepLabel(step),
         summary: getStepSummary(step),

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -42,9 +42,45 @@ describe('replayLineageStep', () => {
 
     it('reports which lineage steps can replay into generate or editor', () => {
         expect(isGenerateReplayable(createStep({ id: 'a', archiveImageId: 'image-a', stepType: 'generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
+        expect(isGenerateReplayable(createStep({ id: 'aa', archiveImageId: 'image-aa', stepType: 'autopilot-iteration', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
         expect(isGenerateReplayable(createStep({ id: 'b', archiveImageId: 'image-b', stepType: 'ai-edit', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
         expect(isEditorReplayable(createStep({ id: 'c', archiveImageId: 'image-c', stepType: 'save-as-copy', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
         expect(isEditorReplayable(createStep({ id: 'd', archiveImageId: 'image-d', stepType: 'reference-generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
+    });
+
+    it('hydrates a generate draft from an autopilot step without an archive image fallback', () => {
+        const step = createStep({
+            id: 'step-9',
+            archiveImageId: 'autopilot:run:iteration:2',
+            stepType: 'autopilot-iteration',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'editorial portrait, deep blue haze, dramatic rim light',
+                quality: 'high',
+                aspectRatio: '1536x1024',
+                background: 'transparent',
+                style: '35mm film still',
+                lighting: 'neon rim light',
+                palette: 'cobalt + vermilion + bone',
+            },
+        });
+
+        expect(buildGenerateReplay(null, step)).toEqual({
+            draft: {
+                prompt: 'editorial portrait, deep blue haze, dramatic rim light',
+                quality: 'high',
+                aspectRatio: '1536x1024',
+                background: 'transparent',
+                style: '35mm film still',
+                lighting: 'neon rim light',
+                palette: 'cobalt + vermilion + bone',
+                isSaved: false,
+            },
+            lineageSource: {
+                archiveImageId: 'autopilot:run:iteration:2',
+                stepId: 'step-9',
+            },
+        });
     });
 });
 

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { ArchiveImage } from '../db/types';
+import type { LineageStep } from './LineageStore';
+import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+
+describe('replayLineageStep', () => {
+    it('hydrates a generate draft from lineage metadata and preserves an exact fork source', () => {
+        const image = createImage();
+        const step = createStep({
+            id: 'step-7',
+            archiveImageId: 'image-7',
+            stepType: 'reference-generation',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'cathedral-sized jellyfish drifting over a neon harbor',
+                quality: 'high',
+                aspectRatio: '1536x1024',
+                background: 'transparent',
+                style: 'editorial sci-fi',
+                lighting: 'storm glow',
+                palette: 'violet + amber',
+            },
+        });
+
+        expect(buildGenerateReplay(image, step)).toEqual({
+            draft: {
+                prompt: 'cathedral-sized jellyfish drifting over a neon harbor',
+                quality: 'high',
+                aspectRatio: '1536x1024',
+                background: 'transparent',
+                style: 'editorial sci-fi',
+                lighting: 'storm glow',
+                palette: 'violet + amber',
+                isSaved: false,
+            },
+            lineageSource: {
+                archiveImageId: 'image-7',
+                stepId: 'step-7',
+            },
+        });
+    });
+
+    it('reports which lineage steps can replay into generate or editor', () => {
+        expect(isGenerateReplayable(createStep({ id: 'a', archiveImageId: 'image-a', stepType: 'generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
+        expect(isGenerateReplayable(createStep({ id: 'b', archiveImageId: 'image-b', stepType: 'ai-edit', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
+        expect(isEditorReplayable(createStep({ id: 'c', archiveImageId: 'image-c', stepType: 'save-as-copy', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
+        expect(isEditorReplayable(createStep({ id: 'd', archiveImageId: 'image-d', stepType: 'reference-generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
+    });
+});
+
+function createImage(overrides: Partial<ArchiveImage> = {}): ArchiveImage {
+    return {
+        id: 'image-7',
+        url: 'data:image/png;base64,abc',
+        prompt: 'fallback prompt',
+        quality: 'medium',
+        aspectRatio: '1024x1024',
+        background: 'auto',
+        timestamp: '2026-04-04T08:00:00.000Z',
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        ...overrides,
+    };
+}
+
+function createStep(overrides: Partial<LineageStep> & Pick<LineageStep, 'id' | 'archiveImageId' | 'stepType' | 'timestamp'>): LineageStep {
+    return {
+        parentStepId: null,
+        metadata: {},
+        ...overrides,
+    };
+}

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -1,0 +1,47 @@
+import type { ArchiveImage } from '../db/types';
+import type { GenerateDraft, GenerateLineageSource } from '../generate-session/GenerateSession';
+import type { LineageStep } from './LineageStore';
+
+type ReplayableStep = Pick<LineageStep, 'stepType'>;
+
+export function isGenerateReplayable(step: ReplayableStep) {
+    return step.stepType === 'generation' || step.stepType === 'reference-generation';
+}
+
+export function isEditorReplayable(step: ReplayableStep) {
+    return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
+}
+
+export function buildGenerateReplay(image: ArchiveImage, step: LineageStep): {
+    draft: GenerateDraft;
+    lineageSource: GenerateLineageSource;
+} {
+    return {
+        draft: {
+            prompt: asString(step.metadata.prompt) ?? image.prompt,
+            quality: asQuality(step.metadata.quality) ?? asQuality(image.quality) ?? 'medium',
+            aspectRatio: asString(step.metadata.aspectRatio) ?? image.aspectRatio,
+            background: asBackground(step.metadata.background) ?? asBackground(image.background) ?? 'auto',
+            style: asString(step.metadata.style) ?? image.style ?? 'none',
+            lighting: asString(step.metadata.lighting) ?? image.lighting ?? 'none',
+            palette: asString(step.metadata.palette) ?? image.palette ?? 'none',
+            isSaved: false,
+        },
+        lineageSource: {
+            archiveImageId: step.archiveImageId,
+            stepId: step.id,
+        },
+    };
+}
+
+function asString(value: unknown) {
+    return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asQuality(value: unknown): GenerateDraft['quality'] | null {
+    return value === 'low' || value === 'medium' || value === 'high' ? value : null;
+}
+
+function asBackground(value: unknown): GenerateDraft['background'] | null {
+    return value === 'auto' || value === 'opaque' || value === 'transparent' ? value : null;
+}

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -5,26 +5,26 @@ import type { LineageStep } from './LineageStore';
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 
 export function isGenerateReplayable(step: ReplayableStep) {
-    return step.stepType === 'generation' || step.stepType === 'reference-generation';
+    return step.stepType === 'generation' || step.stepType === 'reference-generation' || step.stepType === 'autopilot-iteration';
 }
 
 export function isEditorReplayable(step: ReplayableStep) {
     return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
 }
 
-export function buildGenerateReplay(image: ArchiveImage, step: LineageStep): {
+export function buildGenerateReplay(image: ArchiveImage | null, step: LineageStep): {
     draft: GenerateDraft;
     lineageSource: GenerateLineageSource;
 } {
     return {
         draft: {
-            prompt: asString(step.metadata.prompt) ?? image.prompt,
-            quality: asQuality(step.metadata.quality) ?? asQuality(image.quality) ?? 'medium',
-            aspectRatio: asString(step.metadata.aspectRatio) ?? image.aspectRatio,
-            background: asBackground(step.metadata.background) ?? asBackground(image.background) ?? 'auto',
-            style: asString(step.metadata.style) ?? image.style ?? 'none',
-            lighting: asString(step.metadata.lighting) ?? image.lighting ?? 'none',
-            palette: asString(step.metadata.palette) ?? image.palette ?? 'none',
+            prompt: asString(step.metadata.prompt) ?? image?.prompt ?? '',
+            quality: asQuality(step.metadata.quality) ?? asQuality(image?.quality) ?? 'medium',
+            aspectRatio: asString(step.metadata.aspectRatio) ?? image?.aspectRatio ?? '1024x1024',
+            background: asBackground(step.metadata.background) ?? asBackground(image?.background) ?? 'auto',
+            style: asString(step.metadata.style) ?? image?.style ?? 'none',
+            lighting: asString(step.metadata.lighting) ?? image?.lighting ?? 'none',
+            palette: asString(step.metadata.palette) ?? image?.palette ?? 'none',
             isSaved: false,
         },
         lineageSource: {

--- a/src/lineage/types.ts
+++ b/src/lineage/types.ts
@@ -1,0 +1,21 @@
+export type LineageStepType =
+    | 'generation'
+    | 'reference-generation'
+    | 'ai-edit'
+    | 'manual-edit'
+    | 'overwrite'
+    | 'save-as-copy'
+    | 'autopilot-iteration';
+
+export interface LineageStep {
+    id: string;
+    archiveImageId: string;
+    parentStepId: string | null;
+    stepType: LineageStepType;
+    timestamp: string;
+    metadata: Record<string, unknown>;
+}
+
+export type SaveLineageStepInput = Omit<LineageStep, 'id'> & {
+    id?: string;
+};

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -15,8 +15,23 @@ export interface OpenAiImageResponse {
     b64_json?: string;
 }
 
+export interface OpenAiResponsesRequest {
+    apiKey: string;
+    systemPrompt: string;
+    userText: string;
+    imageDataUrl?: string;
+}
+
+export interface OpenAiResponsesResponse {
+    outputText: string;
+}
+
 export interface OpenAiImageClient {
     createImage(request: OpenAiImageRequest): Promise<OpenAiImageResponse>;
+}
+
+export interface OpenAiResponsesClient {
+    createResponse(request: OpenAiResponsesRequest): Promise<OpenAiResponsesResponse>;
 }
 
 export const openAiImageClient: OpenAiImageClient = {
@@ -87,3 +102,70 @@ export const openAiImageClient: OpenAiImageClient = {
         return data.data[0];
     },
 };
+
+export const openAiResponsesClient: OpenAiResponsesClient = {
+    async createResponse(request) {
+        const response = await fetch('https://api.openai.com/v1/responses', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${request.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                model: 'gpt-4o',
+                input: [
+                    {
+                        role: 'system',
+                        content: [{ type: 'input_text', text: request.systemPrompt }],
+                    },
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'input_text', text: request.userText },
+                            ...(request.imageDataUrl
+                                ? [{ type: 'input_image', image_url: request.imageDataUrl }]
+                                : []),
+                        ],
+                    },
+                ],
+            }),
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch((): { error?: { message?: string } } | null => null);
+            throw new Error(errorData?.error?.message || `OpenAI API Error: ${response.status}`);
+        }
+
+        const data: unknown = await response.json();
+        const outputText = extractResponseOutputText(data);
+
+        if (!outputText) {
+            throw new Error('No text response returned from OpenAI');
+        }
+
+        return { outputText };
+    },
+};
+
+function extractResponseOutputText(data: unknown) {
+    if (!data || typeof data !== 'object') {
+        return null;
+    }
+
+    const record = data as {
+        output_text?: unknown;
+        output?: Array<{ content?: Array<{ type?: unknown; text?: unknown }> }>;
+    };
+
+    if (typeof record.output_text === 'string' && record.output_text.trim()) {
+        return record.output_text;
+    }
+
+    const textParts = record.output
+        ?.flatMap((item) => item.content ?? [])
+        .filter((content): content is { type: 'output_text'; text: string } => content.type === 'output_text' && typeof content.text === 'string')
+        .map((content) => content.text.trim())
+        .filter(Boolean);
+
+    return textParts && textParts.length > 0 ? textParts.join('\n').trim() : null;
+}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -4,11 +4,12 @@ import type { ArchiveImage } from '../db/types';
 import { useEditorCanvas } from '../editor/useEditorCanvas';
 import { useEditorController } from '../editor/useEditorController';
 import { useEditorSession } from '../editor/useEditorSession';
+import type { EditorSaveContext } from '../editor/saveEditedImage';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
     apiKey: string | null;
-    onSave: (updatedUrl: string, isCopy?: boolean, references?: string[]) => void;
+    onSave: (updatedUrl: string, context: EditorSaveContext) => void;
 }
 
 const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
@@ -21,6 +22,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         setSaturation,
         filter,
         setFilter,
+        adjustments,
         canvasFilter,
         currentImageUrl,
         setCurrentImageUrl,
@@ -54,6 +56,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, apiKey, onSave }) => {
         serializeReferences,
         exportDataUrl,
         exportBlob,
+        adjustments,
         onSave,
     });
 

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -8,7 +8,7 @@ import ReferenceImageModal from '../components/ReferenceImageModal';
 
 interface GenerateViewProps {
     apiKey: string | null;
-    onSaveImage: (image: ArchiveImage) => void;
+    onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
 }
 
 const EXAMPLE_PROMPTS = [

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -5,6 +5,9 @@ import { useGenerateDraft } from '../generate-session/GenerateSession';
 import { useGenerateController } from '../generate-session/useGenerateController';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { DEFAULT_AUTOPILOT_MAX_ITERATIONS, DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD, MAX_AUTOPILOT_ITERATIONS } from '../autopilot/AutopilotSession';
+import { goalPromptTranslator } from '../autopilot/GoalPromptTranslator';
 
 interface GenerateViewProps {
     apiKey: string | null;
@@ -59,8 +62,15 @@ const PALETTES = [
 
 const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [draft, setDraft] = useGenerateDraft();
+    const [mode, setMode] = useLocalStorage<'single-shot' | 'autopilot'>('generate_mode', 'single-shot');
+    const [goal, setGoal] = useLocalStorage('generate_autopilot_goal', '');
+    const [maxIterations, setMaxIterations] = useLocalStorage('generate_autopilot_max_iterations', DEFAULT_AUTOPILOT_MAX_ITERATIONS);
+    const [satisfactionThreshold, setSatisfactionThreshold] = useLocalStorage('generate_autopilot_threshold', DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD);
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
+    const [showCostDisclosure, setShowCostDisclosure] = useState(false);
+    const [autopilotNotice, setAutopilotNotice] = useState<string | null>(null);
+    const [translatingGoal, setTranslatingGoal] = useState(false);
     const { prompt, quality, aspectRatio, background, style, lighting, palette, isSaved } = draft;
     const referenceCollection = useReferenceImageCollection();
     const referenceImages = referenceCollection.files;
@@ -71,8 +81,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         currentResult,
         loading,
         error,
+        autopilot,
         updateDraft,
         generate,
+        runAutopilot,
+        cancelAutopilot,
         save,
         download,
         clear,
@@ -120,6 +133,53 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
         }
     };
 
+    const handleTranslateGoal = async () => {
+        if (!apiKey || !goal.trim()) {
+            return;
+        }
+
+        setTranslatingGoal(true);
+        setAutopilotNotice(null);
+        try {
+            const nextPrompt = await goalPromptTranslator.translate({ goal, apiKey });
+            updateDraft({ prompt: nextPrompt, isSaved: false });
+        } catch (translationError) {
+            setAutopilotNotice(translationError instanceof Error ? translationError.message : 'Failed to translate goal');
+        } finally {
+            setTranslatingGoal(false);
+        }
+    };
+
+    const handleRunAutopilot = async () => {
+        setAutopilotNotice(null);
+        const result = await runAutopilot({
+            goal,
+            maxIterations,
+            satisfactionThreshold,
+        });
+
+        if (!result) {
+            return;
+        }
+
+        if (result.status === 'max-iterations') {
+            setAutopilotNotice('Autopilot reached the iteration limit without meeting the satisfaction threshold.');
+            return;
+        }
+
+        if (result.status === 'cancelled') {
+            setAutopilotNotice('Autopilot was cancelled. Showing the best result so far.');
+            return;
+        }
+
+        if (result.status === 'satisfied' && result.bestIteration) {
+            setAutopilotNotice(`Best result selected from iteration ${result.bestIteration.iterationNumber}.`);
+        }
+    };
+
+    const maxApiCalls = maxIterations * 3;
+    const isAutopilotMode = mode === 'autopilot';
+
 
 
     return (
@@ -131,6 +191,92 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
 
             <div className="generate-grid">
                 <section className="controls-panel glass-panel">
+                    <div className="input-section">
+                        <label>MODE</label>
+                        <div className="toggle-group">
+                            <button
+                                className={!isAutopilotMode ? 'active' : ''}
+                                onClick={() => setMode('single-shot')}
+                            >Single Shot</button>
+                            <button
+                                className={isAutopilotMode ? 'active' : ''}
+                                onClick={() => setMode('autopilot')}
+                            >Autopilot</button>
+                        </div>
+                    </div>
+
+                    {isAutopilotMode && (
+                        <div className="autopilot-panel glass-panel">
+                            <div className="input-section">
+                                <div className="prompt-header">
+                                    <label>GOAL</label>
+                                    <button
+                                        className="aura-btn aura-btn--glass autopilot-inline-btn"
+                                        onClick={() => { void handleTranslateGoal(); }}
+                                        disabled={!goal.trim() || !apiKey || translatingGoal || loading}
+                                    >
+                                        {translatingGoal ? 'Translating...' : 'Translate to Prompt'}
+                                    </button>
+                                </div>
+                                <textarea
+                                    placeholder="Describe the outcome you want in plain language..."
+                                    value={goal}
+                                    onChange={(e) => setGoal(e.target.value)}
+                                    className="prompt-input autopilot-goal-input"
+                                />
+                            </div>
+
+                            <div className="autopilot-settings-grid">
+                                <div className="option-group">
+                                    <label>MAX ITERATIONS</label>
+                                    <input
+                                        type="range"
+                                        min={1}
+                                        max={MAX_AUTOPILOT_ITERATIONS}
+                                        value={maxIterations}
+                                        onChange={(e) => setMaxIterations(Number(e.target.value))}
+                                        className="range-input"
+                                    />
+                                    <span className="autopilot-metric">{maxIterations}</span>
+                                </div>
+
+                                <div className="option-group">
+                                    <label>SATISFACTION THRESHOLD</label>
+                                    <input
+                                        type="range"
+                                        min={50}
+                                        max={100}
+                                        value={satisfactionThreshold}
+                                        onChange={(e) => setSatisfactionThreshold(Number(e.target.value))}
+                                        className="range-input"
+                                    />
+                                    <span className="autopilot-metric">{satisfactionThreshold}/100</span>
+                                </div>
+                            </div>
+
+                            <div className="autopilot-disclosure glass-panel">
+                                <strong>Cost disclosure</strong>
+                                <p>Up to {maxIterations} iterations and roughly {maxApiCalls} API calls per run.</p>
+                            </div>
+
+                            {showCostDisclosure && (
+                                <div className="autopilot-confirmation glass-panel">
+                                    <p>Confirm Autopilot run with up to {maxIterations} iterations and approximately {maxApiCalls} API calls.</p>
+                                    <div className="autopilot-confirmation-actions">
+                                        <button className="aura-btn aura-btn--glass" onClick={() => setShowCostDisclosure(false)}>Cancel</button>
+                                        <button
+                                            className="aura-btn aura-btn--primary"
+                                            onClick={() => {
+                                                setShowCostDisclosure(false);
+                                                void handleRunAutopilot();
+                                            }}
+                                        >Confirm Run</button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
                     <div className="input-section">
                         <div className="prompt-header">
                             <label>PROMPT</label>
@@ -293,26 +439,73 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                         </div>
                     </div>
 
-                    <button
-                        className="aura-btn aura-btn--primary"
-                        onClick={() => { void generate(); }}
-                        disabled={loading || !prompt.trim() || !apiKey}
-                        style={{ width: '100%' }}
-                    >
-                        {loading ? <Loader2 className="spin" size={20} /> : <Sparkles size={20} />}
-                        {loading ? 'Generating...' : 'Generate Image'}
-                    </button>
+                    {isAutopilotMode ? (
+                        <button
+                            className="aura-btn aura-btn--primary"
+                            onClick={() => setShowCostDisclosure(true)}
+                            disabled={loading || !prompt.trim() || !goal.trim() || !apiKey}
+                            style={{ width: '100%' }}
+                        >
+                            {loading ? <Loader2 className="spin" size={20} /> : <Sparkles size={20} />}
+                            {loading ? 'Autopilot Running...' : 'Run Autopilot'}
+                        </button>
+                    ) : (
+                        <button
+                            className="aura-btn aura-btn--primary"
+                            onClick={() => { void generate(); }}
+                            disabled={loading || !prompt.trim() || !apiKey}
+                            style={{ width: '100%' }}
+                        >
+                            {loading ? <Loader2 className="spin" size={20} /> : <Sparkles size={20} />}
+                            {loading ? 'Generating...' : 'Generate Image'}
+                        </button>
+                    )}
+
+                    {isAutopilotMode && autopilot.running && (
+                        <div className="autopilot-live-panel glass-panel">
+                            <div className="autopilot-live-header">
+                                <strong>Iteration {autopilot.iterations.length}/{maxIterations}</strong>
+                                <button className="aura-btn aura-btn--danger" onClick={cancelAutopilot}>Pause / Cancel</button>
+                            </div>
+                            <p className="autopilot-live-feedback">
+                                {autopilot.iterations.at(-1)?.feedback[0] ?? 'Generating the first candidate...'}
+                            </p>
+                            <div className="autopilot-thumbnail-strip">
+                                {autopilot.iterations.map((iteration) => (
+                                    <div key={iteration.stepId} className={`autopilot-thumbnail ${autopilot.bestIterationNumber === iteration.iterationNumber ? 'best' : ''}`}>
+                                        <img src={iteration.imageDataUrl} alt={`Autopilot iteration ${iteration.iterationNumber}`} />
+                                        <span>#{iteration.iterationNumber} · {iteration.score}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
 
                     {!apiKey && (
                         <div className="error-message">API Key missing. Go to Settings to configure.</div>
                     )}
                     {error && <div className="error-message">{error}</div>}
+                    {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
 
                 <section className="preview-panel glass-panel">
                     {currentResult ? (
                         <div className="result-container">
                             <img src={currentResult} alt="Generated result" className="result-image" />
+                            {isAutopilotMode && autopilot.iterations.length > 0 && (
+                                <div className="autopilot-result-banner glass-panel">
+                                    <strong>
+                                        {autopilot.bestIterationNumber ? `Best Autopilot Result: iteration ${autopilot.bestIterationNumber}` : 'Autopilot result'}
+                                    </strong>
+                                    <span>
+                                        {autopilot.status === 'max-iterations' && 'Reached iteration limit without converging.'}
+                                        {autopilot.status === 'cancelled' && 'Run cancelled. Showing the best result to date.'}
+                                        {autopilot.status === 'failed' && autopilot.lastErrorIteration && `Run stopped at iteration ${autopilot.lastErrorIteration}.`}
+                                        {autopilot.status === 'satisfied' && 'Satisfaction threshold reached early.'}
+                                        {autopilot.status === 'running' && 'Autopilot is evaluating and refining this run.'}
+                                    </span>
+                                </div>
+                            )}
                             <div className="result-actions">
                                 <button
                                     onClick={() => { void save(); }}


### PR DESCRIPTION
## Summary
- Add creative lineage persistence, timeline loading, replay and fork actions, and image detail modal history UI so generated and edited images keep their provenance.
- Add autopilot prompt translation, refinement, satisfaction evaluation, and generate-session orchestration to iterate toward a user goal from the Generate view.
- Add archive transfer and persistence support, QA documentation, and focused tests covering lineage, archive transfer, autopilot, and save flows.