### PR TITLE
Migrate persistent localStorage session state to SQLite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/jszip": "^3.4.0",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
@@ -26,11 +28,63 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.0.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.0.tgz",
+      "integrity": "sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -266,6 +320,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -312,6 +376,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -913,6 +1130,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1380,6 +1615,61 @@
       "bin": {
         "sqlite-wasm": "bin/index.js"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1955,6 +2245,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1977,6 +2277,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2003,6 +2313,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2205,12 +2525,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2230,6 +2578,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2247,12 +2602,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2704,6 +3089,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
@@ -2782,6 +3180,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2813,6 +3218,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2947,6 +3403,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2956,6 +3422,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3079,6 +3552,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3175,6 +3661,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3218,6 +3732,13 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3241,6 +3762,16 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3303,6 +3834,19 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -3477,6 +4021,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3536,6 +4087,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3600,6 +4197,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3827,6 +4434,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3891,6 +4546,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/jszip": "^3.4.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
@@ -33,6 +35,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.0.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -5,13 +5,14 @@ import { generateSessionStore } from '../generate-session/GenerateSession';
 import { useAppNotifications } from './useAppNotifications';
 import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';
-import { initializeAuraPersistence } from '../db/AuraPersistence';
 import { saveEditedImage, type EditorSaveContext } from '../editor/saveEditedImage';
 import { lineageStore } from '../lineage/LineageStore';
 import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
+import { useApiKey } from '../session/useApiKey';
 
 export function useAppController() {
-    const { currentView, apiKey, theme, changeView, updateApiKey, toggleTheme } = useAppPreferences();
+    const { currentView, theme, changeView, toggleTheme } = useAppPreferences();
+    const { apiKey, setApiKey, lastError: apiKeyError } = useApiKey();
     const { toasts, addToast, removeToast, notifyError } = useAppNotifications();
     const handleArchiveError = useCallback((error: Error, operation: 'load' | 'save' | 'delete') => {
         notifyError(error, `Archive ${operation} failed`);
@@ -22,11 +23,14 @@ export function useAppController() {
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
 
     useEffect(() => {
-        initializeAuraPersistence().catch((error) => {
-            const nextError = error instanceof Error ? error : new Error('Failed to initialize local storage');
-            notifyError(nextError, 'Storage initialization failed');
-        });
-    }, [notifyError]);
+        if (apiKeyError) {
+            notifyError(apiKeyError.cause, `API key ${apiKeyError.operation} failed`);
+        }
+    }, [apiKeyError, notifyError]);
+
+    const updateApiKey = useCallback((key: string) => {
+        void setApiKey(key);
+    }, [setApiKey]);
 
     const saveImage = useCallback(async (image: ArchiveImage) => {
         const savedImage = await addImage(image);

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useArchiveController } from '../archive/useArchiveController';
 import type { ArchiveImage } from '../db/types';
-import { generateSessionStore } from '../generate-session/GenerateSession';
+import { generateSessionStore } from '../session/sessionBootstrap';
 import { useAppNotifications } from './useAppNotifications';
 import { useAppPreferences } from './useAppPreferences';
 import { useImageArchive } from '../hooks/useImageArchive';

--- a/src/app/useAppPreferences.ts
+++ b/src/app/useAppPreferences.ts
@@ -4,29 +4,15 @@ import type { AppView } from '../types';
 
 export function useAppPreferences() {
     const [currentView, setCurrentView] = useLocalStorage<AppView>('aura_current_view', 'generate');
-    const [apiKey, setApiKey] = useLocalStorage<string>('aura_openapi_key', '');
     const [theme, setTheme] = useLocalStorage<'dark' | 'light'>('aura_theme', 'dark');
 
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
     }, [theme]);
 
-    useEffect(() => {
-        if (!apiKey) {
-            const legacyKey = localStorage.getItem('openai_api_key');
-            if (legacyKey) {
-                setApiKey(legacyKey);
-            }
-        }
-    }, [apiKey, setApiKey]);
-
     const changeView = useCallback((view: AppView) => {
         setCurrentView(view);
     }, [setCurrentView]);
-
-    const updateApiKey = useCallback((key: string) => {
-        setApiKey(key);
-    }, [setApiKey]);
 
     const toggleTheme = useCallback(() => {
         setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark');
@@ -34,10 +20,8 @@ export function useAppPreferences() {
 
     return {
         currentView,
-        apiKey,
         theme,
         changeView,
-        updateApiKey,
         toggleTheme,
     };
 }

--- a/src/autopilot/AutopilotSettings.ts
+++ b/src/autopilot/AutopilotSettings.ts
@@ -1,0 +1,79 @@
+import {
+    DEFAULT_AUTOPILOT_MAX_ITERATIONS,
+    DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD,
+    MAX_AUTOPILOT_ITERATIONS,
+} from './AutopilotSession';
+
+export const AUTOPILOT_MODE_KEY = 'generate_mode';
+export const AUTOPILOT_GOAL_KEY = 'generate_autopilot_goal';
+export const AUTOPILOT_MAX_ITERATIONS_KEY = 'generate_autopilot_max_iterations';
+export const AUTOPILOT_THRESHOLD_KEY = 'generate_autopilot_threshold';
+
+export const LEGACY_AUTOPILOT_KEYS = {
+    mode: AUTOPILOT_MODE_KEY,
+    goal: AUTOPILOT_GOAL_KEY,
+    maxIterations: AUTOPILOT_MAX_ITERATIONS_KEY,
+    satisfactionThreshold: AUTOPILOT_THRESHOLD_KEY,
+} as const;
+
+export type LegacyAutopilotField = keyof typeof LEGACY_AUTOPILOT_KEYS;
+
+export type AutopilotMode = 'single-shot' | 'autopilot';
+
+export interface AutopilotSettings {
+    mode: AutopilotMode;
+    goal: string;
+    maxIterations: number;
+    satisfactionThreshold: number;
+}
+
+export const DEFAULT_AUTOPILOT_SETTINGS: AutopilotSettings = {
+    mode: 'single-shot',
+    goal: '',
+    maxIterations: DEFAULT_AUTOPILOT_MAX_ITERATIONS,
+    satisfactionThreshold: DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD,
+};
+
+export function sanitizeAutopilotSettings(
+    settings: Partial<Record<keyof AutopilotSettings, unknown>>,
+): AutopilotSettings {
+    return {
+        mode: coerceMode(settings.mode),
+        goal: typeof settings.goal === 'string' ? settings.goal : DEFAULT_AUTOPILOT_SETTINGS.goal,
+        maxIterations: coerceMaxIterations(settings.maxIterations),
+        satisfactionThreshold: coerceSatisfactionThreshold(settings.satisfactionThreshold),
+    };
+}
+
+function coerceMode(value: unknown): AutopilotMode {
+    return value === 'single-shot' || value === 'autopilot' ? value : DEFAULT_AUTOPILOT_SETTINGS.mode;
+}
+
+function coerceMaxIterations(value: unknown): number {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+        return DEFAULT_AUTOPILOT_SETTINGS.maxIterations;
+    }
+    const rounded = Math.round(numeric);
+    if (rounded < 1) {
+        return 1;
+    }
+    if (rounded > MAX_AUTOPILOT_ITERATIONS) {
+        return MAX_AUTOPILOT_ITERATIONS;
+    }
+    return rounded;
+}
+
+function coerceSatisfactionThreshold(value: unknown): number {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+        return DEFAULT_AUTOPILOT_SETTINGS.satisfactionThreshold;
+    }
+    if (numeric < 0) {
+        return 0;
+    }
+    if (numeric > 100) {
+        return 100;
+    }
+    return numeric;
+}

--- a/src/autopilot/SQLiteAutopilotSettingsPort.test.ts
+++ b/src/autopilot/SQLiteAutopilotSettingsPort.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { AutopilotSettingsPort } from './SQLiteAutopilotSettingsPort';
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    sanitizeAutopilotSettings,
+    type AutopilotSettings,
+} from './AutopilotSettings';
+
+class InMemoryAutopilotSettingsPort implements AutopilotSettingsPort {
+    private settings: AutopilotSettings | null = null;
+    private rowCount = 0;
+    private initialized = false;
+
+    async init(): Promise<void> {
+        this.initialized = true;
+    }
+
+    async load(): Promise<AutopilotSettings | null> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        return this.settings;
+    }
+
+    async save(settings: AutopilotSettings): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.settings = sanitizeAutopilotSettings(settings);
+        this.rowCount = 1;
+    }
+
+    async clear(): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.settings = null;
+        this.rowCount = 0;
+    }
+
+    getRowCount(): number {
+        return this.rowCount;
+    }
+}
+
+function makeSettings(overrides: Partial<AutopilotSettings> = {}): AutopilotSettings {
+    return {
+        mode: 'autopilot',
+        goal: 'A cozy wintery scene',
+        maxIterations: 6,
+        satisfactionThreshold: 85,
+        ...overrides,
+    };
+}
+
+describe('AutopilotSettingsPort contract', () => {
+    it('returns null for an empty store', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+
+        await expect(port.load()).resolves.toBeNull();
+    });
+
+    it('round-trips saved settings', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+        const settings = makeSettings();
+
+        await port.save(settings);
+
+        await expect(port.load()).resolves.toEqual(settings);
+    });
+
+    it('overwrites settings on subsequent save', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+
+        await port.save(makeSettings({ goal: 'first' }));
+        await port.save(makeSettings({ goal: 'second' }));
+
+        const loaded = await port.load();
+        expect(loaded?.goal).toBe('second');
+    });
+
+    it('keeps the settings table as a singleton across saves', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+
+        await port.save(makeSettings({ goal: 'a' }));
+        await port.save(makeSettings({ goal: 'b' }));
+        await port.save(makeSettings({ goal: 'c' }));
+
+        expect(port.getRowCount()).toBe(1);
+    });
+
+    it('clears the stored value', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+
+        await port.save(makeSettings());
+        await port.clear();
+
+        await expect(port.load()).resolves.toBeNull();
+        expect(port.getRowCount()).toBe(0);
+    });
+
+    it('returns defaults when loading settings saved with missing fields', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+
+        await port.save(sanitizeAutopilotSettings({}));
+
+        await expect(port.load()).resolves.toEqual(DEFAULT_AUTOPILOT_SETTINGS);
+    });
+});

--- a/src/autopilot/SQLiteAutopilotSettingsPort.ts
+++ b/src/autopilot/SQLiteAutopilotSettingsPort.ts
@@ -1,0 +1,86 @@
+import { SQLocal } from 'sqlocal';
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    sanitizeAutopilotSettings,
+    type AutopilotSettings,
+} from './AutopilotSettings';
+
+export interface AutopilotSettingsPort {
+    init(): Promise<void>;
+    load(): Promise<AutopilotSettings | null>;
+    save(settings: AutopilotSettings): Promise<void>;
+    clear(): Promise<void>;
+}
+
+interface AutopilotSettingsRow {
+    mode: string | null;
+    goal: string | null;
+    max_iterations: number | null;
+    satisfaction_threshold: number | null;
+}
+
+export class SQLiteAutopilotSettingsPort implements AutopilotSettingsPort {
+    private readonly sql: SQLocal;
+    private initialized = false;
+
+    constructor(databaseName: string = 'aura_database.sqlite3') {
+        this.sql = new SQLocal(databaseName);
+    }
+
+    async init(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+
+        await this.sql.sql`
+            CREATE TABLE IF NOT EXISTS autopilot_settings (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                mode TEXT,
+                goal TEXT,
+                max_iterations INTEGER,
+                satisfaction_threshold REAL
+            );
+        `;
+
+        this.initialized = true;
+    }
+
+    async load(): Promise<AutopilotSettings | null> {
+        await this.init();
+        const result = await this.sql.sql`
+            SELECT mode, goal, max_iterations, satisfaction_threshold
+            FROM autopilot_settings WHERE id = 1
+        `;
+        const row = (result as AutopilotSettingsRow[])[0];
+        if (!row) {
+            return null;
+        }
+
+        return sanitizeAutopilotSettings({
+            mode: row.mode ?? DEFAULT_AUTOPILOT_SETTINGS.mode,
+            goal: row.goal ?? DEFAULT_AUTOPILOT_SETTINGS.goal,
+            maxIterations: row.max_iterations ?? DEFAULT_AUTOPILOT_SETTINGS.maxIterations,
+            satisfactionThreshold: row.satisfaction_threshold ?? DEFAULT_AUTOPILOT_SETTINGS.satisfactionThreshold,
+        });
+    }
+
+    async save(settings: AutopilotSettings): Promise<void> {
+        await this.init();
+        const sanitized = sanitizeAutopilotSettings(settings);
+        await this.sql.sql`
+            INSERT OR REPLACE INTO autopilot_settings (id, mode, goal, max_iterations, satisfaction_threshold)
+            VALUES (
+                1,
+                ${sanitized.mode},
+                ${sanitized.goal},
+                ${sanitized.maxIterations},
+                ${sanitized.satisfactionThreshold}
+            )
+        `;
+    }
+
+    async clear(): Promise<void> {
+        await this.init();
+        await this.sql.sql`DELETE FROM autopilot_settings WHERE id = 1`;
+    }
+}

--- a/src/components/MigrationPrompt.tsx
+++ b/src/components/MigrationPrompt.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { DatabaseZap, KeyRound, ShieldCheck, X } from 'lucide-react';
+import type { MigrationSnapshot } from '../session/LocalStorageMigrator';
+
+interface MigrationPromptProps {
+    snapshot: MigrationSnapshot;
+    onMigrate: () => void;
+    onDecline: () => void;
+    isMigrating?: boolean;
+}
+
+const MigrationPrompt: React.FC<MigrationPromptProps> = ({ snapshot, onMigrate, onDecline, isMigrating = false }) => {
+    return (
+        <div className="modal-overlay dialog-overlay" role="dialog" aria-modal="true" aria-labelledby="migration-prompt-title">
+            <div className="modal-content glass-panel migration-prompt" onClick={(event) => event.stopPropagation()}>
+                <div className="modal-icon-container">
+                    <div className="modal-icon info">
+                        <DatabaseZap size={24} />
+                    </div>
+                </div>
+
+                <div className="confirm-body">
+                    <h3 id="migration-prompt-title">Move session data to local SQLite?</h3>
+                    <p>
+                        We can migrate values that are currently stored in your browser's localStorage
+                        into the local SQLite database. The data never leaves your machine.
+                    </p>
+
+                    <ul className="migration-prompt__list">
+                        <li className="migration-prompt__row">
+                            <span className="migration-prompt__row-icon">
+                                <KeyRound size={16} />
+                            </span>
+                            <span className="migration-prompt__row-label">OpenAI API key</span>
+                            <span className={`migration-prompt__row-status ${snapshot.apiKey.present ? 'is-present' : 'is-absent'}`}>
+                                {snapshot.apiKey.present ? 'present' : 'not set'}
+                            </span>
+                        </li>
+                    </ul>
+
+                    <div className="migration-prompt__notice">
+                        <ShieldCheck size={14} />
+                        <span>API key value is never displayed here.</span>
+                    </div>
+
+                    <div className="confirm-actions">
+                        <button className="glass-btn" onClick={onDecline} disabled={isMigrating}>
+                            <X size={16} />
+                            Decline
+                        </button>
+                        <button
+                            className="action-button primary"
+                            onClick={onMigrate}
+                            disabled={isMigrating}
+                        >
+                            {isMigrating ? 'Migrating…' : 'Migrate'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default MigrationPrompt;

--- a/src/components/MigrationPrompt.tsx
+++ b/src/components/MigrationPrompt.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DatabaseZap, FileText, KeyRound, Rocket, ShieldCheck, X } from 'lucide-react';
+import { DatabaseZap, FileText, GitBranch, KeyRound, Rocket, ShieldCheck, X } from 'lucide-react';
 import type { MigrationSnapshot } from '../session/LocalStorageMigrator';
 
 interface MigrationPromptProps {
@@ -52,6 +52,15 @@ const MigrationPrompt: React.FC<MigrationPromptProps> = ({ snapshot, onMigrate, 
                             <span className="migration-prompt__row-label">Autopilot settings</span>
                             <span className={`migration-prompt__row-status ${snapshot.autopilotSettings.present ? 'is-present' : 'is-absent'}`}>
                                 {snapshot.autopilotSettings.present ? 'present' : 'not set'}
+                            </span>
+                        </li>
+                        <li className="migration-prompt__row">
+                            <span className="migration-prompt__row-icon">
+                                <GitBranch size={16} />
+                            </span>
+                            <span className="migration-prompt__row-label">Lineage source</span>
+                            <span className={`migration-prompt__row-status ${snapshot.generateLineageSource.present ? 'is-present' : 'is-absent'}`}>
+                                {snapshot.generateLineageSource.present ? 'present' : 'not set'}
                             </span>
                         </li>
                     </ul>

--- a/src/components/MigrationPrompt.tsx
+++ b/src/components/MigrationPrompt.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DatabaseZap, KeyRound, ShieldCheck, X } from 'lucide-react';
+import { DatabaseZap, FileText, KeyRound, ShieldCheck, X } from 'lucide-react';
 import type { MigrationSnapshot } from '../session/LocalStorageMigrator';
 
 interface MigrationPromptProps {
@@ -34,6 +34,15 @@ const MigrationPrompt: React.FC<MigrationPromptProps> = ({ snapshot, onMigrate, 
                             <span className="migration-prompt__row-label">OpenAI API key</span>
                             <span className={`migration-prompt__row-status ${snapshot.apiKey.present ? 'is-present' : 'is-absent'}`}>
                                 {snapshot.apiKey.present ? 'present' : 'not set'}
+                            </span>
+                        </li>
+                        <li className="migration-prompt__row">
+                            <span className="migration-prompt__row-icon">
+                                <FileText size={16} />
+                            </span>
+                            <span className="migration-prompt__row-label">Generate draft</span>
+                            <span className={`migration-prompt__row-status ${snapshot.generateDraft.present ? 'is-present' : 'is-absent'}`}>
+                                {snapshot.generateDraft.present ? 'present' : 'not set'}
                             </span>
                         </li>
                     </ul>

--- a/src/components/MigrationPrompt.tsx
+++ b/src/components/MigrationPrompt.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DatabaseZap, FileText, KeyRound, ShieldCheck, X } from 'lucide-react';
+import { DatabaseZap, FileText, KeyRound, Rocket, ShieldCheck, X } from 'lucide-react';
 import type { MigrationSnapshot } from '../session/LocalStorageMigrator';
 
 interface MigrationPromptProps {
@@ -43,6 +43,15 @@ const MigrationPrompt: React.FC<MigrationPromptProps> = ({ snapshot, onMigrate, 
                             <span className="migration-prompt__row-label">Generate draft</span>
                             <span className={`migration-prompt__row-status ${snapshot.generateDraft.present ? 'is-present' : 'is-absent'}`}>
                                 {snapshot.generateDraft.present ? 'present' : 'not set'}
+                            </span>
+                        </li>
+                        <li className="migration-prompt__row">
+                            <span className="migration-prompt__row-icon">
+                                <Rocket size={16} />
+                            </span>
+                            <span className="migration-prompt__row-label">Autopilot settings</span>
+                            <span className={`migration-prompt__row-status ${snapshot.autopilotSettings.present ? 'is-present' : 'is-absent'}`}>
+                                {snapshot.autopilotSettings.present ? 'present' : 'not set'}
                             </span>
                         </li>
                     </ul>

--- a/src/credentials/SQLiteCredentialsPort.test.ts
+++ b/src/credentials/SQLiteCredentialsPort.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { CredentialsPort } from './SQLiteCredentialsPort';
+
+class InMemoryCredentialsPort implements CredentialsPort {
+    private apiKey: string | null = null;
+    private rowCount = 0;
+    private initialized = false;
+
+    async init(): Promise<void> {
+        this.initialized = true;
+    }
+
+    async load(): Promise<string | null> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        return this.apiKey;
+    }
+
+    async save(apiKey: string): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.apiKey = apiKey;
+        this.rowCount = 1;
+    }
+
+    async clear(): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.apiKey = null;
+        this.rowCount = 0;
+    }
+
+    getRowCount(): number {
+        return this.rowCount;
+    }
+}
+
+describe('CredentialsPort contract', () => {
+    it('returns null for an empty store', async () => {
+        const port = new InMemoryCredentialsPort();
+
+        await expect(port.load()).resolves.toBeNull();
+    });
+
+    it('round-trips a saved api key', async () => {
+        const port = new InMemoryCredentialsPort();
+
+        await port.save('sk-test-123');
+
+        await expect(port.load()).resolves.toBe('sk-test-123');
+    });
+
+    it('overwrites the api key on subsequent save', async () => {
+        const port = new InMemoryCredentialsPort();
+
+        await port.save('sk-first');
+        await port.save('sk-second');
+
+        await expect(port.load()).resolves.toBe('sk-second');
+    });
+
+    it('keeps the credentials table as a singleton across saves', async () => {
+        const port = new InMemoryCredentialsPort();
+
+        await port.save('sk-first');
+        await port.save('sk-second');
+        await port.save('sk-third');
+
+        expect(port.getRowCount()).toBe(1);
+    });
+
+    it('clears the stored value', async () => {
+        const port = new InMemoryCredentialsPort();
+
+        await port.save('sk-test-123');
+        await port.clear();
+
+        await expect(port.load()).resolves.toBeNull();
+        expect(port.getRowCount()).toBe(0);
+    });
+});

--- a/src/credentials/SQLiteCredentialsPort.ts
+++ b/src/credentials/SQLiteCredentialsPort.ts
@@ -1,0 +1,58 @@
+import { SQLocal } from 'sqlocal';
+
+export interface CredentialsPort {
+    init(): Promise<void>;
+    load(): Promise<string | null>;
+    save(apiKey: string): Promise<void>;
+    clear(): Promise<void>;
+}
+
+interface CredentialsRow {
+    openai_api_key: string | null;
+}
+
+export class SQLiteCredentialsPort implements CredentialsPort {
+    private readonly sql: SQLocal;
+    private initialized = false;
+
+    constructor(databaseName: string = 'aura_database.sqlite3') {
+        this.sql = new SQLocal(databaseName);
+    }
+
+    async init(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+
+        await this.sql.sql`
+            CREATE TABLE IF NOT EXISTS app_credentials (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                openai_api_key TEXT
+            );
+        `;
+
+        this.initialized = true;
+    }
+
+    async load(): Promise<string | null> {
+        await this.init();
+        const result = await this.sql.sql`
+            SELECT openai_api_key FROM app_credentials WHERE id = 1
+        `;
+        const row = (result as CredentialsRow[])[0];
+        return row?.openai_api_key ?? null;
+    }
+
+    async save(apiKey: string): Promise<void> {
+        await this.init();
+        await this.sql.sql`
+            INSERT OR REPLACE INTO app_credentials (id, openai_api_key)
+            VALUES (1, ${apiKey})
+        `;
+    }
+
+    async clear(): Promise<void> {
+        await this.init();
+        await this.sql.sql`DELETE FROM app_credentials WHERE id = 1`;
+    }
+}

--- a/src/db/AuraPersistence.ts
+++ b/src/db/AuraPersistence.ts
@@ -1,8 +1,10 @@
 import { SQLiteArchiveMetadataPort } from '../archive/SQLiteArchiveMetadataPort';
+import { SQLiteCredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import { SQLiteLineageMetadataPort } from '../lineage/SQLiteLineageMetadataPort';
 
 export const archiveMetadataPort = new SQLiteArchiveMetadataPort();
 export const lineageMetadataPort = new SQLiteLineageMetadataPort();
+export const credentialsPort = new SQLiteCredentialsPort();
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -11,6 +13,7 @@ export function initializeAuraPersistence(): Promise<void> {
         initializationPromise = Promise.all([
             archiveMetadataPort.init(),
             lineageMetadataPort.init(),
+            credentialsPort.init(),
         ]).then(() => undefined);
     }
 

--- a/src/db/AuraPersistence.ts
+++ b/src/db/AuraPersistence.ts
@@ -1,10 +1,12 @@
 import { SQLiteArchiveMetadataPort } from '../archive/SQLiteArchiveMetadataPort';
 import { SQLiteCredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import { SQLiteGenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
 import { SQLiteLineageMetadataPort } from '../lineage/SQLiteLineageMetadataPort';
 
 export const archiveMetadataPort = new SQLiteArchiveMetadataPort();
 export const lineageMetadataPort = new SQLiteLineageMetadataPort();
 export const credentialsPort = new SQLiteCredentialsPort();
+export const generateDraftPort = new SQLiteGenerateDraftPort();
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -14,6 +16,7 @@ export function initializeAuraPersistence(): Promise<void> {
             archiveMetadataPort.init(),
             lineageMetadataPort.init(),
             credentialsPort.init(),
+            generateDraftPort.init(),
         ]).then(() => undefined);
     }
 

--- a/src/db/AuraPersistence.ts
+++ b/src/db/AuraPersistence.ts
@@ -2,6 +2,7 @@ import { SQLiteArchiveMetadataPort } from '../archive/SQLiteArchiveMetadataPort'
 import { SQLiteAutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import { SQLiteCredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import { SQLiteGenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import { SQLiteGenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
 import { SQLiteLineageMetadataPort } from '../lineage/SQLiteLineageMetadataPort';
 
 export const archiveMetadataPort = new SQLiteArchiveMetadataPort();
@@ -9,6 +10,7 @@ export const lineageMetadataPort = new SQLiteLineageMetadataPort();
 export const credentialsPort = new SQLiteCredentialsPort();
 export const generateDraftPort = new SQLiteGenerateDraftPort();
 export const autopilotSettingsPort = new SQLiteAutopilotSettingsPort();
+export const generateLineageSourcePort = new SQLiteGenerateLineageSourcePort();
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -20,6 +22,7 @@ export function initializeAuraPersistence(): Promise<void> {
             credentialsPort.init(),
             generateDraftPort.init(),
             autopilotSettingsPort.init(),
+            generateLineageSourcePort.init(),
         ]).then(() => undefined);
     }
 

--- a/src/db/AuraPersistence.ts
+++ b/src/db/AuraPersistence.ts
@@ -1,4 +1,5 @@
 import { SQLiteArchiveMetadataPort } from '../archive/SQLiteArchiveMetadataPort';
+import { SQLiteAutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import { SQLiteCredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import { SQLiteGenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
 import { SQLiteLineageMetadataPort } from '../lineage/SQLiteLineageMetadataPort';
@@ -7,6 +8,7 @@ export const archiveMetadataPort = new SQLiteArchiveMetadataPort();
 export const lineageMetadataPort = new SQLiteLineageMetadataPort();
 export const credentialsPort = new SQLiteCredentialsPort();
 export const generateDraftPort = new SQLiteGenerateDraftPort();
+export const autopilotSettingsPort = new SQLiteAutopilotSettingsPort();
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -17,6 +19,7 @@ export function initializeAuraPersistence(): Promise<void> {
             lineageMetadataPort.init(),
             credentialsPort.init(),
             generateDraftPort.init(),
+            autopilotSettingsPort.init(),
         ]).then(() => undefined);
     }
 

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -8,7 +8,7 @@ import { useSessionContext } from '../session/sessionContextValue';
 export const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
-const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
+export const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 const VALID_ASPECT_RATIOS = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
 
 export const LEGACY_DRAFT_KEYS = {
@@ -58,10 +58,16 @@ export interface SessionDraftHandle {
     setDraft(draft: GenerateDraft): Promise<void> | void;
 }
 
+export interface SessionLineageSourceHandle {
+    getLineageSource(): GenerateLineageSource | null;
+    setLineageSource(source: GenerateLineageSource): Promise<void> | void;
+    clearLineageSource(): Promise<void> | void;
+}
+
 interface CreateGenerateSessionStoreDeps {
     draftHandle: SessionDraftHandle;
+    lineageSourceHandle: SessionLineageSourceHandle;
     blobStorage?: StorageProvider;
-    localStorage?: Storage;
 }
 
 export const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
@@ -77,13 +83,13 @@ export const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
 
 class HandleBackedGenerateSessionStore implements GenerateSessionStore {
     private readonly blobStorage: StorageProvider;
-    private readonly localStorage: Storage;
     private readonly draftHandle: SessionDraftHandle;
+    private readonly lineageSourceHandle: SessionLineageSourceHandle;
 
-    constructor(blobStorage: StorageProvider, localStorage: Storage, draftHandle: SessionDraftHandle) {
+    constructor(blobStorage: StorageProvider, draftHandle: SessionDraftHandle, lineageSourceHandle: SessionLineageSourceHandle) {
         this.blobStorage = blobStorage;
-        this.localStorage = localStorage;
         this.draftHandle = draftHandle;
+        this.lineageSourceHandle = lineageSourceHandle;
     }
 
     readDraft(): GenerateDraft {
@@ -122,15 +128,20 @@ class HandleBackedGenerateSessionStore implements GenerateSessionStore {
     }
 
     loadLineageSource(): GenerateLineageSource | null {
-        return this.readJson<GenerateLineageSource>(GENERATE_LINEAGE_SOURCE_KEY);
+        return this.lineageSourceHandle.getLineageSource();
     }
 
     saveLineageSource(source: GenerateLineageSource): void {
-        this.localStorage.setItem(GENERATE_LINEAGE_SOURCE_KEY, JSON.stringify(source));
+        const sanitized = sanitizeGenerateLineageSource(source);
+        if (!sanitized) {
+            void this.lineageSourceHandle.clearLineageSource();
+            return;
+        }
+        void this.lineageSourceHandle.setLineageSource(sanitized);
     }
 
     clearLineageSource(): void {
-        this.localStorage.removeItem(GENERATE_LINEAGE_SOURCE_KEY);
+        void this.lineageSourceHandle.clearLineageSource();
     }
 
     loadCurrentResult(): Promise<string | null> {
@@ -160,26 +171,13 @@ class HandleBackedGenerateSessionStore implements GenerateSessionStore {
             return [];
         }
     }
-
-    private readJson<T>(key: string): T | null {
-        const rawValue = this.localStorage.getItem(key);
-        if (!rawValue) {
-            return null;
-        }
-
-        try {
-            return JSON.parse(rawValue) as T;
-        } catch {
-            return null;
-        }
-    }
 }
 
 export function createGenerateSessionStore(deps: CreateGenerateSessionStoreDeps): GenerateSessionStore {
     return new HandleBackedGenerateSessionStore(
         deps.blobStorage ?? storage,
-        deps.localStorage ?? window.localStorage,
         deps.draftHandle,
+        deps.lineageSourceHandle,
     );
 }
 
@@ -202,6 +200,21 @@ export function useGenerateDraft(): readonly [GenerateDraft, Dispatch<SetStateAc
     );
     return [draft, setDraft] as const;
 }
+
+export const sanitizeGenerateLineageSource = (
+    source: Partial<Record<keyof GenerateLineageSource, unknown>> | null | undefined,
+): GenerateLineageSource | null => {
+    if (!source || typeof source !== 'object') {
+        return null;
+    }
+    const archiveImageId = typeof source.archiveImageId === 'string' ? source.archiveImageId : '';
+    if (archiveImageId.length === 0) {
+        return null;
+    }
+    const stepIdValue = source.stepId;
+    const stepId = typeof stepIdValue === 'string' && stepIdValue.length > 0 ? stepIdValue : null;
+    return { archiveImageId, stepId };
+};
 
 export const sanitizeGenerateDraft = (draft: Partial<Record<keyof GenerateDraft, unknown>>): GenerateDraft => ({
     prompt: typeof draft.prompt === 'string' ? draft.prompt : DEFAULT_GENERATE_DRAFT.prompt,

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -1,15 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { storage, type StorageProvider } from '../services/StorageService';
 import type { ImageBackground, ImageQuality } from '../utils/openai';
+import { useSessionContext } from '../session/sessionContextValue';
 
-const GENERATE_DRAFT_KEY = 'aura_generate_draft';
+export const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
 const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 const VALID_ASPECT_RATIOS = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
 
-const LEGACY_KEYS = {
+export const LEGACY_DRAFT_KEYS = {
     prompt: 'aura_generate_prompt',
     quality: 'aura_generate_quality',
     aspectRatio: 'aura_generate_aspect_ratio',
@@ -19,6 +21,8 @@ const LEGACY_KEYS = {
     palette: 'aura_generate_palette',
     isSaved: 'aura_generate_is_saved',
 } as const;
+
+export type LegacyDraftField = keyof typeof LEGACY_DRAFT_KEYS;
 
 export interface GenerateDraft {
     prompt: string;
@@ -49,12 +53,18 @@ export interface GenerateSessionStore {
     consumeTransferredReferences(): Promise<string[]>;
 }
 
+export interface SessionDraftHandle {
+    getDraft(): GenerateDraft;
+    setDraft(draft: GenerateDraft): Promise<void> | void;
+}
+
 interface CreateGenerateSessionStoreDeps {
+    draftHandle: SessionDraftHandle;
     blobStorage?: StorageProvider;
     localStorage?: Storage;
 }
 
-const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
+export const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
     prompt: '',
     quality: 'medium',
     aspectRatio: '1024x1024',
@@ -65,37 +75,24 @@ const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
     isSaved: false,
 };
 
-class LocalGenerateSessionStore implements GenerateSessionStore {
+class HandleBackedGenerateSessionStore implements GenerateSessionStore {
     private readonly blobStorage: StorageProvider;
     private readonly localStorage: Storage;
+    private readonly draftHandle: SessionDraftHandle;
 
-    constructor(blobStorage: StorageProvider, localStorage: Storage) {
+    constructor(blobStorage: StorageProvider, localStorage: Storage, draftHandle: SessionDraftHandle) {
         this.blobStorage = blobStorage;
         this.localStorage = localStorage;
+        this.draftHandle = draftHandle;
     }
 
     readDraft(): GenerateDraft {
-        const storedDraft = this.readJson<GenerateDraft>(GENERATE_DRAFT_KEY);
-        if (storedDraft) {
-            return sanitizeGenerateDraft(storedDraft);
-        }
-
-        return sanitizeGenerateDraft({
-            prompt: this.readLegacyValue(LEGACY_KEYS.prompt, DEFAULT_GENERATE_DRAFT.prompt),
-            quality: this.readLegacyValue(LEGACY_KEYS.quality, DEFAULT_GENERATE_DRAFT.quality),
-            aspectRatio: this.readLegacyValue(LEGACY_KEYS.aspectRatio, DEFAULT_GENERATE_DRAFT.aspectRatio),
-            background: this.readLegacyValue(LEGACY_KEYS.background, DEFAULT_GENERATE_DRAFT.background),
-            style: this.readLegacyValue(LEGACY_KEYS.style, DEFAULT_GENERATE_DRAFT.style),
-            lighting: this.readLegacyValue(LEGACY_KEYS.lighting, DEFAULT_GENERATE_DRAFT.lighting),
-            palette: this.readLegacyValue(LEGACY_KEYS.palette, DEFAULT_GENERATE_DRAFT.palette),
-            isSaved: this.readLegacyValue(LEGACY_KEYS.isSaved, DEFAULT_GENERATE_DRAFT.isSaved),
-        });
+        return sanitizeGenerateDraft(this.draftHandle.getDraft());
     }
 
     writeDraft(draft: GenerateDraft): void {
         const nextDraft = sanitizeGenerateDraft(draft);
-        this.localStorage.setItem(GENERATE_DRAFT_KEY, JSON.stringify(nextDraft));
-        this.clearLegacyDraftKeys();
+        void this.draftHandle.setDraft(nextDraft);
     }
 
     async transferFromArchive(image: ArchiveImage, lineageSource: GenerateLineageSource | null = { archiveImageId: image.id }, draftOverrides: Partial<GenerateDraft> = {}): Promise<void> {
@@ -164,19 +161,6 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         }
     }
 
-    private readLegacyValue<T>(key: string, fallback: T): T {
-        const rawValue = this.localStorage.getItem(key);
-        if (!rawValue) {
-            return fallback;
-        }
-
-        try {
-            return JSON.parse(rawValue) as T;
-        } catch {
-            return rawValue as T;
-        }
-    }
-
     private readJson<T>(key: string): T | null {
         const rawValue = this.localStorage.getItem(key);
         if (!rawValue) {
@@ -189,32 +173,37 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
             return null;
         }
     }
-
-    private clearLegacyDraftKeys() {
-        Object.values(LEGACY_KEYS).forEach((key) => this.localStorage.removeItem(key));
-    }
 }
 
-export function createGenerateSessionStore(deps: CreateGenerateSessionStoreDeps = {}): GenerateSessionStore {
-    return new LocalGenerateSessionStore(
+export function createGenerateSessionStore(deps: CreateGenerateSessionStoreDeps): GenerateSessionStore {
+    return new HandleBackedGenerateSessionStore(
         deps.blobStorage ?? storage,
         deps.localStorage ?? window.localStorage,
+        deps.draftHandle,
     );
 }
 
-export const generateSessionStore = createGenerateSessionStore();
-
-export function useGenerateDraft(store: GenerateSessionStore = generateSessionStore) {
-    const [draft, setDraft] = useState<GenerateDraft>(() => store.readDraft());
-
+export function useGenerateDraft(): readonly [GenerateDraft, Dispatch<SetStateAction<GenerateDraft>>] {
+    const ctx = useSessionContext();
+    const draft = ctx.state.snapshot.generateDraft;
+    const draftRef = useRef(draft);
     useEffect(() => {
-        store.writeDraft(draft);
-    }, [draft, store]);
-
+        draftRef.current = draft;
+    }, [draft]);
+    const { setGenerateDraft } = ctx;
+    const setDraft = useCallback<Dispatch<SetStateAction<GenerateDraft>>>(
+        (update) => {
+            const next = typeof update === 'function'
+                ? (update as (current: GenerateDraft) => GenerateDraft)(draftRef.current)
+                : update;
+            void setGenerateDraft(sanitizeGenerateDraft(next));
+        },
+        [setGenerateDraft],
+    );
     return [draft, setDraft] as const;
 }
 
-const sanitizeGenerateDraft = (draft: Partial<GenerateDraft>): GenerateDraft => ({
+export const sanitizeGenerateDraft = (draft: Partial<Record<keyof GenerateDraft, unknown>>): GenerateDraft => ({
     prompt: typeof draft.prompt === 'string' ? draft.prompt : DEFAULT_GENERATE_DRAFT.prompt,
     quality: coerceQuality(draft.quality),
     aspectRatio: typeof draft.aspectRatio === 'string' && VALID_ASPECT_RATIOS.has(draft.aspectRatio)

--- a/src/generate-session/SQLiteGenerateDraftPort.test.ts
+++ b/src/generate-session/SQLiteGenerateDraftPort.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { GenerateDraftPort } from './SQLiteGenerateDraftPort';
+import type { GenerateDraft } from './GenerateSession';
+
+class InMemoryGenerateDraftPort implements GenerateDraftPort {
+    private draft: GenerateDraft | null = null;
+    private rowCount = 0;
+    private initialized = false;
+
+    async init(): Promise<void> {
+        this.initialized = true;
+    }
+
+    async load(): Promise<GenerateDraft | null> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        return this.draft;
+    }
+
+    async save(draft: GenerateDraft): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.draft = { ...draft };
+        this.rowCount = 1;
+    }
+
+    async clear(): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.draft = null;
+        this.rowCount = 0;
+    }
+
+    getRowCount(): number {
+        return this.rowCount;
+    }
+}
+
+function makeDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft {
+    return {
+        prompt: 'a koi pond at dusk',
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'auto',
+        style: 'risograph poster',
+        lighting: 'golden hour',
+        palette: 'copper + teal + cream',
+        isSaved: true,
+        ...overrides,
+    };
+}
+
+describe('GenerateDraftPort contract', () => {
+    it('returns null for an empty store', async () => {
+        const port = new InMemoryGenerateDraftPort();
+
+        await expect(port.load()).resolves.toBeNull();
+    });
+
+    it('round-trips a saved draft', async () => {
+        const port = new InMemoryGenerateDraftPort();
+        const draft = makeDraft();
+
+        await port.save(draft);
+
+        await expect(port.load()).resolves.toEqual(draft);
+    });
+
+    it('overwrites the draft on subsequent save', async () => {
+        const port = new InMemoryGenerateDraftPort();
+
+        await port.save(makeDraft({ prompt: 'first' }));
+        await port.save(makeDraft({ prompt: 'second' }));
+
+        const loaded = await port.load();
+        expect(loaded?.prompt).toBe('second');
+    });
+
+    it('keeps the draft table as a singleton across saves', async () => {
+        const port = new InMemoryGenerateDraftPort();
+
+        await port.save(makeDraft({ prompt: 'first' }));
+        await port.save(makeDraft({ prompt: 'second' }));
+        await port.save(makeDraft({ prompt: 'third' }));
+
+        expect(port.getRowCount()).toBe(1);
+    });
+
+    it('clears the stored value', async () => {
+        const port = new InMemoryGenerateDraftPort();
+
+        await port.save(makeDraft());
+        await port.clear();
+
+        await expect(port.load()).resolves.toBeNull();
+        expect(port.getRowCount()).toBe(0);
+    });
+});

--- a/src/generate-session/SQLiteGenerateDraftPort.ts
+++ b/src/generate-session/SQLiteGenerateDraftPort.ts
@@ -1,0 +1,99 @@
+import { SQLocal } from 'sqlocal';
+import type { GenerateDraft } from './GenerateSession';
+import { DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft } from './GenerateSession';
+
+export interface GenerateDraftPort {
+    init(): Promise<void>;
+    load(): Promise<GenerateDraft | null>;
+    save(draft: GenerateDraft): Promise<void>;
+    clear(): Promise<void>;
+}
+
+interface GenerateDraftRow {
+    prompt: string | null;
+    quality: string | null;
+    aspect_ratio: string | null;
+    background: string | null;
+    style: string | null;
+    lighting: string | null;
+    palette: string | null;
+    is_saved: number | null;
+}
+
+export class SQLiteGenerateDraftPort implements GenerateDraftPort {
+    private readonly sql: SQLocal;
+    private initialized = false;
+
+    constructor(databaseName: string = 'aura_database.sqlite3') {
+        this.sql = new SQLocal(databaseName);
+    }
+
+    async init(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+
+        await this.sql.sql`
+            CREATE TABLE IF NOT EXISTS generate_draft (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                prompt TEXT,
+                quality TEXT,
+                aspect_ratio TEXT,
+                background TEXT,
+                style TEXT,
+                lighting TEXT,
+                palette TEXT,
+                is_saved INTEGER
+            );
+        `;
+
+        this.initialized = true;
+    }
+
+    async load(): Promise<GenerateDraft | null> {
+        await this.init();
+        const result = await this.sql.sql`
+            SELECT prompt, quality, aspect_ratio, background, style, lighting, palette, is_saved
+            FROM generate_draft WHERE id = 1
+        `;
+        const row = (result as GenerateDraftRow[])[0];
+        if (!row) {
+            return null;
+        }
+
+        return sanitizeGenerateDraft({
+            prompt: row.prompt ?? DEFAULT_GENERATE_DRAFT.prompt,
+            quality: row.quality ?? DEFAULT_GENERATE_DRAFT.quality,
+            aspectRatio: row.aspect_ratio ?? DEFAULT_GENERATE_DRAFT.aspectRatio,
+            background: row.background ?? DEFAULT_GENERATE_DRAFT.background,
+            style: row.style ?? DEFAULT_GENERATE_DRAFT.style,
+            lighting: row.lighting ?? DEFAULT_GENERATE_DRAFT.lighting,
+            palette: row.palette ?? DEFAULT_GENERATE_DRAFT.palette,
+            isSaved: row.is_saved === 1,
+        });
+    }
+
+    async save(draft: GenerateDraft): Promise<void> {
+        await this.init();
+        const sanitized = sanitizeGenerateDraft(draft);
+        await this.sql.sql`
+            INSERT OR REPLACE INTO generate_draft (id, prompt, quality, aspect_ratio, background, style, lighting, palette, is_saved)
+            VALUES (
+                1,
+                ${sanitized.prompt},
+                ${sanitized.quality},
+                ${sanitized.aspectRatio},
+                ${sanitized.background},
+                ${sanitized.style},
+                ${sanitized.lighting},
+                ${sanitized.palette},
+                ${sanitized.isSaved ? 1 : 0}
+            )
+        `;
+    }
+
+    async clear(): Promise<void> {
+        await this.init();
+        await this.sql.sql`DELETE FROM generate_draft WHERE id = 1`;
+    }
+}

--- a/src/generate-session/SQLiteGenerateLineageSourcePort.test.ts
+++ b/src/generate-session/SQLiteGenerateLineageSourcePort.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { GenerateLineageSourcePort } from './SQLiteGenerateLineageSourcePort';
+import type { GenerateLineageSource } from './GenerateSession';
+
+class InMemoryGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    private source: GenerateLineageSource | null = null;
+    private rowPresent = false;
+    private rowCount = 0;
+    private initialized = false;
+
+    async init(): Promise<void> {
+        this.initialized = true;
+    }
+
+    async load(): Promise<GenerateLineageSource | null> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        if (!this.rowPresent) {
+            return null;
+        }
+        return this.source;
+    }
+
+    async save(source: GenerateLineageSource): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.source = { archiveImageId: source.archiveImageId, stepId: source.stepId ?? null };
+        this.rowPresent = true;
+        this.rowCount = 1;
+    }
+
+    async clear(): Promise<void> {
+        if (!this.initialized) {
+            await this.init();
+        }
+        this.source = null;
+        this.rowPresent = false;
+        this.rowCount = 0;
+    }
+
+    getRowCount(): number {
+        return this.rowCount;
+    }
+
+    rowExists(): boolean {
+        return this.rowPresent;
+    }
+}
+
+function makeSource(overrides: Partial<GenerateLineageSource> = {}): GenerateLineageSource {
+    return {
+        archiveImageId: 'archive-1',
+        stepId: 'step-1',
+        ...overrides,
+    };
+}
+
+describe('GenerateLineageSourcePort contract', () => {
+    it('returns null for an empty store', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+
+        await expect(port.load()).resolves.toBeNull();
+    });
+
+    it('round-trips a saved lineage source', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+        const source = makeSource();
+
+        await port.save(source);
+
+        await expect(port.load()).resolves.toEqual(source);
+    });
+
+    it('round-trips a lineage source with a null step id', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+        const source = makeSource({ stepId: null });
+
+        await port.save(source);
+
+        await expect(port.load()).resolves.toEqual({ archiveImageId: 'archive-1', stepId: null });
+    });
+
+    it('overwrites the lineage source on subsequent save', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+
+        await port.save(makeSource({ archiveImageId: 'first' }));
+        await port.save(makeSource({ archiveImageId: 'second' }));
+
+        const loaded = await port.load();
+        expect(loaded?.archiveImageId).toBe('second');
+    });
+
+    it('keeps the lineage source table as a singleton across saves', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+
+        await port.save(makeSource({ archiveImageId: 'first' }));
+        await port.save(makeSource({ archiveImageId: 'second' }));
+        await port.save(makeSource({ archiveImageId: 'third' }));
+
+        expect(port.getRowCount()).toBe(1);
+    });
+
+    it('clears the stored value and distinguishes absence from a null step id', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+
+        await port.save(makeSource({ stepId: null }));
+        expect(port.rowExists()).toBe(true);
+        await expect(port.load()).resolves.toEqual({ archiveImageId: 'archive-1', stepId: null });
+
+        await port.clear();
+
+        expect(port.rowExists()).toBe(false);
+        await expect(port.load()).resolves.toBeNull();
+        expect(port.getRowCount()).toBe(0);
+    });
+});

--- a/src/generate-session/SQLiteGenerateLineageSourcePort.ts
+++ b/src/generate-session/SQLiteGenerateLineageSourcePort.ts
@@ -1,0 +1,77 @@
+import { SQLocal } from 'sqlocal';
+import type { GenerateLineageSource } from './GenerateSession';
+
+export interface GenerateLineageSourcePort {
+    init(): Promise<void>;
+    load(): Promise<GenerateLineageSource | null>;
+    save(source: GenerateLineageSource): Promise<void>;
+    clear(): Promise<void>;
+}
+
+interface GenerateLineageSourceRow {
+    archive_image_id: string | null;
+    step_id: string | null;
+}
+
+export class SQLiteGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    private readonly sql: SQLocal;
+    private initialized = false;
+
+    constructor(databaseName: string = 'aura_database.sqlite3') {
+        this.sql = new SQLocal(databaseName);
+    }
+
+    async init(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+
+        await this.sql.sql`
+            CREATE TABLE IF NOT EXISTS generate_lineage_source (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                archive_image_id TEXT,
+                step_id TEXT
+            );
+        `;
+
+        this.initialized = true;
+    }
+
+    async load(): Promise<GenerateLineageSource | null> {
+        await this.init();
+        const result = await this.sql.sql`
+            SELECT archive_image_id, step_id
+            FROM generate_lineage_source WHERE id = 1
+        `;
+        const row = (result as GenerateLineageSourceRow[])[0];
+        if (!row) {
+            return null;
+        }
+
+        if (typeof row.archive_image_id !== 'string' || row.archive_image_id.length === 0) {
+            return null;
+        }
+
+        return {
+            archiveImageId: row.archive_image_id,
+            stepId: row.step_id,
+        };
+    }
+
+    async save(source: GenerateLineageSource): Promise<void> {
+        await this.init();
+        await this.sql.sql`
+            INSERT OR REPLACE INTO generate_lineage_source (id, archive_image_id, step_id)
+            VALUES (
+                1,
+                ${source.archiveImageId},
+                ${source.stepId ?? null}
+            )
+        `;
+    }
+
+    async clear(): Promise<void> {
+        await this.init();
+        await this.sql.sql`DELETE FROM generate_lineage_source WHERE id = 1`;
+    }
+}

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
+import { generateSessionStore } from '../session/sessionBootstrap';
+import type { GenerateDraft, GenerateSessionStore } from './GenerateSession';
 import { imageWorkflow, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';

--- a/src/generate-session/useGenerateDraft.test.tsx
+++ b/src/generate-session/useGenerateDraft.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { SessionProvider } from '../session/SessionContext';
+import { createSessionHydrator, type SessionHydrator } from '../session/SessionHydrator';
+import { DEFAULT_GENERATE_DRAFT, useGenerateDraft, type GenerateDraft } from './GenerateSession';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from './SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from './SQLiteGenerateLineageSourcePort';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+
+class InMemoryGenerateDraftPort implements GenerateDraftPort {
+    draft: GenerateDraft | null;
+    saveCalls: GenerateDraft[] = [];
+    clearCalls = 0;
+
+    constructor(initial: GenerateDraft | null = null) {
+        this.draft = initial;
+    }
+
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateDraft | null> { return this.draft; }
+    async save(draft: GenerateDraft): Promise<void> {
+        this.saveCalls.push(draft);
+        this.draft = draft;
+    }
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.draft = null;
+    }
+}
+
+class FailingOnSaveDraftPort implements GenerateDraftPort {
+    saveAttempts = 0;
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateDraft | null> { return null; }
+    async save(): Promise<void> {
+        this.saveAttempts += 1;
+        throw new Error('save draft failed');
+    }
+    async clear(): Promise<void> {}
+}
+
+const emptyCredentialsPort: CredentialsPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyAutopilotPort: AutopilotSettingsPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyLineageSourcePort: GenerateLineageSourcePort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+function makeHydratorWithDraft(draftPort: GenerateDraftPort): SessionHydrator {
+    return createSessionHydrator({
+        credentialsPort: emptyCredentialsPort,
+        generateDraftPort: draftPort,
+        autopilotSettingsPort: emptyAutopilotPort,
+        generateLineageSourcePort: emptyLineageSourcePort,
+    });
+}
+
+async function renderUseGenerateDraft(hydrator: SessionHydrator) {
+    await hydrator.hydrate();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+    );
+
+    const result = renderHook(() => useGenerateDraft(), { wrapper });
+    await waitFor(() => {
+        const [draft] = result.result.current;
+        expect(draft).toBeDefined();
+    });
+    return result;
+}
+
+function makeDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft {
+    return {
+        prompt: 'a koi pond at dusk',
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'auto',
+        style: 'risograph poster',
+        lighting: 'golden hour',
+        palette: 'copper + teal + cream',
+        isSaved: false,
+        ...overrides,
+    };
+}
+
+describe('useGenerateDraft', () => {
+    it('reflects the hydrated draft from the session snapshot', async () => {
+        const stored = makeDraft({ prompt: 'stored prompt' });
+        const port = new InMemoryGenerateDraftPort(stored);
+        const hydrator = makeHydratorWithDraft(port);
+
+        const { result } = await renderUseGenerateDraft(hydrator);
+        const [draft] = result.current;
+
+        expect(draft).toEqual(stored);
+    });
+
+    it('falls back to default draft when the port is empty', async () => {
+        const port = new InMemoryGenerateDraftPort(null);
+        const hydrator = makeHydratorWithDraft(port);
+
+        const { result } = await renderUseGenerateDraft(hydrator);
+        const [draft] = result.current;
+
+        expect(draft).toEqual(DEFAULT_GENERATE_DRAFT);
+    });
+
+    it('updates the snapshot optimistically and saves to the port when called with a value', async () => {
+        const port = new InMemoryGenerateDraftPort(makeDraft());
+        const hydrator = makeHydratorWithDraft(port);
+
+        const { result } = await renderUseGenerateDraft(hydrator);
+
+        const next = makeDraft({ prompt: 'next prompt' });
+        await act(async () => {
+            const [, setDraft] = result.current;
+            setDraft(next);
+            // let the microtask that invokes port.save resolve
+            await Promise.resolve();
+        });
+
+        const [draft] = result.current;
+        expect(draft).toEqual(next);
+        expect(port.saveCalls.at(-1)).toEqual(next);
+    });
+
+    it('supports the functional updater form', async () => {
+        const port = new InMemoryGenerateDraftPort(makeDraft({ prompt: 'seed' }));
+        const hydrator = makeHydratorWithDraft(port);
+
+        const { result } = await renderUseGenerateDraft(hydrator);
+
+        await act(async () => {
+            const [, setDraft] = result.current;
+            setDraft((current) => ({ ...current, prompt: 'updated via fn' }));
+            await Promise.resolve();
+        });
+
+        const [draft] = result.current;
+        expect(draft.prompt).toBe('updated via fn');
+        expect(port.saveCalls.at(-1)?.prompt).toBe('updated via fn');
+    });
+
+    it('surfaces save errors via the session state without corrupting the optimistic snapshot', async () => {
+        const port = new FailingOnSaveDraftPort();
+        const hydrator = makeHydratorWithDraft(port);
+
+        const { result } = await renderUseGenerateDraft(hydrator);
+
+        const next = makeDraft({ prompt: 'doomed prompt' });
+        await act(async () => {
+            const [, setDraft] = result.current;
+            setDraft(next);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        const [draft] = result.current;
+        expect(draft).toEqual(next);
+        expect(port.saveAttempts).toBe(1);
+        expect(hydrator.getState().lastError?.domain).toBe('generateDraft');
+        expect(hydrator.getState().lastError?.operation).toBe('save');
+    });
+
+    it('notifies consumers on every change', async () => {
+        const port = new InMemoryGenerateDraftPort();
+        const hydrator = makeHydratorWithDraft(port);
+
+        const spy = vi.fn();
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+        );
+
+        await hydrator.hydrate();
+        const { result } = renderHook(() => {
+            const value = useGenerateDraft();
+            spy(value[0].prompt);
+            return value;
+        }, { wrapper });
+
+        await waitFor(() => expect(spy).toHaveBeenCalled());
+        const callsAfterInitial = spy.mock.calls.length;
+
+        await act(async () => {
+            const [, setDraft] = result.current;
+            setDraft(makeDraft({ prompt: 'trigger-change' }));
+            await Promise.resolve();
+        });
+
+        expect(spy.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+    });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -2192,3 +2192,105 @@ textarea {
     font-size: 0.8rem;
     border-radius: var(--radius-sm);
 }
+
+/* --- Hydration Loader --- */
+.hydration-loader {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    background: var(--bg-main, #0b0b0f);
+    color: var(--text-muted, rgba(255, 255, 255, 0.7));
+    font-size: 0.95rem;
+    z-index: 5000;
+}
+
+.hydration-loader__spinner {
+    animation: hydration-spin 1s linear infinite;
+}
+
+@keyframes hydration-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* --- Migration Prompt --- */
+.modal-content.migration-prompt {
+    width: 90vw !important;
+    max-width: 520px !important;
+    height: auto !important;
+    padding: 2.5rem !important;
+    flex-direction: row;
+    border-radius: 24px;
+    gap: 1.5rem;
+    align-items: flex-start;
+    animation: dialog-pop 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    background: rgba(15, 15, 18, 0.9) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.migration-prompt__list {
+    list-style: none;
+    margin: 0 0 1.5rem 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.migration-prompt__row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.migration-prompt__row-icon {
+    display: inline-flex;
+    width: 28px;
+    height: 28px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: rgba(168, 85, 247, 0.15);
+    color: #c084fc;
+}
+
+.migration-prompt__row-label {
+    flex: 1;
+    font-size: 0.9rem;
+    color: var(--text-main);
+}
+
+.migration-prompt__row-status {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+}
+
+.migration-prompt__row-status.is-present {
+    background: rgba(16, 185, 129, 0.15);
+    color: #10b981;
+}
+
+.migration-prompt__row-status.is-absent {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-muted);
+}
+
+.migration-prompt__notice {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-bottom: 1.5rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { SessionProvider } from './session/SessionContext'
+import { MigrationGate } from './session/MigrationGate'
+import { localStorageMigrator, sessionHydrator } from './session/sessionBootstrap'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SessionProvider hydrator={sessionHydrator}>
+      <MigrationGate migrator={localStorageMigrator} hydrator={sessionHydrator}>
+        <App />
+      </MigrationGate>
+    </SessionProvider>
   </StrictMode>,
 )

--- a/src/session/LocalStorageMigrator.test.ts
+++ b/src/session/LocalStorageMigrator.test.ts
@@ -6,6 +6,13 @@ import {
     createLocalStorageMigrator,
     type LocalStorageMigrator,
 } from './LocalStorageMigrator';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    LEGACY_AUTOPILOT_KEYS,
+    sanitizeAutopilotSettings,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
 import {
@@ -97,11 +104,39 @@ class FailingGenerateDraftPort implements GenerateDraftPort {
     async clear(): Promise<void> {}
 }
 
+class InMemoryAutopilotSettingsPort implements AutopilotSettingsPort {
+    settings: AutopilotSettings | null = null;
+    saveCount = 0;
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<AutopilotSettings | null> {
+        return this.settings;
+    }
+
+    async save(settings: AutopilotSettings): Promise<void> {
+        this.settings = { ...settings };
+        this.saveCount += 1;
+    }
+
+    async clear(): Promise<void> {
+        this.settings = null;
+    }
+}
+
+class FailingAutopilotSettingsPort implements AutopilotSettingsPort {
+    async init(): Promise<void> {}
+    async load(): Promise<AutopilotSettings | null> { return null; }
+    async save(): Promise<void> { throw new Error('autopilot write failed'); }
+    async clear(): Promise<void> {}
+}
+
 interface Harness {
     migrator: LocalStorageMigrator;
     storage: MemoryStorage;
     credentialsPort: InMemoryCredentialsPort;
     draftPort: InMemoryGenerateDraftPort;
+    autopilotPort: InMemoryAutopilotSettingsPort;
 }
 
 function createHarness(
@@ -109,6 +144,7 @@ function createHarness(
     overrides: {
         credentialsPort?: CredentialsPort;
         generateDraftPort?: GenerateDraftPort;
+        autopilotSettingsPort?: AutopilotSettingsPort;
     } = {},
 ): Harness {
     const storage = new MemoryStorage();
@@ -117,9 +153,11 @@ function createHarness(
     }
     const credentialsPort = overrides.credentialsPort ?? new InMemoryCredentialsPort();
     const draftPort = overrides.generateDraftPort ?? new InMemoryGenerateDraftPort();
+    const autopilotPort = overrides.autopilotSettingsPort ?? new InMemoryAutopilotSettingsPort();
     const migrator = createLocalStorageMigrator({
         credentialsPort,
         generateDraftPort: draftPort,
+        autopilotSettingsPort: autopilotPort,
         localStorage: storage,
     });
     return {
@@ -127,6 +165,7 @@ function createHarness(
         storage,
         credentialsPort: credentialsPort as InMemoryCredentialsPort,
         draftPort: draftPort as InMemoryGenerateDraftPort,
+        autopilotPort: autopilotPort as InMemoryAutopilotSettingsPort,
     };
 }
 
@@ -139,6 +178,17 @@ function makeStoredDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft 
     };
 }
 
+function makeStoredAutopilot(overrides: Partial<AutopilotSettings> = {}): AutopilotSettings {
+    return {
+        ...DEFAULT_AUTOPILOT_SETTINGS,
+        mode: 'autopilot',
+        goal: 'stored goal',
+        maxIterations: 5,
+        satisfactionThreshold: 80,
+        ...overrides,
+    };
+}
+
 describe('LocalStorageMigrator.detect', () => {
     it('reports everything as absent when nothing is stored', () => {
         const { migrator } = createHarness();
@@ -146,6 +196,7 @@ describe('LocalStorageMigrator.detect', () => {
         expect(migrator.detect()).toEqual({
             apiKey: { present: false },
             generateDraft: { present: false },
+            autopilotSettings: { present: false },
         });
         expect(migrator.hasMigratableData()).toBe(false);
     });
@@ -198,6 +249,23 @@ describe('LocalStorageMigrator.detect', () => {
         });
 
         expect(migrator.detect().generateDraft.present).toBe(false);
+    });
+
+    it('detects autopilot settings when any of the four legacy keys is present', () => {
+        const { migrator } = createHarness({
+            [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+        });
+
+        expect(migrator.detect().autopilotSettings.present).toBe(true);
+        expect(migrator.hasMigratableData()).toBe(true);
+    });
+
+    it('reports autopilot settings absent when no autopilot keys exist', () => {
+        const { migrator } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+        });
+
+        expect(migrator.detect().autopilotSettings.present).toBe(false);
     });
 });
 
@@ -375,17 +443,144 @@ describe('LocalStorageMigrator.migrate draft branch', () => {
     });
 });
 
+describe('LocalStorageMigrator.migrate autopilot branch', () => {
+    it('composes settings from all four autopilot keys, migrates them, and removes the source keys', async () => {
+        const { migrator, storage, autopilotPort } = createHarness({
+            [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+            [LEGACY_AUTOPILOT_KEYS.goal]: JSON.stringify('a cozy scene'),
+            [LEGACY_AUTOPILOT_KEYS.maxIterations]: JSON.stringify(7),
+            [LEGACY_AUTOPILOT_KEYS.satisfactionThreshold]: JSON.stringify(75),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.autopilotSettings).toEqual({ detected: true, migrated: true });
+        expect(autopilotPort.settings).toEqual({
+            mode: 'autopilot',
+            goal: 'a cozy scene',
+            maxIterations: 7,
+            satisfactionThreshold: 75,
+        });
+        for (const key of Object.values(LEGACY_AUTOPILOT_KEYS)) {
+            expect(storage.getItem(key)).toBeNull();
+        }
+    });
+
+    it('migrates a partial autopilot record, filling missing fields with defaults', async () => {
+        const { migrator, autopilotPort } = createHarness({
+            [LEGACY_AUTOPILOT_KEYS.goal]: JSON.stringify('only goal set'),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.autopilotSettings.migrated).toBe(true);
+        expect(autopilotPort.settings).toEqual({
+            ...DEFAULT_AUTOPILOT_SETTINGS,
+            goal: 'only goal set',
+        });
+    });
+
+    it('reports autopilot absence when no autopilot keys are present', async () => {
+        const { migrator, autopilotPort } = createHarness();
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.autopilotSettings).toEqual({ detected: false, migrated: false });
+        expect(autopilotPort.settings).toBeNull();
+    });
+
+    it('leaves autopilot source keys intact when the autopilot port write fails', async () => {
+        const { migrator, storage } = createHarness(
+            {
+                [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+                [LEGACY_AUTOPILOT_KEYS.goal]: JSON.stringify('unchanged goal'),
+            },
+            { autopilotSettingsPort: new FailingAutopilotSettingsPort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.autopilotSettings.migrated).toBe(false);
+        expect(outcome.autopilotSettings.error?.message).toBe('autopilot write failed');
+        expect(storage.getItem(LEGACY_AUTOPILOT_KEYS.mode)).toBe(JSON.stringify('autopilot'));
+        expect(storage.getItem(LEGACY_AUTOPILOT_KEYS.goal)).toBe(JSON.stringify('unchanged goal'));
+    });
+
+    it('isolates autopilot failure from api key and draft success', async () => {
+        const storedDraft = makeStoredDraft();
+        const { migrator, storage, credentialsPort, draftPort } = createHarness(
+            {
+                [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+                [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+                [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+            },
+            { autopilotSettingsPort: new FailingAutopilotSettingsPort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: true, migrated: true });
+        expect(outcome.generateDraft).toEqual({ detected: true, migrated: true });
+        expect(outcome.autopilotSettings.migrated).toBe(false);
+        expect(credentialsPort.apiKey).toBe('sk-current');
+        expect(draftPort.draft).toEqual(storedDraft);
+        expect(storage.getItem(LEGACY_AUTOPILOT_KEYS.mode)).toBe(JSON.stringify('autopilot'));
+    });
+
+    it('is idempotent — second migrate finds no autopilot data after success', async () => {
+        const { migrator, autopilotPort } = createHarness({
+            [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+        });
+
+        await migrator.migrate();
+        const before = autopilotPort.saveCount;
+        const outcome = await migrator.migrate();
+
+        expect(outcome.autopilotSettings).toEqual({ detected: false, migrated: false });
+        expect(autopilotPort.saveCount).toBe(before);
+    });
+
+    it('migrates all four domains together in a single pass', async () => {
+        const storedDraft = makeStoredDraft();
+        const storedAutopilot = makeStoredAutopilot();
+        const { migrator, storage, credentialsPort, draftPort, autopilotPort } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+            [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+            [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify(storedAutopilot.mode),
+            [LEGACY_AUTOPILOT_KEYS.goal]: JSON.stringify(storedAutopilot.goal),
+            [LEGACY_AUTOPILOT_KEYS.maxIterations]: JSON.stringify(storedAutopilot.maxIterations),
+            [LEGACY_AUTOPILOT_KEYS.satisfactionThreshold]: JSON.stringify(storedAutopilot.satisfactionThreshold),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey.migrated).toBe(true);
+        expect(outcome.generateDraft.migrated).toBe(true);
+        expect(outcome.autopilotSettings.migrated).toBe(true);
+        expect(credentialsPort.apiKey).toBe('sk-current');
+        expect(draftPort.draft).toEqual(storedDraft);
+        expect(autopilotPort.settings).toEqual(sanitizeAutopilotSettings(storedAutopilot));
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).toBeNull();
+        for (const key of Object.values(LEGACY_AUTOPILOT_KEYS)) {
+            expect(storage.getItem(key)).toBeNull();
+        }
+    });
+});
+
 describe('LocalStorageMigrator.decline + decision', () => {
     it('preserves source data and flips the flag on decline', () => {
         const { migrator, storage } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
             [GENERATE_DRAFT_KEY]: JSON.stringify(makeStoredDraft()),
+            [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
         });
 
         migrator.decline();
 
         expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBe(JSON.stringify('sk-current'));
         expect(storage.getItem(GENERATE_DRAFT_KEY)).not.toBeNull();
+        expect(storage.getItem(LEGACY_AUTOPILOT_KEYS.mode)).toBe(JSON.stringify('autopilot'));
         expect(migrator.getDecision()).toBe('declined');
     });
 

--- a/src/session/LocalStorageMigrator.test.ts
+++ b/src/session/LocalStorageMigrator.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+    API_KEY_LEGACY_LS_KEY,
+    API_KEY_PRIMARY_LS_KEY,
+    MIGRATION_DECISION_KEY,
+    createLocalStorageMigrator,
+    type LocalStorageMigrator,
+} from './LocalStorageMigrator';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+
+class MemoryStorage implements Storage {
+    private readonly map = new Map<string, string>();
+
+    get length(): number {
+        return this.map.size;
+    }
+
+    clear(): void {
+        this.map.clear();
+    }
+
+    getItem(key: string): string | null {
+        return this.map.has(key) ? (this.map.get(key) as string) : null;
+    }
+
+    key(index: number): string | null {
+        return Array.from(this.map.keys())[index] ?? null;
+    }
+
+    removeItem(key: string): void {
+        this.map.delete(key);
+    }
+
+    setItem(key: string, value: string): void {
+        this.map.set(key, value);
+    }
+}
+
+class InMemoryCredentialsPort implements CredentialsPort {
+    apiKey: string | null = null;
+    saveCount = 0;
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<string | null> {
+        return this.apiKey;
+    }
+
+    async save(apiKey: string): Promise<void> {
+        this.apiKey = apiKey;
+        this.saveCount += 1;
+    }
+
+    async clear(): Promise<void> {
+        this.apiKey = null;
+    }
+}
+
+class FailingCredentialsPort implements CredentialsPort {
+    async init(): Promise<void> {}
+    async load(): Promise<string | null> { return null; }
+    async save(): Promise<void> { throw new Error('write failed'); }
+    async clear(): Promise<void> {}
+}
+
+interface Harness {
+    migrator: LocalStorageMigrator;
+    storage: MemoryStorage;
+    port: InMemoryCredentialsPort;
+}
+
+function createHarness(seed: Record<string, string> = {}, port: CredentialsPort = new InMemoryCredentialsPort()): Harness {
+    const storage = new MemoryStorage();
+    for (const [key, value] of Object.entries(seed)) {
+        storage.setItem(key, value);
+    }
+    const migrator = createLocalStorageMigrator({ credentialsPort: port, localStorage: storage });
+    return { migrator, storage, port: port as InMemoryCredentialsPort };
+}
+
+describe('LocalStorageMigrator.detect', () => {
+    it('reports api key as absent when nothing is stored', () => {
+        const { migrator } = createHarness();
+
+        expect(migrator.detect()).toEqual({ apiKey: { present: false } });
+        expect(migrator.hasMigratableData()).toBe(false);
+    });
+
+    it('detects an api key stored under the current key', () => {
+        const { migrator } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+        });
+
+        expect(migrator.detect().apiKey.present).toBe(true);
+        expect(migrator.hasMigratableData()).toBe(true);
+    });
+
+    it('detects an api key stored under the legacy key only', () => {
+        const { migrator } = createHarness({
+            [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
+        });
+
+        expect(migrator.detect().apiKey.present).toBe(true);
+    });
+
+    it('treats an empty string value as absent', () => {
+        const { migrator } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify(''),
+        });
+
+        expect(migrator.detect().apiKey.present).toBe(false);
+    });
+});
+
+describe('LocalStorageMigrator.migrate', () => {
+    it('writes the current api key through the port and removes both source keys on success', async () => {
+        const { migrator, storage, port } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+            [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: true, migrated: true });
+        expect(port.apiKey).toBe('sk-current');
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
+        expect(storage.getItem(API_KEY_LEGACY_LS_KEY)).toBeNull();
+        expect(migrator.getDecision()).toBe('migrated');
+    });
+
+    it('migrates the legacy api key when the current key is missing', async () => {
+        const { migrator, storage, port } = createHarness({
+            [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
+        });
+
+        await migrator.migrate();
+
+        expect(port.apiKey).toBe('sk-legacy-raw');
+        expect(storage.getItem(API_KEY_LEGACY_LS_KEY)).toBeNull();
+    });
+
+    it('flips the decision to migrated even when no data was present', async () => {
+        const { migrator, port } = createHarness();
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: false, migrated: false });
+        expect(port.apiKey).toBeNull();
+        expect(migrator.getDecision()).toBe('migrated');
+    });
+
+    it('leaves the source keys intact when the port write fails', async () => {
+        const { migrator, storage } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+            [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
+        }, new FailingCredentialsPort());
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey.migrated).toBe(false);
+        expect(outcome.apiKey.error?.message).toBe('write failed');
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBe(JSON.stringify('sk-current'));
+        expect(storage.getItem(API_KEY_LEGACY_LS_KEY)).toBe('sk-legacy-raw');
+        expect(migrator.getDecision()).toBe('migrated');
+    });
+
+    it('is idempotent when invoked again with no migratable data left', async () => {
+        const { migrator, port } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+        });
+
+        await migrator.migrate();
+        const before = port.saveCount;
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: false, migrated: false });
+        expect(port.saveCount).toBe(before);
+    });
+});
+
+describe('LocalStorageMigrator.decline + decision', () => {
+    it('preserves source data and flips the flag on decline', () => {
+        const { migrator, storage } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+        });
+
+        migrator.decline();
+
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBe(JSON.stringify('sk-current'));
+        expect(migrator.getDecision()).toBe('declined');
+    });
+
+    it('returns null for the decision before any choice', () => {
+        const { migrator } = createHarness();
+
+        expect(migrator.getDecision()).toBeNull();
+    });
+
+    it('restores prompt eligibility after resetDecision', () => {
+        const { migrator, storage } = createHarness();
+
+        migrator.decline();
+        expect(migrator.getDecision()).toBe('declined');
+
+        migrator.resetDecision();
+        expect(migrator.getDecision()).toBeNull();
+        expect(storage.getItem(MIGRATION_DECISION_KEY)).toBeNull();
+    });
+});

--- a/src/session/LocalStorageMigrator.test.ts
+++ b/src/session/LocalStorageMigrator.test.ts
@@ -15,11 +15,14 @@ import {
 } from '../autopilot/AutopilotSettings';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
 import {
     DEFAULT_GENERATE_DRAFT,
     GENERATE_DRAFT_KEY,
+    GENERATE_LINEAGE_SOURCE_KEY,
     LEGACY_DRAFT_KEYS,
     type GenerateDraft,
+    type GenerateLineageSource,
 } from '../generate-session/GenerateSession';
 
 class MemoryStorage implements Storage {
@@ -131,12 +134,40 @@ class FailingAutopilotSettingsPort implements AutopilotSettingsPort {
     async clear(): Promise<void> {}
 }
 
+class InMemoryGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    source: GenerateLineageSource | null = null;
+    saveCount = 0;
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateLineageSource | null> {
+        return this.source;
+    }
+
+    async save(source: GenerateLineageSource): Promise<void> {
+        this.source = { archiveImageId: source.archiveImageId, stepId: source.stepId ?? null };
+        this.saveCount += 1;
+    }
+
+    async clear(): Promise<void> {
+        this.source = null;
+    }
+}
+
+class FailingGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateLineageSource | null> { return null; }
+    async save(): Promise<void> { throw new Error('lineage source write failed'); }
+    async clear(): Promise<void> {}
+}
+
 interface Harness {
     migrator: LocalStorageMigrator;
     storage: MemoryStorage;
     credentialsPort: InMemoryCredentialsPort;
     draftPort: InMemoryGenerateDraftPort;
     autopilotPort: InMemoryAutopilotSettingsPort;
+    lineageSourcePort: InMemoryGenerateLineageSourcePort;
 }
 
 function createHarness(
@@ -145,6 +176,7 @@ function createHarness(
         credentialsPort?: CredentialsPort;
         generateDraftPort?: GenerateDraftPort;
         autopilotSettingsPort?: AutopilotSettingsPort;
+        generateLineageSourcePort?: GenerateLineageSourcePort;
     } = {},
 ): Harness {
     const storage = new MemoryStorage();
@@ -154,10 +186,12 @@ function createHarness(
     const credentialsPort = overrides.credentialsPort ?? new InMemoryCredentialsPort();
     const draftPort = overrides.generateDraftPort ?? new InMemoryGenerateDraftPort();
     const autopilotPort = overrides.autopilotSettingsPort ?? new InMemoryAutopilotSettingsPort();
+    const lineageSourcePort = overrides.generateLineageSourcePort ?? new InMemoryGenerateLineageSourcePort();
     const migrator = createLocalStorageMigrator({
         credentialsPort,
         generateDraftPort: draftPort,
         autopilotSettingsPort: autopilotPort,
+        generateLineageSourcePort: lineageSourcePort,
         localStorage: storage,
     });
     return {
@@ -166,6 +200,7 @@ function createHarness(
         credentialsPort: credentialsPort as InMemoryCredentialsPort,
         draftPort: draftPort as InMemoryGenerateDraftPort,
         autopilotPort: autopilotPort as InMemoryAutopilotSettingsPort,
+        lineageSourcePort: lineageSourcePort as InMemoryGenerateLineageSourcePort,
     };
 }
 
@@ -189,6 +224,14 @@ function makeStoredAutopilot(overrides: Partial<AutopilotSettings> = {}): Autopi
     };
 }
 
+function makeStoredLineageSource(overrides: Partial<GenerateLineageSource> = {}): GenerateLineageSource {
+    return {
+        archiveImageId: 'stored-archive-image',
+        stepId: 'stored-step',
+        ...overrides,
+    };
+}
+
 describe('LocalStorageMigrator.detect', () => {
     it('reports everything as absent when nothing is stored', () => {
         const { migrator } = createHarness();
@@ -197,6 +240,7 @@ describe('LocalStorageMigrator.detect', () => {
             apiKey: { present: false },
             generateDraft: { present: false },
             autopilotSettings: { present: false },
+            generateLineageSource: { present: false },
         });
         expect(migrator.hasMigratableData()).toBe(false);
     });
@@ -266,6 +310,31 @@ describe('LocalStorageMigrator.detect', () => {
         });
 
         expect(migrator.detect().autopilotSettings.present).toBe(false);
+    });
+
+    it('detects a lineage source stored under the lineage key', () => {
+        const { migrator } = createHarness({
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(makeStoredLineageSource()),
+        });
+
+        expect(migrator.detect().generateLineageSource.present).toBe(true);
+        expect(migrator.hasMigratableData()).toBe(true);
+    });
+
+    it('reports lineage source absent when the stored value is malformed', () => {
+        const { migrator } = createHarness({
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify({ stepId: 'orphan' }),
+        });
+
+        expect(migrator.detect().generateLineageSource.present).toBe(false);
+    });
+
+    it('reports lineage source absent when no lineage key exists', () => {
+        const { migrator } = createHarness({
+            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+        });
+
+        expect(migrator.detect().generateLineageSource.present).toBe(false);
     });
 });
 
@@ -543,13 +612,15 @@ describe('LocalStorageMigrator.migrate autopilot branch', () => {
     it('migrates all four domains together in a single pass', async () => {
         const storedDraft = makeStoredDraft();
         const storedAutopilot = makeStoredAutopilot();
-        const { migrator, storage, credentialsPort, draftPort, autopilotPort } = createHarness({
+        const storedLineageSource = makeStoredLineageSource();
+        const { migrator, storage, credentialsPort, draftPort, autopilotPort, lineageSourcePort } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
             [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
             [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify(storedAutopilot.mode),
             [LEGACY_AUTOPILOT_KEYS.goal]: JSON.stringify(storedAutopilot.goal),
             [LEGACY_AUTOPILOT_KEYS.maxIterations]: JSON.stringify(storedAutopilot.maxIterations),
             [LEGACY_AUTOPILOT_KEYS.satisfactionThreshold]: JSON.stringify(storedAutopilot.satisfactionThreshold),
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(storedLineageSource),
         });
 
         const outcome = await migrator.migrate();
@@ -557,23 +628,117 @@ describe('LocalStorageMigrator.migrate autopilot branch', () => {
         expect(outcome.apiKey.migrated).toBe(true);
         expect(outcome.generateDraft.migrated).toBe(true);
         expect(outcome.autopilotSettings.migrated).toBe(true);
+        expect(outcome.generateLineageSource.migrated).toBe(true);
         expect(credentialsPort.apiKey).toBe('sk-current');
         expect(draftPort.draft).toEqual(storedDraft);
         expect(autopilotPort.settings).toEqual(sanitizeAutopilotSettings(storedAutopilot));
+        expect(lineageSourcePort.source).toEqual(storedLineageSource);
         expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
         expect(storage.getItem(GENERATE_DRAFT_KEY)).toBeNull();
+        expect(storage.getItem(GENERATE_LINEAGE_SOURCE_KEY)).toBeNull();
         for (const key of Object.values(LEGACY_AUTOPILOT_KEYS)) {
             expect(storage.getItem(key)).toBeNull();
         }
     });
 });
 
+describe('LocalStorageMigrator.migrate lineage source branch', () => {
+    it('writes the stored lineage source through the port and removes the key on success', async () => {
+        const stored = makeStoredLineageSource();
+        const { migrator, storage, lineageSourcePort } = createHarness({
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(stored),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateLineageSource).toEqual({ detected: true, migrated: true });
+        expect(lineageSourcePort.source).toEqual(stored);
+        expect(storage.getItem(GENERATE_LINEAGE_SOURCE_KEY)).toBeNull();
+    });
+
+    it('migrates a lineage source with a null step id', async () => {
+        const stored = makeStoredLineageSource({ stepId: null });
+        const { migrator, lineageSourcePort } = createHarness({
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(stored),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateLineageSource.migrated).toBe(true);
+        expect(lineageSourcePort.source).toEqual({ archiveImageId: 'stored-archive-image', stepId: null });
+    });
+
+    it('reports lineage source absence when no lineage key is present', async () => {
+        const { migrator, lineageSourcePort } = createHarness();
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateLineageSource).toEqual({ detected: false, migrated: false });
+        expect(lineageSourcePort.source).toBeNull();
+    });
+
+    it('leaves the lineage key intact when the port write fails', async () => {
+        const stored = makeStoredLineageSource();
+        const { migrator, storage } = createHarness(
+            {
+                [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(stored),
+            },
+            { generateLineageSourcePort: new FailingGenerateLineageSourcePort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateLineageSource.migrated).toBe(false);
+        expect(outcome.generateLineageSource.error?.message).toBe('lineage source write failed');
+        expect(storage.getItem(GENERATE_LINEAGE_SOURCE_KEY)).toBe(JSON.stringify(stored));
+    });
+
+    it('isolates lineage source failure from api key and draft success', async () => {
+        const storedDraft = makeStoredDraft();
+        const storedLineageSource = makeStoredLineageSource();
+        const { migrator, storage, credentialsPort, draftPort } = createHarness(
+            {
+                [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+                [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+                [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(storedLineageSource),
+            },
+            { generateLineageSourcePort: new FailingGenerateLineageSourcePort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: true, migrated: true });
+        expect(outcome.generateDraft).toEqual({ detected: true, migrated: true });
+        expect(outcome.generateLineageSource.migrated).toBe(false);
+        expect(credentialsPort.apiKey).toBe('sk-current');
+        expect(draftPort.draft).toEqual(storedDraft);
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).toBeNull();
+        expect(storage.getItem(GENERATE_LINEAGE_SOURCE_KEY)).toBe(JSON.stringify(storedLineageSource));
+    });
+
+    it('is idempotent — second migrate finds no lineage data after success', async () => {
+        const { migrator, lineageSourcePort } = createHarness({
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(makeStoredLineageSource()),
+        });
+
+        await migrator.migrate();
+        const before = lineageSourcePort.saveCount;
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateLineageSource).toEqual({ detected: false, migrated: false });
+        expect(lineageSourcePort.saveCount).toBe(before);
+    });
+});
+
 describe('LocalStorageMigrator.decline + decision', () => {
     it('preserves source data and flips the flag on decline', () => {
+        const stored = makeStoredLineageSource();
         const { migrator, storage } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
             [GENERATE_DRAFT_KEY]: JSON.stringify(makeStoredDraft()),
             [LEGACY_AUTOPILOT_KEYS.mode]: JSON.stringify('autopilot'),
+            [GENERATE_LINEAGE_SOURCE_KEY]: JSON.stringify(stored),
         });
 
         migrator.decline();
@@ -581,6 +746,7 @@ describe('LocalStorageMigrator.decline + decision', () => {
         expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBe(JSON.stringify('sk-current'));
         expect(storage.getItem(GENERATE_DRAFT_KEY)).not.toBeNull();
         expect(storage.getItem(LEGACY_AUTOPILOT_KEYS.mode)).toBe(JSON.stringify('autopilot'));
+        expect(storage.getItem(GENERATE_LINEAGE_SOURCE_KEY)).toBe(JSON.stringify(stored));
         expect(migrator.getDecision()).toBe('declined');
     });
 

--- a/src/session/LocalStorageMigrator.test.ts
+++ b/src/session/LocalStorageMigrator.test.ts
@@ -7,6 +7,13 @@ import {
     type LocalStorageMigrator,
 } from './LocalStorageMigrator';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import {
+    DEFAULT_GENERATE_DRAFT,
+    GENERATE_DRAFT_KEY,
+    LEGACY_DRAFT_KEYS,
+    type GenerateDraft,
+} from '../generate-session/GenerateSession';
 
 class MemoryStorage implements Storage {
     private readonly map = new Map<string, string>();
@@ -63,26 +70,83 @@ class FailingCredentialsPort implements CredentialsPort {
     async clear(): Promise<void> {}
 }
 
+class InMemoryGenerateDraftPort implements GenerateDraftPort {
+    draft: GenerateDraft | null = null;
+    saveCount = 0;
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateDraft | null> {
+        return this.draft;
+    }
+
+    async save(draft: GenerateDraft): Promise<void> {
+        this.draft = { ...draft };
+        this.saveCount += 1;
+    }
+
+    async clear(): Promise<void> {
+        this.draft = null;
+    }
+}
+
+class FailingGenerateDraftPort implements GenerateDraftPort {
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateDraft | null> { return null; }
+    async save(): Promise<void> { throw new Error('draft write failed'); }
+    async clear(): Promise<void> {}
+}
+
 interface Harness {
     migrator: LocalStorageMigrator;
     storage: MemoryStorage;
-    port: InMemoryCredentialsPort;
+    credentialsPort: InMemoryCredentialsPort;
+    draftPort: InMemoryGenerateDraftPort;
 }
 
-function createHarness(seed: Record<string, string> = {}, port: CredentialsPort = new InMemoryCredentialsPort()): Harness {
+function createHarness(
+    seed: Record<string, string> = {},
+    overrides: {
+        credentialsPort?: CredentialsPort;
+        generateDraftPort?: GenerateDraftPort;
+    } = {},
+): Harness {
     const storage = new MemoryStorage();
     for (const [key, value] of Object.entries(seed)) {
         storage.setItem(key, value);
     }
-    const migrator = createLocalStorageMigrator({ credentialsPort: port, localStorage: storage });
-    return { migrator, storage, port: port as InMemoryCredentialsPort };
+    const credentialsPort = overrides.credentialsPort ?? new InMemoryCredentialsPort();
+    const draftPort = overrides.generateDraftPort ?? new InMemoryGenerateDraftPort();
+    const migrator = createLocalStorageMigrator({
+        credentialsPort,
+        generateDraftPort: draftPort,
+        localStorage: storage,
+    });
+    return {
+        migrator,
+        storage,
+        credentialsPort: credentialsPort as InMemoryCredentialsPort,
+        draftPort: draftPort as InMemoryGenerateDraftPort,
+    };
+}
+
+function makeStoredDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft {
+    return {
+        ...DEFAULT_GENERATE_DRAFT,
+        prompt: 'stored prompt',
+        quality: 'high',
+        ...overrides,
+    };
 }
 
 describe('LocalStorageMigrator.detect', () => {
-    it('reports api key as absent when nothing is stored', () => {
+    it('reports everything as absent when nothing is stored', () => {
         const { migrator } = createHarness();
 
-        expect(migrator.detect()).toEqual({ apiKey: { present: false } });
+        expect(migrator.detect()).toEqual({
+            apiKey: { present: false },
+            generateDraft: { present: false },
+        });
         expect(migrator.hasMigratableData()).toBe(false);
     });
 
@@ -110,11 +174,36 @@ describe('LocalStorageMigrator.detect', () => {
 
         expect(migrator.detect().apiKey.present).toBe(false);
     });
+
+    it('detects a draft stored under the current key', () => {
+        const { migrator } = createHarness({
+            [GENERATE_DRAFT_KEY]: JSON.stringify(makeStoredDraft()),
+        });
+
+        expect(migrator.detect().generateDraft.present).toBe(true);
+        expect(migrator.hasMigratableData()).toBe(true);
+    });
+
+    it('detects a draft assembled from any legacy per-field key', () => {
+        const { migrator } = createHarness({
+            [LEGACY_DRAFT_KEYS.prompt]: JSON.stringify('legacy prompt'),
+        });
+
+        expect(migrator.detect().generateDraft.present).toBe(true);
+    });
+
+    it('does not confuse unrelated keys as draft presence', () => {
+        const { migrator } = createHarness({
+            aura_current_view: JSON.stringify('archive'),
+        });
+
+        expect(migrator.detect().generateDraft.present).toBe(false);
+    });
 });
 
-describe('LocalStorageMigrator.migrate', () => {
+describe('LocalStorageMigrator.migrate api key branch', () => {
     it('writes the current api key through the port and removes both source keys on success', async () => {
-        const { migrator, storage, port } = createHarness({
+        const { migrator, storage, credentialsPort } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
             [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
         });
@@ -122,38 +211,42 @@ describe('LocalStorageMigrator.migrate', () => {
         const outcome = await migrator.migrate();
 
         expect(outcome.apiKey).toEqual({ detected: true, migrated: true });
-        expect(port.apiKey).toBe('sk-current');
+        expect(credentialsPort.apiKey).toBe('sk-current');
         expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
         expect(storage.getItem(API_KEY_LEGACY_LS_KEY)).toBeNull();
         expect(migrator.getDecision()).toBe('migrated');
     });
 
     it('migrates the legacy api key when the current key is missing', async () => {
-        const { migrator, storage, port } = createHarness({
+        const { migrator, storage, credentialsPort } = createHarness({
             [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
         });
 
         await migrator.migrate();
 
-        expect(port.apiKey).toBe('sk-legacy-raw');
+        expect(credentialsPort.apiKey).toBe('sk-legacy-raw');
         expect(storage.getItem(API_KEY_LEGACY_LS_KEY)).toBeNull();
     });
 
     it('flips the decision to migrated even when no data was present', async () => {
-        const { migrator, port } = createHarness();
+        const { migrator, credentialsPort } = createHarness();
 
         const outcome = await migrator.migrate();
 
         expect(outcome.apiKey).toEqual({ detected: false, migrated: false });
-        expect(port.apiKey).toBeNull();
+        expect(outcome.generateDraft).toEqual({ detected: false, migrated: false });
+        expect(credentialsPort.apiKey).toBeNull();
         expect(migrator.getDecision()).toBe('migrated');
     });
 
-    it('leaves the source keys intact when the port write fails', async () => {
-        const { migrator, storage } = createHarness({
-            [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
-            [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
-        }, new FailingCredentialsPort());
+    it('leaves the source keys intact when the api key port write fails', async () => {
+        const { migrator, storage } = createHarness(
+            {
+                [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+                [API_KEY_LEGACY_LS_KEY]: 'sk-legacy-raw',
+            },
+            { credentialsPort: new FailingCredentialsPort() },
+        );
 
         const outcome = await migrator.migrate();
 
@@ -165,16 +258,120 @@ describe('LocalStorageMigrator.migrate', () => {
     });
 
     it('is idempotent when invoked again with no migratable data left', async () => {
-        const { migrator, port } = createHarness({
+        const { migrator, credentialsPort } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
         });
 
         await migrator.migrate();
-        const before = port.saveCount;
+        const before = credentialsPort.saveCount;
         const outcome = await migrator.migrate();
 
         expect(outcome.apiKey).toEqual({ detected: false, migrated: false });
-        expect(port.saveCount).toBe(before);
+        expect(credentialsPort.saveCount).toBe(before);
+    });
+});
+
+describe('LocalStorageMigrator.migrate draft branch', () => {
+    it('writes the current draft through the port and removes the current key and all legacy keys on success', async () => {
+        const storedDraft = makeStoredDraft({ prompt: 'current draft prompt' });
+        const { migrator, storage, draftPort } = createHarness({
+            [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+            [LEGACY_DRAFT_KEYS.prompt]: JSON.stringify('stale'),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateDraft).toEqual({ detected: true, migrated: true });
+        expect(draftPort.draft).toEqual(storedDraft);
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).toBeNull();
+        expect(storage.getItem(LEGACY_DRAFT_KEYS.prompt)).toBeNull();
+    });
+
+    it('composes a draft from the 8 legacy per-field keys when the current key is missing', async () => {
+        const { migrator, storage, draftPort } = createHarness({
+            [LEGACY_DRAFT_KEYS.prompt]: JSON.stringify('legacy prompt'),
+            [LEGACY_DRAFT_KEYS.quality]: JSON.stringify('low'),
+            [LEGACY_DRAFT_KEYS.aspectRatio]: JSON.stringify('1536x1024'),
+            [LEGACY_DRAFT_KEYS.background]: JSON.stringify('opaque'),
+            [LEGACY_DRAFT_KEYS.style]: JSON.stringify('oil painting on linen'),
+            [LEGACY_DRAFT_KEYS.lighting]: JSON.stringify('candlelight with deep shadows'),
+            [LEGACY_DRAFT_KEYS.palette]: JSON.stringify('emerald + burgundy + gold'),
+            [LEGACY_DRAFT_KEYS.isSaved]: JSON.stringify(true),
+        });
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateDraft.migrated).toBe(true);
+        expect(draftPort.draft).toEqual({
+            prompt: 'legacy prompt',
+            quality: 'low',
+            aspectRatio: '1536x1024',
+            background: 'opaque',
+            style: 'oil painting on linen',
+            lighting: 'candlelight with deep shadows',
+            palette: 'emerald + burgundy + gold',
+            isSaved: true,
+        });
+        for (const key of Object.values(LEGACY_DRAFT_KEYS)) {
+            expect(storage.getItem(key)).toBeNull();
+        }
+    });
+
+    it('prefers the current key over any legacy fields', async () => {
+        const current = makeStoredDraft({ prompt: 'from current key' });
+        const { migrator, storage, draftPort } = createHarness({
+            [GENERATE_DRAFT_KEY]: JSON.stringify(current),
+            [LEGACY_DRAFT_KEYS.prompt]: JSON.stringify('from legacy key'),
+        });
+
+        await migrator.migrate();
+
+        expect(draftPort.draft?.prompt).toBe('from current key');
+        expect(storage.getItem(LEGACY_DRAFT_KEYS.prompt)).toBeNull();
+    });
+
+    it('reports absence when no draft keys are present', async () => {
+        const { migrator, draftPort } = createHarness();
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateDraft).toEqual({ detected: false, migrated: false });
+        expect(draftPort.draft).toBeNull();
+    });
+
+    it('leaves draft source keys intact when the draft port write fails', async () => {
+        const storedDraft = makeStoredDraft();
+        const { migrator, storage } = createHarness(
+            {
+                [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+            },
+            { generateDraftPort: new FailingGenerateDraftPort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.generateDraft.migrated).toBe(false);
+        expect(outcome.generateDraft.error?.message).toBe('draft write failed');
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).toBe(JSON.stringify(storedDraft));
+    });
+
+    it('isolates api key success from draft port failure', async () => {
+        const storedDraft = makeStoredDraft();
+        const { migrator, storage, credentialsPort } = createHarness(
+            {
+                [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+                [GENERATE_DRAFT_KEY]: JSON.stringify(storedDraft),
+            },
+            { generateDraftPort: new FailingGenerateDraftPort() },
+        );
+
+        const outcome = await migrator.migrate();
+
+        expect(outcome.apiKey).toEqual({ detected: true, migrated: true });
+        expect(outcome.generateDraft.migrated).toBe(false);
+        expect(credentialsPort.apiKey).toBe('sk-current');
+        expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBeNull();
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).toBe(JSON.stringify(storedDraft));
     });
 });
 
@@ -182,11 +379,13 @@ describe('LocalStorageMigrator.decline + decision', () => {
     it('preserves source data and flips the flag on decline', () => {
         const { migrator, storage } = createHarness({
             [API_KEY_PRIMARY_LS_KEY]: JSON.stringify('sk-current'),
+            [GENERATE_DRAFT_KEY]: JSON.stringify(makeStoredDraft()),
         });
 
         migrator.decline();
 
         expect(storage.getItem(API_KEY_PRIMARY_LS_KEY)).toBe(JSON.stringify('sk-current'));
+        expect(storage.getItem(GENERATE_DRAFT_KEY)).not.toBeNull();
         expect(migrator.getDecision()).toBe('declined');
     });
 

--- a/src/session/LocalStorageMigrator.ts
+++ b/src/session/LocalStorageMigrator.ts
@@ -1,4 +1,13 @@
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import {
+    DEFAULT_GENERATE_DRAFT,
+    GENERATE_DRAFT_KEY,
+    LEGACY_DRAFT_KEYS,
+    sanitizeGenerateDraft,
+    type GenerateDraft,
+    type LegacyDraftField,
+} from '../generate-session/GenerateSession';
 
 export const MIGRATION_DECISION_KEY = 'aura_storage_migration_decision';
 export const API_KEY_PRIMARY_LS_KEY = 'aura_openapi_key';
@@ -12,6 +21,7 @@ export interface MigrationFieldSnapshot {
 
 export interface MigrationSnapshot {
     apiKey: MigrationFieldSnapshot;
+    generateDraft: MigrationFieldSnapshot;
 }
 
 export interface MigrationFieldOutcome {
@@ -22,10 +32,12 @@ export interface MigrationFieldOutcome {
 
 export interface MigrationOutcome {
     apiKey: MigrationFieldOutcome;
+    generateDraft: MigrationFieldOutcome;
 }
 
 export interface CreateLocalStorageMigratorDeps {
     credentialsPort: Pick<CredentialsPort, 'save'>;
+    generateDraftPort: Pick<GenerateDraftPort, 'save'>;
     localStorage?: Storage;
 }
 
@@ -37,6 +49,10 @@ export interface LocalStorageMigrator {
     getDecision(): MigrationDecision | null;
     resetDecision(): void;
 }
+
+const LEGACY_DRAFT_KEY_LIST: Array<[LegacyDraftField, string]> = Object.entries(LEGACY_DRAFT_KEYS) as Array<
+    [LegacyDraftField, string]
+>;
 
 export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps): LocalStorageMigrator {
     const ls = deps.localStorage ?? window.localStorage;
@@ -50,9 +66,45 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         return readStringValue(ls, API_KEY_LEGACY_LS_KEY);
     }
 
+    function readDraftFromLocalStorage(): { draft: GenerateDraft; sourceKeys: string[] } | null {
+        const currentRaw = ls.getItem(GENERATE_DRAFT_KEY);
+        if (currentRaw !== null) {
+            const parsed = tryParseJson(currentRaw);
+            if (parsed && typeof parsed === 'object') {
+                return {
+                    draft: sanitizeGenerateDraft(parsed as Partial<GenerateDraft>),
+                    sourceKeys: [GENERATE_DRAFT_KEY, ...LEGACY_DRAFT_KEY_LIST.map(([, key]) => key)],
+                };
+            }
+        }
+
+        const legacy: Partial<GenerateDraft> = {};
+        const touchedKeys: string[] = [];
+        for (const [field, key] of LEGACY_DRAFT_KEY_LIST) {
+            const raw = ls.getItem(key);
+            if (raw === null) {
+                continue;
+            }
+            touchedKeys.push(key);
+            const parsed = tryParseJson(raw);
+            const value = parsed === undefined ? raw : parsed;
+            (legacy as Record<string, unknown>)[field] = value;
+        }
+
+        if (touchedKeys.length === 0) {
+            return null;
+        }
+
+        return {
+            draft: sanitizeGenerateDraft(legacy),
+            sourceKeys: touchedKeys,
+        };
+    }
+
     function detect(): MigrationSnapshot {
         return {
             apiKey: { present: readApiKeyFromLocalStorage() !== null },
+            generateDraft: { present: readDraftFromLocalStorage() !== null },
         };
     }
 
@@ -60,12 +112,13 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         detect,
         hasMigratableData(): boolean {
             const snapshot = detect();
-            return snapshot.apiKey.present;
+            return snapshot.apiKey.present || snapshot.generateDraft.present;
         },
         async migrate(): Promise<MigrationOutcome> {
             const apiKey = readApiKeyFromLocalStorage();
-            const outcome: MigrationOutcome = {
-                apiKey: { detected: apiKey !== null, migrated: false },
+            const apiKeyOutcome: MigrationFieldOutcome = {
+                detected: apiKey !== null,
+                migrated: false,
             };
 
             if (apiKey !== null) {
@@ -73,14 +126,36 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
                     await deps.credentialsPort.save(apiKey);
                     ls.removeItem(API_KEY_PRIMARY_LS_KEY);
                     ls.removeItem(API_KEY_LEGACY_LS_KEY);
-                    outcome.apiKey.migrated = true;
+                    apiKeyOutcome.migrated = true;
                 } catch (error) {
-                    outcome.apiKey.error = error instanceof Error ? error : new Error(String(error));
+                    apiKeyOutcome.error = error instanceof Error ? error : new Error(String(error));
+                }
+            }
+
+            const draftRead = readDraftFromLocalStorage();
+            const draftOutcome: MigrationFieldOutcome = {
+                detected: draftRead !== null,
+                migrated: false,
+            };
+
+            if (draftRead !== null) {
+                try {
+                    await deps.generateDraftPort.save(draftRead.draft);
+                    for (const key of draftRead.sourceKeys) {
+                        ls.removeItem(key);
+                    }
+                    draftOutcome.migrated = true;
+                } catch (error) {
+                    draftOutcome.error = error instanceof Error ? error : new Error(String(error));
                 }
             }
 
             ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('migrated'));
-            return outcome;
+
+            return {
+                apiKey: apiKeyOutcome,
+                generateDraft: draftOutcome,
+            };
         },
         decline(): void {
             ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('declined'));
@@ -118,3 +193,6 @@ function tryParseJson(raw: string): unknown {
         return undefined;
     }
 }
+
+// re-export so tests and callers have a single source of truth
+export { DEFAULT_GENERATE_DRAFT };

--- a/src/session/LocalStorageMigrator.ts
+++ b/src/session/LocalStorageMigrator.ts
@@ -7,12 +7,16 @@ import {
 import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
 import {
     DEFAULT_GENERATE_DRAFT,
     GENERATE_DRAFT_KEY,
+    GENERATE_LINEAGE_SOURCE_KEY,
     LEGACY_DRAFT_KEYS,
     sanitizeGenerateDraft,
+    sanitizeGenerateLineageSource,
     type GenerateDraft,
+    type GenerateLineageSource,
     type LegacyDraftField,
 } from '../generate-session/GenerateSession';
 
@@ -30,6 +34,7 @@ export interface MigrationSnapshot {
     apiKey: MigrationFieldSnapshot;
     generateDraft: MigrationFieldSnapshot;
     autopilotSettings: MigrationFieldSnapshot;
+    generateLineageSource: MigrationFieldSnapshot;
 }
 
 export interface MigrationFieldOutcome {
@@ -42,12 +47,14 @@ export interface MigrationOutcome {
     apiKey: MigrationFieldOutcome;
     generateDraft: MigrationFieldOutcome;
     autopilotSettings: MigrationFieldOutcome;
+    generateLineageSource: MigrationFieldOutcome;
 }
 
 export interface CreateLocalStorageMigratorDeps {
     credentialsPort: Pick<CredentialsPort, 'save'>;
     generateDraftPort: Pick<GenerateDraftPort, 'save'>;
     autopilotSettingsPort: Pick<AutopilotSettingsPort, 'save'>;
+    generateLineageSourcePort: Pick<GenerateLineageSourcePort, 'save'>;
     localStorage?: Storage;
 }
 
@@ -103,6 +110,25 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         };
     }
 
+    function readLineageSourceFromLocalStorage(): { source: GenerateLineageSource; sourceKey: string } | null {
+        const raw = ls.getItem(GENERATE_LINEAGE_SOURCE_KEY);
+        if (raw === null) {
+            return null;
+        }
+
+        const parsed = tryParseJson(raw);
+        if (!parsed || typeof parsed !== 'object') {
+            return null;
+        }
+
+        const sanitized = sanitizeGenerateLineageSource(parsed as Partial<GenerateLineageSource>);
+        if (!sanitized) {
+            return null;
+        }
+
+        return { source: sanitized, sourceKey: GENERATE_LINEAGE_SOURCE_KEY };
+    }
+
     function readDraftFromLocalStorage(): { draft: GenerateDraft; sourceKeys: string[] } | null {
         const currentRaw = ls.getItem(GENERATE_DRAFT_KEY);
         if (currentRaw !== null) {
@@ -143,6 +169,7 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
             apiKey: { present: readApiKeyFromLocalStorage() !== null },
             generateDraft: { present: readDraftFromLocalStorage() !== null },
             autopilotSettings: { present: readAutopilotFromLocalStorage() !== null },
+            generateLineageSource: { present: readLineageSourceFromLocalStorage() !== null },
         };
     }
 
@@ -150,7 +177,12 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         detect,
         hasMigratableData(): boolean {
             const snapshot = detect();
-            return snapshot.apiKey.present || snapshot.generateDraft.present || snapshot.autopilotSettings.present;
+            return (
+                snapshot.apiKey.present
+                || snapshot.generateDraft.present
+                || snapshot.autopilotSettings.present
+                || snapshot.generateLineageSource.present
+            );
         },
         async migrate(): Promise<MigrationOutcome> {
             const apiKey = readApiKeyFromLocalStorage();
@@ -206,12 +238,29 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
                 }
             }
 
+            const lineageSourceRead = readLineageSourceFromLocalStorage();
+            const lineageSourceOutcome: MigrationFieldOutcome = {
+                detected: lineageSourceRead !== null,
+                migrated: false,
+            };
+
+            if (lineageSourceRead !== null) {
+                try {
+                    await deps.generateLineageSourcePort.save(lineageSourceRead.source);
+                    ls.removeItem(lineageSourceRead.sourceKey);
+                    lineageSourceOutcome.migrated = true;
+                } catch (error) {
+                    lineageSourceOutcome.error = error instanceof Error ? error : new Error(String(error));
+                }
+            }
+
             ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('migrated'));
 
             return {
                 apiKey: apiKeyOutcome,
                 generateDraft: draftOutcome,
                 autopilotSettings: autopilotOutcome,
+                generateLineageSource: lineageSourceOutcome,
             };
         },
         decline(): void {

--- a/src/session/LocalStorageMigrator.ts
+++ b/src/session/LocalStorageMigrator.ts
@@ -1,3 +1,10 @@
+import {
+    LEGACY_AUTOPILOT_KEYS,
+    sanitizeAutopilotSettings,
+    type AutopilotSettings,
+    type LegacyAutopilotField,
+} from '../autopilot/AutopilotSettings';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
 import {
@@ -22,6 +29,7 @@ export interface MigrationFieldSnapshot {
 export interface MigrationSnapshot {
     apiKey: MigrationFieldSnapshot;
     generateDraft: MigrationFieldSnapshot;
+    autopilotSettings: MigrationFieldSnapshot;
 }
 
 export interface MigrationFieldOutcome {
@@ -33,11 +41,13 @@ export interface MigrationFieldOutcome {
 export interface MigrationOutcome {
     apiKey: MigrationFieldOutcome;
     generateDraft: MigrationFieldOutcome;
+    autopilotSettings: MigrationFieldOutcome;
 }
 
 export interface CreateLocalStorageMigratorDeps {
     credentialsPort: Pick<CredentialsPort, 'save'>;
     generateDraftPort: Pick<GenerateDraftPort, 'save'>;
+    autopilotSettingsPort: Pick<AutopilotSettingsPort, 'save'>;
     localStorage?: Storage;
 }
 
@@ -54,6 +64,10 @@ const LEGACY_DRAFT_KEY_LIST: Array<[LegacyDraftField, string]> = Object.entries(
     [LegacyDraftField, string]
 >;
 
+const LEGACY_AUTOPILOT_KEY_LIST: Array<[LegacyAutopilotField, string]> = Object.entries(LEGACY_AUTOPILOT_KEYS) as Array<
+    [LegacyAutopilotField, string]
+>;
+
 export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps): LocalStorageMigrator {
     const ls = deps.localStorage ?? window.localStorage;
 
@@ -64,6 +78,29 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         }
 
         return readStringValue(ls, API_KEY_LEGACY_LS_KEY);
+    }
+
+    function readAutopilotFromLocalStorage(): { settings: AutopilotSettings; sourceKeys: string[] } | null {
+        const raw: Partial<Record<LegacyAutopilotField, unknown>> = {};
+        const touchedKeys: string[] = [];
+        for (const [field, key] of LEGACY_AUTOPILOT_KEY_LIST) {
+            const rawValue = ls.getItem(key);
+            if (rawValue === null) {
+                continue;
+            }
+            touchedKeys.push(key);
+            const parsed = tryParseJson(rawValue);
+            raw[field] = parsed === undefined ? rawValue : parsed;
+        }
+
+        if (touchedKeys.length === 0) {
+            return null;
+        }
+
+        return {
+            settings: sanitizeAutopilotSettings(raw),
+            sourceKeys: touchedKeys,
+        };
     }
 
     function readDraftFromLocalStorage(): { draft: GenerateDraft; sourceKeys: string[] } | null {
@@ -105,6 +142,7 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         return {
             apiKey: { present: readApiKeyFromLocalStorage() !== null },
             generateDraft: { present: readDraftFromLocalStorage() !== null },
+            autopilotSettings: { present: readAutopilotFromLocalStorage() !== null },
         };
     }
 
@@ -112,7 +150,7 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
         detect,
         hasMigratableData(): boolean {
             const snapshot = detect();
-            return snapshot.apiKey.present || snapshot.generateDraft.present;
+            return snapshot.apiKey.present || snapshot.generateDraft.present || snapshot.autopilotSettings.present;
         },
         async migrate(): Promise<MigrationOutcome> {
             const apiKey = readApiKeyFromLocalStorage();
@@ -150,11 +188,30 @@ export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps)
                 }
             }
 
+            const autopilotRead = readAutopilotFromLocalStorage();
+            const autopilotOutcome: MigrationFieldOutcome = {
+                detected: autopilotRead !== null,
+                migrated: false,
+            };
+
+            if (autopilotRead !== null) {
+                try {
+                    await deps.autopilotSettingsPort.save(autopilotRead.settings);
+                    for (const key of autopilotRead.sourceKeys) {
+                        ls.removeItem(key);
+                    }
+                    autopilotOutcome.migrated = true;
+                } catch (error) {
+                    autopilotOutcome.error = error instanceof Error ? error : new Error(String(error));
+                }
+            }
+
             ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('migrated'));
 
             return {
                 apiKey: apiKeyOutcome,
                 generateDraft: draftOutcome,
+                autopilotSettings: autopilotOutcome,
             };
         },
         decline(): void {

--- a/src/session/LocalStorageMigrator.ts
+++ b/src/session/LocalStorageMigrator.ts
@@ -1,0 +1,120 @@
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+
+export const MIGRATION_DECISION_KEY = 'aura_storage_migration_decision';
+export const API_KEY_PRIMARY_LS_KEY = 'aura_openapi_key';
+export const API_KEY_LEGACY_LS_KEY = 'openai_api_key';
+
+export type MigrationDecision = 'migrated' | 'declined';
+
+export interface MigrationFieldSnapshot {
+    present: boolean;
+}
+
+export interface MigrationSnapshot {
+    apiKey: MigrationFieldSnapshot;
+}
+
+export interface MigrationFieldOutcome {
+    detected: boolean;
+    migrated: boolean;
+    error?: Error;
+}
+
+export interface MigrationOutcome {
+    apiKey: MigrationFieldOutcome;
+}
+
+export interface CreateLocalStorageMigratorDeps {
+    credentialsPort: Pick<CredentialsPort, 'save'>;
+    localStorage?: Storage;
+}
+
+export interface LocalStorageMigrator {
+    detect(): MigrationSnapshot;
+    hasMigratableData(): boolean;
+    migrate(): Promise<MigrationOutcome>;
+    decline(): void;
+    getDecision(): MigrationDecision | null;
+    resetDecision(): void;
+}
+
+export function createLocalStorageMigrator(deps: CreateLocalStorageMigratorDeps): LocalStorageMigrator {
+    const ls = deps.localStorage ?? window.localStorage;
+
+    function readApiKeyFromLocalStorage(): string | null {
+        const primary = readStringValue(ls, API_KEY_PRIMARY_LS_KEY);
+        if (primary !== null) {
+            return primary;
+        }
+
+        return readStringValue(ls, API_KEY_LEGACY_LS_KEY);
+    }
+
+    function detect(): MigrationSnapshot {
+        return {
+            apiKey: { present: readApiKeyFromLocalStorage() !== null },
+        };
+    }
+
+    return {
+        detect,
+        hasMigratableData(): boolean {
+            const snapshot = detect();
+            return snapshot.apiKey.present;
+        },
+        async migrate(): Promise<MigrationOutcome> {
+            const apiKey = readApiKeyFromLocalStorage();
+            const outcome: MigrationOutcome = {
+                apiKey: { detected: apiKey !== null, migrated: false },
+            };
+
+            if (apiKey !== null) {
+                try {
+                    await deps.credentialsPort.save(apiKey);
+                    ls.removeItem(API_KEY_PRIMARY_LS_KEY);
+                    ls.removeItem(API_KEY_LEGACY_LS_KEY);
+                    outcome.apiKey.migrated = true;
+                } catch (error) {
+                    outcome.apiKey.error = error instanceof Error ? error : new Error(String(error));
+                }
+            }
+
+            ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('migrated'));
+            return outcome;
+        },
+        decline(): void {
+            ls.setItem(MIGRATION_DECISION_KEY, JSON.stringify('declined'));
+        },
+        getDecision(): MigrationDecision | null {
+            const raw = ls.getItem(MIGRATION_DECISION_KEY);
+            if (!raw) {
+                return null;
+            }
+
+            const parsed = tryParseJson(raw) ?? raw;
+            return parsed === 'migrated' || parsed === 'declined' ? parsed : null;
+        },
+        resetDecision(): void {
+            ls.removeItem(MIGRATION_DECISION_KEY);
+        },
+    };
+}
+
+function readStringValue(ls: Storage, key: string): string | null {
+    const raw = ls.getItem(key);
+    if (raw === null) {
+        return null;
+    }
+
+    const parsed = tryParseJson(raw);
+    const candidate = typeof parsed === 'string' ? parsed : raw;
+    return candidate.length > 0 ? candidate : null;
+}
+
+function tryParseJson(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+}

--- a/src/session/MigrationGate.tsx
+++ b/src/session/MigrationGate.tsx
@@ -48,7 +48,7 @@ export function MigrationGate({
         }
 
         const next = migrator.detect();
-        const hasAny = next.apiKey.present || next.generateDraft.present;
+        const hasAny = next.apiKey.present || next.generateDraft.present || next.autopilotSettings.present;
         setSnapshot(hasAny ? next : null);
     }, [evaluationToken, migrator]);
 
@@ -63,6 +63,9 @@ export function MigrationGate({
             }
             if (outcome.generateDraft.error) {
                 onMigrationError?.(outcome.generateDraft.error);
+            }
+            if (outcome.autopilotSettings.error) {
+                onMigrationError?.(outcome.autopilotSettings.error);
             }
         } catch (error) {
             const wrapped = error instanceof Error ? error : new Error(String(error));

--- a/src/session/MigrationGate.tsx
+++ b/src/session/MigrationGate.tsx
@@ -1,0 +1,102 @@
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import type { ReactNode } from 'react';
+import MigrationPrompt from '../components/MigrationPrompt';
+import type {
+    LocalStorageMigrator,
+    MigrationOutcome,
+    MigrationSnapshot,
+} from './LocalStorageMigrator';
+import type { SessionHydrator } from './SessionHydrator';
+import { MigrationContext, type MigrationContextValue } from './migrationContext';
+
+export interface MigrationGateProps {
+    migrator: LocalStorageMigrator;
+    hydrator: SessionHydrator;
+    onMigrationComplete?: (outcome: MigrationOutcome) => void;
+    onMigrationError?: (error: Error) => void;
+    children: ReactNode;
+}
+
+export function MigrationGate({
+    migrator,
+    hydrator,
+    onMigrationComplete,
+    onMigrationError,
+    children,
+}: MigrationGateProps) {
+    const [snapshot, setSnapshot] = useState<MigrationSnapshot | null>(null);
+    const [isMigrating, setIsMigrating] = useState(false);
+    const [evaluationToken, setEvaluationToken] = useState(0);
+    const evaluatedTokenRef = useRef(-1);
+
+    useEffect(() => {
+        if (evaluatedTokenRef.current === evaluationToken) {
+            return;
+        }
+        evaluatedTokenRef.current = evaluationToken;
+
+        const decision = migrator.getDecision();
+        if (decision !== null) {
+            setSnapshot(null);
+            return;
+        }
+
+        const next = migrator.detect();
+        const hasAny = next.apiKey.present;
+        setSnapshot(hasAny ? next : null);
+    }, [evaluationToken, migrator]);
+
+    const handleMigrate = useCallback(async () => {
+        setIsMigrating(true);
+        try {
+            const outcome = await migrator.migrate();
+            await hydrator.refresh();
+            onMigrationComplete?.(outcome);
+            if (outcome.apiKey.error) {
+                onMigrationError?.(outcome.apiKey.error);
+            }
+        } catch (error) {
+            const wrapped = error instanceof Error ? error : new Error(String(error));
+            onMigrationError?.(wrapped);
+        } finally {
+            setIsMigrating(false);
+            setSnapshot(null);
+            setEvaluationToken((token) => token + 1);
+        }
+    }, [hydrator, migrator, onMigrationComplete, onMigrationError]);
+
+    const handleDecline = useCallback(() => {
+        migrator.decline();
+        setSnapshot(null);
+        setEvaluationToken((token) => token + 1);
+    }, [migrator]);
+
+    const requestRerun = useCallback(() => {
+        migrator.resetDecision();
+        setEvaluationToken((token) => token + 1);
+    }, [migrator]);
+
+    const contextValue = useMemo<MigrationContextValue>(() => ({
+        requestRerun,
+    }), [requestRerun]);
+
+    return (
+        <MigrationContext.Provider value={contextValue}>
+            {children}
+            {snapshot && (
+                <MigrationPrompt
+                    snapshot={snapshot}
+                    onMigrate={handleMigrate}
+                    onDecline={handleDecline}
+                    isMigrating={isMigrating}
+                />
+            )}
+        </MigrationContext.Provider>
+    );
+}

--- a/src/session/MigrationGate.tsx
+++ b/src/session/MigrationGate.tsx
@@ -48,7 +48,10 @@ export function MigrationGate({
         }
 
         const next = migrator.detect();
-        const hasAny = next.apiKey.present || next.generateDraft.present || next.autopilotSettings.present;
+        const hasAny = next.apiKey.present
+            || next.generateDraft.present
+            || next.autopilotSettings.present
+            || next.generateLineageSource.present;
         setSnapshot(hasAny ? next : null);
     }, [evaluationToken, migrator]);
 
@@ -66,6 +69,9 @@ export function MigrationGate({
             }
             if (outcome.autopilotSettings.error) {
                 onMigrationError?.(outcome.autopilotSettings.error);
+            }
+            if (outcome.generateLineageSource.error) {
+                onMigrationError?.(outcome.generateLineageSource.error);
             }
         } catch (error) {
             const wrapped = error instanceof Error ? error : new Error(String(error));

--- a/src/session/MigrationGate.tsx
+++ b/src/session/MigrationGate.tsx
@@ -48,7 +48,7 @@ export function MigrationGate({
         }
 
         const next = migrator.detect();
-        const hasAny = next.apiKey.present;
+        const hasAny = next.apiKey.present || next.generateDraft.present;
         setSnapshot(hasAny ? next : null);
     }, [evaluationToken, migrator]);
 
@@ -60,6 +60,9 @@ export function MigrationGate({
             onMigrationComplete?.(outcome);
             if (outcome.apiKey.error) {
                 onMigrationError?.(outcome.apiKey.error);
+            }
+            if (outcome.generateDraft.error) {
+                onMigrationError?.(outcome.generateDraft.error);
             }
         } catch (error) {
             const wrapped = error instanceof Error ? error : new Error(String(error));

--- a/src/session/SessionContext.tsx
+++ b/src/session/SessionContext.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import type { ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { SessionHydrator } from './SessionHydrator';
+import { SessionContext, type SessionContextValue } from './sessionContextValue';
+
+export interface SessionProviderProps {
+    hydrator: SessionHydrator;
+    children: ReactNode;
+    fallback?: ReactNode;
+}
+
+export function SessionProvider({ hydrator, children, fallback }: SessionProviderProps) {
+    const hydrationStartedRef = useRef(false);
+
+    useEffect(() => {
+        if (hydrationStartedRef.current) {
+            return;
+        }
+        hydrationStartedRef.current = true;
+        void hydrator.hydrate();
+    }, [hydrator]);
+
+    const state = useSyncExternalStore(hydrator.subscribe, hydrator.getState);
+
+    const value = useMemo<SessionContextValue>(() => ({
+        state,
+        setApiKey: hydrator.setApiKey,
+    }), [state, hydrator]);
+
+    if (!state.isHydrated) {
+        return <>{fallback ?? <DefaultHydrationLoader />}</>;
+    }
+
+    return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}
+
+function DefaultHydrationLoader() {
+    return (
+        <div className="hydration-loader" role="status" aria-live="polite">
+            <Loader2 size={32} className="hydration-loader__spinner" />
+            <span>Loading your studio…</span>
+        </div>
+    );
+}

--- a/src/session/SessionContext.tsx
+++ b/src/session/SessionContext.tsx
@@ -28,6 +28,8 @@ export function SessionProvider({ hydrator, children, fallback }: SessionProvide
         setApiKey: hydrator.setApiKey,
         setGenerateDraft: hydrator.setGenerateDraft,
         setAutopilotSettings: hydrator.setAutopilotSettings,
+        setGenerateLineageSource: hydrator.setGenerateLineageSource,
+        clearGenerateLineageSource: hydrator.clearGenerateLineageSource,
     }), [state, hydrator]);
 
     if (!state.isHydrated) {

--- a/src/session/SessionContext.tsx
+++ b/src/session/SessionContext.tsx
@@ -27,6 +27,7 @@ export function SessionProvider({ hydrator, children, fallback }: SessionProvide
         state,
         setApiKey: hydrator.setApiKey,
         setGenerateDraft: hydrator.setGenerateDraft,
+        setAutopilotSettings: hydrator.setAutopilotSettings,
     }), [state, hydrator]);
 
     if (!state.isHydrated) {

--- a/src/session/SessionContext.tsx
+++ b/src/session/SessionContext.tsx
@@ -26,6 +26,7 @@ export function SessionProvider({ hydrator, children, fallback }: SessionProvide
     const value = useMemo<SessionContextValue>(() => ({
         state,
         setApiKey: hydrator.setApiKey,
+        setGenerateDraft: hydrator.setGenerateDraft,
     }), [state, hydrator]);
 
     if (!state.isHydrated) {

--- a/src/session/SessionHydrator.test.ts
+++ b/src/session/SessionHydrator.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { createSessionHydrator, type SessionHydratorDeps } from './SessionHydrator';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
 import {
     DEFAULT_GENERATE_DRAFT,
     type GenerateDraft,
@@ -105,10 +110,60 @@ class FlakyGenerateDraftPort implements GenerateDraftPort {
     }
 }
 
+class InMemoryAutopilotSettingsPort implements AutopilotSettingsPort {
+    settings: AutopilotSettings | null;
+    saveCalls: AutopilotSettings[] = [];
+    clearCalls = 0;
+
+    constructor(initial: AutopilotSettings | null = null) {
+        this.settings = initial;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<AutopilotSettings | null> {
+        return this.settings;
+    }
+
+    async save(settings: AutopilotSettings): Promise<void> {
+        this.saveCalls.push(settings);
+        this.settings = settings;
+    }
+
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.settings = null;
+    }
+}
+
+class FlakyAutopilotSettingsPort implements AutopilotSettingsPort {
+    private shouldFail: 'save' | 'load' | 'clear' | null;
+
+    constructor(failOn: 'save' | 'load' | 'clear' | null = null) {
+        this.shouldFail = failOn;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<AutopilotSettings | null> {
+        if (this.shouldFail === 'load') throw new Error('load autopilot failed');
+        return null;
+    }
+
+    async save(): Promise<void> {
+        if (this.shouldFail === 'save') throw new Error('save autopilot failed');
+    }
+
+    async clear(): Promise<void> {
+        if (this.shouldFail === 'clear') throw new Error('clear autopilot failed');
+    }
+}
+
 function makeHydrator(deps: Partial<SessionHydratorDeps> = {}) {
     return createSessionHydrator({
         credentialsPort: deps.credentialsPort ?? new InMemoryCredentialsPort(),
         generateDraftPort: deps.generateDraftPort ?? new InMemoryGenerateDraftPort(),
+        autopilotSettingsPort: deps.autopilotSettingsPort ?? new InMemoryAutopilotSettingsPort(),
         bootstrap: deps.bootstrap,
     });
 }
@@ -127,17 +182,32 @@ function makeDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft {
     };
 }
 
+function makeAutopilotSettings(overrides: Partial<AutopilotSettings> = {}): AutopilotSettings {
+    return {
+        mode: 'autopilot',
+        goal: 'A rainy Tokyo street at night',
+        maxIterations: 6,
+        satisfactionThreshold: 85,
+        ...overrides,
+    };
+}
+
 describe('SessionHydrator.hydrate', () => {
     it('hydrates an empty store to defaults', async () => {
         const hydrator = makeHydrator({
             credentialsPort: new InMemoryCredentialsPort(null),
             generateDraftPort: new InMemoryGenerateDraftPort(null),
+            autopilotSettingsPort: new InMemoryAutopilotSettingsPort(null),
         });
 
         await hydrator.hydrate();
 
         expect(hydrator.getState()).toEqual({
-            snapshot: { apiKey: '', generateDraft: DEFAULT_GENERATE_DRAFT },
+            snapshot: {
+                apiKey: '',
+                generateDraft: DEFAULT_GENERATE_DRAFT,
+                autopilotSettings: DEFAULT_AUTOPILOT_SETTINGS,
+            },
             isHydrated: true,
             lastError: null,
         });
@@ -155,6 +225,28 @@ describe('SessionHydrator.hydrate', () => {
         expect(hydrator.getState().snapshot.apiKey).toBe('sk-stored');
         expect(hydrator.getState().snapshot.generateDraft).toEqual(storedDraft);
         expect(hydrator.getState().isHydrated).toBe(true);
+    });
+
+    it('hydrates persisted autopilot settings alongside other domains', async () => {
+        const storedSettings = makeAutopilotSettings({ goal: 'stored goal' });
+        const hydrator = makeHydrator({
+            autopilotSettingsPort: new InMemoryAutopilotSettingsPort(storedSettings),
+        });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState().snapshot.autopilotSettings).toEqual(storedSettings);
+        expect(hydrator.getAutopilotSettings()).toEqual(storedSettings);
+    });
+
+    it('falls back to default autopilot settings when the port returns null', async () => {
+        const hydrator = makeHydrator({
+            autopilotSettingsPort: new InMemoryAutopilotSettingsPort(null),
+        });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState().snapshot.autopilotSettings).toEqual(DEFAULT_AUTOPILOT_SETTINGS);
     });
 
     it('loads api key and draft in parallel', async () => {
@@ -221,6 +313,20 @@ describe('SessionHydrator.hydrate', () => {
         expect(state.lastError?.domain).toBe('generateDraft');
         expect(state.lastError?.operation).toBe('load');
         expect(state.snapshot.generateDraft).toEqual(DEFAULT_GENERATE_DRAFT);
+    });
+
+    it('records a load error and stays hydrated when the autopilot port fails', async () => {
+        const hydrator = makeHydrator({
+            autopilotSettingsPort: new FlakyAutopilotSettingsPort('load'),
+        });
+
+        await hydrator.hydrate();
+
+        const state = hydrator.getState();
+        expect(state.isHydrated).toBe(true);
+        expect(state.lastError?.domain).toBe('autopilotSettings');
+        expect(state.lastError?.operation).toBe('load');
+        expect(state.snapshot.autopilotSettings).toEqual(DEFAULT_AUTOPILOT_SETTINGS);
     });
 
     it('only runs hydration once across concurrent calls', async () => {
@@ -390,6 +496,62 @@ describe('SessionHydrator.setGenerateDraft', () => {
     });
 });
 
+describe('SessionHydrator.setAutopilotSettings', () => {
+    it('updates the snapshot optimistically before the port settles', async () => {
+        let resolveSave: (() => void) | null = null;
+        const port = new InMemoryAutopilotSettingsPort();
+        port.save = vi.fn(async (settings: AutopilotSettings) => {
+            await new Promise<void>((resolve) => {
+                resolveSave = resolve;
+            });
+            port.settings = settings;
+        });
+
+        const hydrator = makeHydrator({ autopilotSettingsPort: port });
+        await hydrator.hydrate();
+
+        const next = makeAutopilotSettings({ goal: 'new goal' });
+        const writePromise = hydrator.setAutopilotSettings(next);
+
+        expect(hydrator.getState().snapshot.autopilotSettings).toEqual(next);
+
+        resolveSave!();
+        await writePromise;
+
+        expect(port.save).toHaveBeenCalledWith(next);
+    });
+
+    it('records a save error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyAutopilotSettingsPort('save');
+        const hydrator = makeHydrator({ autopilotSettingsPort: port });
+        await hydrator.hydrate();
+
+        const next = makeAutopilotSettings({ goal: 'new goal' });
+        await hydrator.setAutopilotSettings(next);
+
+        const state = hydrator.getState();
+        expect(state.snapshot.autopilotSettings).toEqual(next);
+        expect(state.lastError?.domain).toBe('autopilotSettings');
+        expect(state.lastError?.operation).toBe('save');
+        expect(state.lastError?.cause.message).toBe('save autopilot failed');
+    });
+
+    it('notifies subscribers on autopilot setting changes', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+        const hydrator = makeHydrator({ autopilotSettingsPort: port });
+
+        const listener = vi.fn();
+        hydrator.subscribe(listener);
+
+        await hydrator.hydrate();
+        const callsAfterHydrate = listener.mock.calls.length;
+
+        await hydrator.setAutopilotSettings(makeAutopilotSettings({ goal: 'next' }));
+
+        expect(listener.mock.calls.length).toBeGreaterThan(callsAfterHydrate);
+    });
+});
+
 describe('SessionHydrator.refresh', () => {
     it('re-reads the api key from the port after external writes', async () => {
         const port = new InMemoryCredentialsPort();
@@ -412,5 +574,17 @@ describe('SessionHydrator.refresh', () => {
         await hydrator.refresh();
 
         expect(hydrator.getState().snapshot.generateDraft).toEqual(next);
+    });
+
+    it('re-reads autopilot settings from the port after external writes', async () => {
+        const port = new InMemoryAutopilotSettingsPort();
+        const hydrator = makeHydrator({ autopilotSettingsPort: port });
+        await hydrator.hydrate();
+
+        const next = makeAutopilotSettings({ goal: 'external write' });
+        port.settings = next;
+        await hydrator.refresh();
+
+        expect(hydrator.getState().snapshot.autopilotSettings).toEqual(next);
     });
 });

--- a/src/session/SessionHydrator.test.ts
+++ b/src/session/SessionHydrator.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionHydrator, type SessionHydratorDeps } from './SessionHydrator';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+
+class InMemoryCredentialsPort implements CredentialsPort {
+    apiKey: string | null;
+    saveCalls: string[] = [];
+    clearCalls = 0;
+
+    constructor(initial: string | null = null) {
+        this.apiKey = initial;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<string | null> {
+        return this.apiKey;
+    }
+
+    async save(apiKey: string): Promise<void> {
+        this.saveCalls.push(apiKey);
+        this.apiKey = apiKey;
+    }
+
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.apiKey = null;
+    }
+}
+
+class FlakyCredentialsPort implements CredentialsPort {
+    private shouldFail: 'save' | 'clear' | 'load' | null;
+
+    constructor(failOn: 'save' | 'clear' | 'load' | null = null) {
+        this.shouldFail = failOn;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<string | null> {
+        if (this.shouldFail === 'load') throw new Error('load failed');
+        return null;
+    }
+
+    async save(): Promise<void> {
+        if (this.shouldFail === 'save') throw new Error('save failed');
+    }
+
+    async clear(): Promise<void> {
+        if (this.shouldFail === 'clear') throw new Error('clear failed');
+    }
+}
+
+function makeHydrator(deps: Partial<SessionHydratorDeps> = {}) {
+    return createSessionHydrator({
+        credentialsPort: deps.credentialsPort ?? new InMemoryCredentialsPort(),
+        bootstrap: deps.bootstrap,
+    });
+}
+
+describe('SessionHydrator.hydrate', () => {
+    it('hydrates an empty store to defaults', async () => {
+        const hydrator = makeHydrator({ credentialsPort: new InMemoryCredentialsPort(null) });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState()).toEqual({
+            snapshot: { apiKey: '' },
+            isHydrated: true,
+            lastError: null,
+        });
+    });
+
+    it('hydrates a populated store with the persisted api key', async () => {
+        const hydrator = makeHydrator({ credentialsPort: new InMemoryCredentialsPort('sk-stored') });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState().snapshot.apiKey).toBe('sk-stored');
+        expect(hydrator.getState().isHydrated).toBe(true);
+    });
+
+    it('awaits the bootstrap step before loading from the port', async () => {
+        const order: string[] = [];
+        const port = new InMemoryCredentialsPort('sk-stored');
+        const originalLoad = port.load.bind(port);
+        port.load = async () => {
+            order.push('load');
+            return originalLoad();
+        };
+        const bootstrap = vi.fn(async () => {
+            order.push('bootstrap');
+        });
+
+        const hydrator = makeHydrator({ credentialsPort: port, bootstrap });
+        await hydrator.hydrate();
+
+        expect(order).toEqual(['bootstrap', 'load']);
+    });
+
+    it('records a load error and stays hydrated when the port fails', async () => {
+        const hydrator = makeHydrator({ credentialsPort: new FlakyCredentialsPort('load') });
+
+        await hydrator.hydrate();
+
+        const state = hydrator.getState();
+        expect(state.isHydrated).toBe(true);
+        expect(state.lastError?.operation).toBe('load');
+        expect(state.snapshot.apiKey).toBe('');
+    });
+
+    it('only runs hydration once across concurrent calls', async () => {
+        const port = new InMemoryCredentialsPort('sk-stored');
+        const loadSpy = vi.spyOn(port, 'load');
+        const hydrator = makeHydrator({ credentialsPort: port });
+
+        await Promise.all([hydrator.hydrate(), hydrator.hydrate(), hydrator.hydrate()]);
+
+        expect(loadSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('SessionHydrator.setApiKey', () => {
+    it('updates the snapshot optimistically before the port settles', async () => {
+        let resolveSave: (() => void) | null = null;
+        const port = new InMemoryCredentialsPort();
+        port.save = vi.fn(async (value: string) => {
+            await new Promise<void>((resolve) => {
+                resolveSave = resolve;
+            });
+            port.apiKey = value;
+        });
+
+        const hydrator = makeHydrator({ credentialsPort: port });
+        await hydrator.hydrate();
+
+        const writePromise = hydrator.setApiKey('sk-new');
+
+        expect(hydrator.getState().snapshot.apiKey).toBe('sk-new');
+
+        resolveSave!();
+        await writePromise;
+
+        expect(port.save).toHaveBeenCalledWith('sk-new');
+    });
+
+    it('routes empty values through clear()', async () => {
+        const port = new InMemoryCredentialsPort('sk-stored');
+        const hydrator = makeHydrator({ credentialsPort: port });
+        await hydrator.hydrate();
+
+        await hydrator.setApiKey('');
+
+        expect(hydrator.getState().snapshot.apiKey).toBe('');
+        expect(port.clearCalls).toBe(1);
+    });
+
+    it('records a save error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyCredentialsPort('save');
+        const hydrator = makeHydrator({ credentialsPort: port });
+        await hydrator.hydrate();
+
+        await hydrator.setApiKey('sk-new');
+
+        const state = hydrator.getState();
+        expect(state.snapshot.apiKey).toBe('sk-new');
+        expect(state.lastError?.operation).toBe('save');
+        expect(state.lastError?.cause.message).toBe('save failed');
+    });
+
+    it('records a clear error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyCredentialsPort('clear');
+        const hydrator = makeHydrator({ credentialsPort: port });
+        await hydrator.hydrate();
+
+        await hydrator.setApiKey('');
+
+        const state = hydrator.getState();
+        expect(state.snapshot.apiKey).toBe('');
+        expect(state.lastError?.operation).toBe('clear');
+    });
+
+    it('notifies subscribers on each state change', async () => {
+        const port = new InMemoryCredentialsPort('sk-initial');
+        const hydrator = makeHydrator({ credentialsPort: port });
+
+        const listener = vi.fn();
+        hydrator.subscribe(listener);
+
+        await hydrator.hydrate();
+        expect(listener).toHaveBeenCalled();
+
+        const callsAfterHydrate = listener.mock.calls.length;
+        await hydrator.setApiKey('sk-next');
+        expect(listener.mock.calls.length).toBeGreaterThan(callsAfterHydrate);
+    });
+
+    it('stops notifying after unsubscribe', async () => {
+        const port = new InMemoryCredentialsPort();
+        const hydrator = makeHydrator({ credentialsPort: port });
+
+        const listener = vi.fn();
+        const unsubscribe = hydrator.subscribe(listener);
+
+        await hydrator.hydrate();
+        unsubscribe();
+        const callCount = listener.mock.calls.length;
+
+        await hydrator.setApiKey('sk-next');
+
+        expect(listener.mock.calls.length).toBe(callCount);
+    });
+});
+
+describe('SessionHydrator.refresh', () => {
+    it('re-reads the api key from the port after external writes', async () => {
+        const port = new InMemoryCredentialsPort();
+        const hydrator = makeHydrator({ credentialsPort: port });
+        await hydrator.hydrate();
+
+        port.apiKey = 'sk-from-elsewhere';
+        await hydrator.refresh();
+
+        expect(hydrator.getState().snapshot.apiKey).toBe('sk-from-elsewhere');
+    });
+});

--- a/src/session/SessionHydrator.test.ts
+++ b/src/session/SessionHydrator.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createSessionHydrator, type SessionHydratorDeps } from './SessionHydrator';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import {
+    DEFAULT_GENERATE_DRAFT,
+    type GenerateDraft,
+} from '../generate-session/GenerateSession';
 
 class InMemoryCredentialsPort implements CredentialsPort {
     apiKey: string | null;
@@ -51,36 +56,131 @@ class FlakyCredentialsPort implements CredentialsPort {
     }
 }
 
+class InMemoryGenerateDraftPort implements GenerateDraftPort {
+    draft: GenerateDraft | null;
+    saveCalls: GenerateDraft[] = [];
+    clearCalls = 0;
+
+    constructor(initial: GenerateDraft | null = null) {
+        this.draft = initial;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateDraft | null> {
+        return this.draft;
+    }
+
+    async save(draft: GenerateDraft): Promise<void> {
+        this.saveCalls.push(draft);
+        this.draft = draft;
+    }
+
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.draft = null;
+    }
+}
+
+class FlakyGenerateDraftPort implements GenerateDraftPort {
+    private shouldFail: 'save' | 'load' | 'clear' | null;
+
+    constructor(failOn: 'save' | 'load' | 'clear' | null = null) {
+        this.shouldFail = failOn;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateDraft | null> {
+        if (this.shouldFail === 'load') throw new Error('load draft failed');
+        return null;
+    }
+
+    async save(): Promise<void> {
+        if (this.shouldFail === 'save') throw new Error('save draft failed');
+    }
+
+    async clear(): Promise<void> {
+        if (this.shouldFail === 'clear') throw new Error('clear draft failed');
+    }
+}
+
 function makeHydrator(deps: Partial<SessionHydratorDeps> = {}) {
     return createSessionHydrator({
         credentialsPort: deps.credentialsPort ?? new InMemoryCredentialsPort(),
+        generateDraftPort: deps.generateDraftPort ?? new InMemoryGenerateDraftPort(),
         bootstrap: deps.bootstrap,
     });
 }
 
+function makeDraft(overrides: Partial<GenerateDraft> = {}): GenerateDraft {
+    return {
+        prompt: 'a koi pond at dusk',
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'auto',
+        style: 'risograph poster',
+        lighting: 'golden hour',
+        palette: 'copper + teal + cream',
+        isSaved: false,
+        ...overrides,
+    };
+}
+
 describe('SessionHydrator.hydrate', () => {
     it('hydrates an empty store to defaults', async () => {
-        const hydrator = makeHydrator({ credentialsPort: new InMemoryCredentialsPort(null) });
+        const hydrator = makeHydrator({
+            credentialsPort: new InMemoryCredentialsPort(null),
+            generateDraftPort: new InMemoryGenerateDraftPort(null),
+        });
 
         await hydrator.hydrate();
 
         expect(hydrator.getState()).toEqual({
-            snapshot: { apiKey: '' },
+            snapshot: { apiKey: '', generateDraft: DEFAULT_GENERATE_DRAFT },
             isHydrated: true,
             lastError: null,
         });
     });
 
-    it('hydrates a populated store with the persisted api key', async () => {
-        const hydrator = makeHydrator({ credentialsPort: new InMemoryCredentialsPort('sk-stored') });
+    it('hydrates a populated store with the persisted api key and draft', async () => {
+        const storedDraft = makeDraft({ prompt: 'stored prompt' });
+        const hydrator = makeHydrator({
+            credentialsPort: new InMemoryCredentialsPort('sk-stored'),
+            generateDraftPort: new InMemoryGenerateDraftPort(storedDraft),
+        });
 
         await hydrator.hydrate();
 
         expect(hydrator.getState().snapshot.apiKey).toBe('sk-stored');
+        expect(hydrator.getState().snapshot.generateDraft).toEqual(storedDraft);
         expect(hydrator.getState().isHydrated).toBe(true);
     });
 
-    it('awaits the bootstrap step before loading from the port', async () => {
+    it('loads api key and draft in parallel', async () => {
+        const order: string[] = [];
+        const credentialsPort = new InMemoryCredentialsPort('sk-stored');
+        const draftPort = new InMemoryGenerateDraftPort(makeDraft());
+
+        credentialsPort.load = async () => {
+            order.push('apiKey-start');
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            order.push('apiKey-end');
+            return 'sk-stored';
+        };
+        draftPort.load = async () => {
+            order.push('draft-start');
+            return makeDraft();
+        };
+
+        const hydrator = makeHydrator({ credentialsPort, generateDraftPort: draftPort });
+        await hydrator.hydrate();
+
+        expect(order[0]).toBe('apiKey-start');
+        expect(order[1]).toBe('draft-start');
+    });
+
+    it('awaits the bootstrap step before loading from the ports', async () => {
         const order: string[] = [];
         const port = new InMemoryCredentialsPort('sk-stored');
         const originalLoad = port.load.bind(port);
@@ -95,18 +195,32 @@ describe('SessionHydrator.hydrate', () => {
         const hydrator = makeHydrator({ credentialsPort: port, bootstrap });
         await hydrator.hydrate();
 
-        expect(order).toEqual(['bootstrap', 'load']);
+        expect(order[0]).toBe('bootstrap');
+        expect(order).toContain('load');
     });
 
-    it('records a load error and stays hydrated when the port fails', async () => {
+    it('records a load error and stays hydrated when the credentials port fails', async () => {
         const hydrator = makeHydrator({ credentialsPort: new FlakyCredentialsPort('load') });
 
         await hydrator.hydrate();
 
         const state = hydrator.getState();
         expect(state.isHydrated).toBe(true);
+        expect(state.lastError?.domain).toBe('apiKey');
         expect(state.lastError?.operation).toBe('load');
         expect(state.snapshot.apiKey).toBe('');
+    });
+
+    it('records a load error and stays hydrated when the draft port fails', async () => {
+        const hydrator = makeHydrator({ generateDraftPort: new FlakyGenerateDraftPort('load') });
+
+        await hydrator.hydrate();
+
+        const state = hydrator.getState();
+        expect(state.isHydrated).toBe(true);
+        expect(state.lastError?.domain).toBe('generateDraft');
+        expect(state.lastError?.operation).toBe('load');
+        expect(state.snapshot.generateDraft).toEqual(DEFAULT_GENERATE_DRAFT);
     });
 
     it('only runs hydration once across concurrent calls', async () => {
@@ -212,6 +326,70 @@ describe('SessionHydrator.setApiKey', () => {
     });
 });
 
+describe('SessionHydrator.setGenerateDraft', () => {
+    it('updates the snapshot optimistically before the port settles', async () => {
+        let resolveSave: (() => void) | null = null;
+        const port = new InMemoryGenerateDraftPort();
+        port.save = vi.fn(async (draft: GenerateDraft) => {
+            await new Promise<void>((resolve) => {
+                resolveSave = resolve;
+            });
+            port.draft = draft;
+        });
+
+        const hydrator = makeHydrator({ generateDraftPort: port });
+        await hydrator.hydrate();
+
+        const next = makeDraft({ prompt: 'new prompt' });
+        const writePromise = hydrator.setGenerateDraft(next);
+
+        expect(hydrator.getState().snapshot.generateDraft).toEqual(next);
+
+        resolveSave!();
+        await writePromise;
+
+        expect(port.save).toHaveBeenCalledWith(next);
+    });
+
+    it('records a save error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyGenerateDraftPort('save');
+        const hydrator = makeHydrator({ generateDraftPort: port });
+        await hydrator.hydrate();
+
+        const next = makeDraft({ prompt: 'new prompt' });
+        await hydrator.setGenerateDraft(next);
+
+        const state = hydrator.getState();
+        expect(state.snapshot.generateDraft).toEqual(next);
+        expect(state.lastError?.domain).toBe('generateDraft');
+        expect(state.lastError?.operation).toBe('save');
+        expect(state.lastError?.cause.message).toBe('save draft failed');
+    });
+
+    it('notifies subscribers on draft changes', async () => {
+        const port = new InMemoryGenerateDraftPort();
+        const hydrator = makeHydrator({ generateDraftPort: port });
+
+        const listener = vi.fn();
+        hydrator.subscribe(listener);
+
+        await hydrator.hydrate();
+        const callsAfterHydrate = listener.mock.calls.length;
+
+        await hydrator.setGenerateDraft(makeDraft({ prompt: 'next' }));
+
+        expect(listener.mock.calls.length).toBeGreaterThan(callsAfterHydrate);
+    });
+
+    it('reflects the persisted draft via getDraft()', async () => {
+        const stored = makeDraft({ prompt: 'stored' });
+        const hydrator = makeHydrator({ generateDraftPort: new InMemoryGenerateDraftPort(stored) });
+        await hydrator.hydrate();
+
+        expect(hydrator.getDraft()).toEqual(stored);
+    });
+});
+
 describe('SessionHydrator.refresh', () => {
     it('re-reads the api key from the port after external writes', async () => {
         const port = new InMemoryCredentialsPort();
@@ -222,5 +400,17 @@ describe('SessionHydrator.refresh', () => {
         await hydrator.refresh();
 
         expect(hydrator.getState().snapshot.apiKey).toBe('sk-from-elsewhere');
+    });
+
+    it('re-reads the draft from the port after external writes', async () => {
+        const port = new InMemoryGenerateDraftPort();
+        const hydrator = makeHydrator({ generateDraftPort: port });
+        await hydrator.hydrate();
+
+        const next = makeDraft({ prompt: 'from-elsewhere' });
+        port.draft = next;
+        await hydrator.refresh();
+
+        expect(hydrator.getState().snapshot.generateDraft).toEqual(next);
     });
 });

--- a/src/session/SessionHydrator.test.ts
+++ b/src/session/SessionHydrator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createSessionHydrator, type SessionHydratorDeps } from './SessionHydrator';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
 import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import {
     DEFAULT_AUTOPILOT_SETTINGS,
@@ -10,6 +11,7 @@ import {
 import {
     DEFAULT_GENERATE_DRAFT,
     type GenerateDraft,
+    type GenerateLineageSource,
 } from '../generate-session/GenerateSession';
 
 class InMemoryCredentialsPort implements CredentialsPort {
@@ -159,11 +161,61 @@ class FlakyAutopilotSettingsPort implements AutopilotSettingsPort {
     }
 }
 
+class InMemoryGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    source: GenerateLineageSource | null;
+    saveCalls: GenerateLineageSource[] = [];
+    clearCalls = 0;
+
+    constructor(initial: GenerateLineageSource | null = null) {
+        this.source = initial;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateLineageSource | null> {
+        return this.source;
+    }
+
+    async save(source: GenerateLineageSource): Promise<void> {
+        this.saveCalls.push(source);
+        this.source = source;
+    }
+
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.source = null;
+    }
+}
+
+class FlakyGenerateLineageSourcePort implements GenerateLineageSourcePort {
+    private shouldFail: 'save' | 'load' | 'clear' | null;
+
+    constructor(failOn: 'save' | 'load' | 'clear' | null = null) {
+        this.shouldFail = failOn;
+    }
+
+    async init(): Promise<void> {}
+
+    async load(): Promise<GenerateLineageSource | null> {
+        if (this.shouldFail === 'load') throw new Error('load lineage source failed');
+        return null;
+    }
+
+    async save(): Promise<void> {
+        if (this.shouldFail === 'save') throw new Error('save lineage source failed');
+    }
+
+    async clear(): Promise<void> {
+        if (this.shouldFail === 'clear') throw new Error('clear lineage source failed');
+    }
+}
+
 function makeHydrator(deps: Partial<SessionHydratorDeps> = {}) {
     return createSessionHydrator({
         credentialsPort: deps.credentialsPort ?? new InMemoryCredentialsPort(),
         generateDraftPort: deps.generateDraftPort ?? new InMemoryGenerateDraftPort(),
         autopilotSettingsPort: deps.autopilotSettingsPort ?? new InMemoryAutopilotSettingsPort(),
+        generateLineageSourcePort: deps.generateLineageSourcePort ?? new InMemoryGenerateLineageSourcePort(),
         bootstrap: deps.bootstrap,
     });
 }
@@ -198,6 +250,7 @@ describe('SessionHydrator.hydrate', () => {
             credentialsPort: new InMemoryCredentialsPort(null),
             generateDraftPort: new InMemoryGenerateDraftPort(null),
             autopilotSettingsPort: new InMemoryAutopilotSettingsPort(null),
+            generateLineageSourcePort: new InMemoryGenerateLineageSourcePort(null),
         });
 
         await hydrator.hydrate();
@@ -207,6 +260,7 @@ describe('SessionHydrator.hydrate', () => {
                 apiKey: '',
                 generateDraft: DEFAULT_GENERATE_DRAFT,
                 autopilotSettings: DEFAULT_AUTOPILOT_SETTINGS,
+                generateLineageSource: null,
             },
             isHydrated: true,
             lastError: null,
@@ -327,6 +381,42 @@ describe('SessionHydrator.hydrate', () => {
         expect(state.lastError?.domain).toBe('autopilotSettings');
         expect(state.lastError?.operation).toBe('load');
         expect(state.snapshot.autopilotSettings).toEqual(DEFAULT_AUTOPILOT_SETTINGS);
+    });
+
+    it('hydrates a persisted lineage source alongside other domains', async () => {
+        const stored: GenerateLineageSource = { archiveImageId: 'archive-1', stepId: 'step-1' };
+        const hydrator = makeHydrator({
+            generateLineageSourcePort: new InMemoryGenerateLineageSourcePort(stored),
+        });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toEqual(stored);
+        expect(hydrator.getGenerateLineageSource()).toEqual(stored);
+    });
+
+    it('falls back to null lineage source when the port returns null', async () => {
+        const hydrator = makeHydrator({
+            generateLineageSourcePort: new InMemoryGenerateLineageSourcePort(null),
+        });
+
+        await hydrator.hydrate();
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toBeNull();
+    });
+
+    it('records a load error and stays hydrated when the lineage source port fails', async () => {
+        const hydrator = makeHydrator({
+            generateLineageSourcePort: new FlakyGenerateLineageSourcePort('load'),
+        });
+
+        await hydrator.hydrate();
+
+        const state = hydrator.getState();
+        expect(state.isHydrated).toBe(true);
+        expect(state.lastError?.domain).toBe('generateLineageSource');
+        expect(state.lastError?.operation).toBe('load');
+        expect(state.snapshot.generateLineageSource).toBeNull();
     });
 
     it('only runs hydration once across concurrent calls', async () => {
@@ -586,5 +676,111 @@ describe('SessionHydrator.refresh', () => {
         await hydrator.refresh();
 
         expect(hydrator.getState().snapshot.autopilotSettings).toEqual(next);
+    });
+
+    it('re-reads the lineage source from the port after external writes', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        const next: GenerateLineageSource = { archiveImageId: 'external-archive', stepId: 'external-step' };
+        port.source = next;
+        await hydrator.refresh();
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toEqual(next);
+    });
+});
+
+describe('SessionHydrator.setGenerateLineageSource', () => {
+    it('updates the snapshot optimistically before the port settles', async () => {
+        let resolveSave: (() => void) | null = null;
+        const port = new InMemoryGenerateLineageSourcePort();
+        port.save = vi.fn(async (source: GenerateLineageSource) => {
+            await new Promise<void>((resolve) => {
+                resolveSave = resolve;
+            });
+            port.source = source;
+        });
+
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        const next: GenerateLineageSource = { archiveImageId: 'archive-next', stepId: 'step-next' };
+        const writePromise = hydrator.setGenerateLineageSource(next);
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toEqual(next);
+
+        resolveSave!();
+        await writePromise;
+
+        expect(port.save).toHaveBeenCalledWith(next);
+    });
+
+    it('routes invalid values (no archiveImageId) through clear()', async () => {
+        const port = new InMemoryGenerateLineageSourcePort({ archiveImageId: 'archive-1', stepId: 'step-1' });
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        await hydrator.setGenerateLineageSource({ archiveImageId: '', stepId: null } as GenerateLineageSource);
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toBeNull();
+        expect(port.clearCalls).toBe(1);
+    });
+
+    it('records a save error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyGenerateLineageSourcePort('save');
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        const next: GenerateLineageSource = { archiveImageId: 'archive-1', stepId: 'step-1' };
+        await hydrator.setGenerateLineageSource(next);
+
+        const state = hydrator.getState();
+        expect(state.snapshot.generateLineageSource).toEqual(next);
+        expect(state.lastError?.domain).toBe('generateLineageSource');
+        expect(state.lastError?.operation).toBe('save');
+        expect(state.lastError?.cause.message).toBe('save lineage source failed');
+    });
+
+    it('notifies subscribers on lineage source changes', async () => {
+        const port = new InMemoryGenerateLineageSourcePort();
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+
+        const listener = vi.fn();
+        hydrator.subscribe(listener);
+
+        await hydrator.hydrate();
+        const callsAfterHydrate = listener.mock.calls.length;
+
+        await hydrator.setGenerateLineageSource({ archiveImageId: 'archive-next', stepId: null });
+
+        expect(listener.mock.calls.length).toBeGreaterThan(callsAfterHydrate);
+    });
+});
+
+describe('SessionHydrator.clearGenerateLineageSource', () => {
+    it('clears the snapshot and invokes port.clear()', async () => {
+        const port = new InMemoryGenerateLineageSourcePort({ archiveImageId: 'archive-1', stepId: 'step-1' });
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        await hydrator.clearGenerateLineageSource();
+
+        expect(hydrator.getState().snapshot.generateLineageSource).toBeNull();
+        expect(port.clearCalls).toBe(1);
+    });
+
+    it('records a clear error without corrupting the optimistic snapshot', async () => {
+        const port = new FlakyGenerateLineageSourcePort('clear');
+        const hydrator = makeHydrator({ generateLineageSourcePort: port });
+        await hydrator.hydrate();
+
+        await hydrator.clearGenerateLineageSource();
+
+        const state = hydrator.getState();
+        expect(state.snapshot.generateLineageSource).toBeNull();
+        expect(state.lastError?.domain).toBe('generateLineageSource');
+        expect(state.lastError?.operation).toBe('clear');
+        expect(state.lastError?.cause.message).toBe('clear lineage source failed');
     });
 });

--- a/src/session/SessionHydrator.ts
+++ b/src/session/SessionHydrator.ts
@@ -6,10 +6,13 @@ import {
 import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
 import {
     DEFAULT_GENERATE_DRAFT,
     sanitizeGenerateDraft,
+    sanitizeGenerateLineageSource,
     type GenerateDraft,
+    type GenerateLineageSource,
 } from '../generate-session/GenerateSession';
 import {
     EMPTY_SESSION_SNAPSHOT,
@@ -24,6 +27,7 @@ export interface SessionHydratorDeps {
     credentialsPort: CredentialsPort;
     generateDraftPort: GenerateDraftPort;
     autopilotSettingsPort: AutopilotSettingsPort;
+    generateLineageSourcePort: GenerateLineageSourcePort;
     bootstrap?: () => Promise<void>;
 }
 
@@ -33,10 +37,13 @@ export interface SessionHydrator {
     getState(): SessionState;
     getDraft(): GenerateDraft;
     getAutopilotSettings(): AutopilotSettings;
+    getGenerateLineageSource(): GenerateLineageSource | null;
     subscribe(listener: () => void): () => void;
     setApiKey(value: string): Promise<void>;
     setGenerateDraft(value: GenerateDraft): Promise<void>;
     setAutopilotSettings(value: AutopilotSettings): Promise<void>;
+    setGenerateLineageSource(value: GenerateLineageSource): Promise<void>;
+    clearGenerateLineageSource(): Promise<void>;
 }
 
 export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrator {
@@ -71,7 +78,7 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
     }
 
     async function loadFromPorts(markHydrated: boolean): Promise<void> {
-        const [apiKeyResult, draftResult, autopilotResult] = await Promise.all([
+        const [apiKeyResult, draftResult, autopilotResult, lineageSourceResult] = await Promise.all([
             deps.credentialsPort.load().then(
                 (value) => ({ ok: true as const, value }),
                 (error) => ({ ok: false as const, error }),
@@ -84,6 +91,10 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 (value) => ({ ok: true as const, value }),
                 (error) => ({ ok: false as const, error }),
             ),
+            deps.generateLineageSourcePort.load().then(
+                (value) => ({ ok: true as const, value }),
+                (error) => ({ ok: false as const, error }),
+            ),
         ]);
 
         const nextApiKey = apiKeyResult.ok ? (apiKeyResult.value ?? '') : state.snapshot.apiKey;
@@ -93,6 +104,9 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
         const nextAutopilot = autopilotResult.ok
             ? (autopilotResult.value ? sanitizeAutopilotSettings(autopilotResult.value) : DEFAULT_AUTOPILOT_SETTINGS)
             : state.snapshot.autopilotSettings;
+        const nextLineageSource = lineageSourceResult.ok
+            ? (lineageSourceResult.value ? sanitizeGenerateLineageSource(lineageSourceResult.value) : null)
+            : state.snapshot.generateLineageSource;
 
         const loadError = !apiKeyResult.ok
             ? makeError('apiKey', 'load', apiKeyResult.error)
@@ -100,7 +114,9 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 ? makeError('generateDraft', 'load', draftResult.error)
                 : !autopilotResult.ok
                     ? makeError('autopilotSettings', 'load', autopilotResult.error)
-                    : null;
+                    : !lineageSourceResult.ok
+                        ? makeError('generateLineageSource', 'load', lineageSourceResult.error)
+                        : null;
 
         setState({
             snapshot: {
@@ -108,6 +124,7 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 apiKey: nextApiKey,
                 generateDraft: nextDraft,
                 autopilotSettings: nextAutopilot,
+                generateLineageSource: nextLineageSource,
             },
             isHydrated: markHydrated || state.isHydrated,
             lastError: loadError,
@@ -149,6 +166,9 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
         },
         getAutopilotSettings(): AutopilotSettings {
             return state.snapshot.autopilotSettings;
+        },
+        getGenerateLineageSource(): GenerateLineageSource | null {
+            return state.snapshot.generateLineageSource;
         },
         subscribe(listener: () => void): () => void {
             listeners.add(listener);
@@ -206,5 +226,42 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 recordError(makeError('autopilotSettings', 'save', error));
             }
         },
+        async setGenerateLineageSource(value: GenerateLineageSource): Promise<void> {
+            const sanitized = sanitizeGenerateLineageSource(value);
+            if (!sanitized) {
+                await clearLineageSource();
+                return;
+            }
+            const previousState = state;
+            setState({
+                ...previousState,
+                snapshot: { ...previousState.snapshot, generateLineageSource: sanitized },
+                lastError: null,
+            });
+
+            try {
+                await deps.generateLineageSourcePort.save(sanitized);
+            } catch (error) {
+                recordError(makeError('generateLineageSource', 'save', error));
+            }
+        },
+        clearGenerateLineageSource(): Promise<void> {
+            return clearLineageSource();
+        },
     };
+
+    async function clearLineageSource(): Promise<void> {
+        const previousState = state;
+        setState({
+            ...previousState,
+            snapshot: { ...previousState.snapshot, generateLineageSource: null },
+            lastError: null,
+        });
+
+        try {
+            await deps.generateLineageSourcePort.clear();
+        } catch (error) {
+            recordError(makeError('generateLineageSource', 'clear', error));
+        }
+    }
 }

--- a/src/session/SessionHydrator.ts
+++ b/src/session/SessionHydrator.ts
@@ -1,0 +1,135 @@
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import {
+    EMPTY_SESSION_SNAPSHOT,
+    INITIAL_SESSION_STATE,
+    type SessionError,
+    type SessionState,
+} from './types';
+
+export interface SessionHydratorDeps {
+    credentialsPort: CredentialsPort;
+    bootstrap?: () => Promise<void>;
+}
+
+export interface SessionHydrator {
+    hydrate(): Promise<void>;
+    refresh(): Promise<void>;
+    getState(): SessionState;
+    subscribe(listener: () => void): () => void;
+    setApiKey(value: string): Promise<void>;
+}
+
+export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrator {
+    let state: SessionState = INITIAL_SESSION_STATE;
+    const listeners = new Set<() => void>();
+    let hydrationPromise: Promise<void> | null = null;
+
+    function notify() {
+        for (const listener of listeners) {
+            listener();
+        }
+    }
+
+    function setState(next: SessionState) {
+        state = next;
+        notify();
+    }
+
+    function recordError(error: SessionError) {
+        setState({
+            ...state,
+            lastError: error,
+        });
+    }
+
+    function toError(value: unknown): Error {
+        return value instanceof Error ? value : new Error(String(value));
+    }
+
+    async function loadFromPort(markHydrated: boolean): Promise<void> {
+        try {
+            const apiKey = await deps.credentialsPort.load();
+            setState({
+                snapshot: { ...EMPTY_SESSION_SNAPSHOT, apiKey: apiKey ?? '' },
+                isHydrated: markHydrated || state.isHydrated,
+                lastError: null,
+            });
+        } catch (error) {
+            setState({
+                snapshot: state.snapshot,
+                isHydrated: markHydrated || state.isHydrated,
+                lastError: {
+                    domain: 'apiKey',
+                    operation: 'load',
+                    cause: toError(error),
+                },
+            });
+        }
+    }
+
+    return {
+        hydrate(): Promise<void> {
+            if (hydrationPromise) {
+                return hydrationPromise;
+            }
+
+            hydrationPromise = (async () => {
+                if (deps.bootstrap) {
+                    try {
+                        await deps.bootstrap();
+                    } catch (error) {
+                        setState({
+                            snapshot: EMPTY_SESSION_SNAPSHOT,
+                            isHydrated: true,
+                            lastError: {
+                                domain: 'apiKey',
+                                operation: 'load',
+                                cause: toError(error),
+                            },
+                        });
+                        return;
+                    }
+                }
+                await loadFromPort(true);
+            })();
+
+            return hydrationPromise;
+        },
+        refresh(): Promise<void> {
+            return loadFromPort(false);
+        },
+        getState(): SessionState {
+            return state;
+        },
+        subscribe(listener: () => void): () => void {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        async setApiKey(value: string): Promise<void> {
+            const previousState = state;
+            setState({
+                ...previousState,
+                snapshot: { ...previousState.snapshot, apiKey: value },
+                lastError: null,
+            });
+
+            const operation = value === '' ? 'clear' : 'save';
+
+            try {
+                if (operation === 'clear') {
+                    await deps.credentialsPort.clear();
+                } else {
+                    await deps.credentialsPort.save(value);
+                }
+            } catch (error) {
+                recordError({
+                    domain: 'apiKey',
+                    operation,
+                    cause: toError(error),
+                });
+            }
+        },
+    };
+}

--- a/src/session/SessionHydrator.ts
+++ b/src/session/SessionHydrator.ts
@@ -1,3 +1,9 @@
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    sanitizeAutopilotSettings,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
 import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
 import {
@@ -17,6 +23,7 @@ import {
 export interface SessionHydratorDeps {
     credentialsPort: CredentialsPort;
     generateDraftPort: GenerateDraftPort;
+    autopilotSettingsPort: AutopilotSettingsPort;
     bootstrap?: () => Promise<void>;
 }
 
@@ -25,9 +32,11 @@ export interface SessionHydrator {
     refresh(): Promise<void>;
     getState(): SessionState;
     getDraft(): GenerateDraft;
+    getAutopilotSettings(): AutopilotSettings;
     subscribe(listener: () => void): () => void;
     setApiKey(value: string): Promise<void>;
     setGenerateDraft(value: GenerateDraft): Promise<void>;
+    setAutopilotSettings(value: AutopilotSettings): Promise<void>;
 }
 
 export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrator {
@@ -62,12 +71,16 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
     }
 
     async function loadFromPorts(markHydrated: boolean): Promise<void> {
-        const [apiKeyResult, draftResult] = await Promise.all([
+        const [apiKeyResult, draftResult, autopilotResult] = await Promise.all([
             deps.credentialsPort.load().then(
                 (value) => ({ ok: true as const, value }),
                 (error) => ({ ok: false as const, error }),
             ),
             deps.generateDraftPort.load().then(
+                (value) => ({ ok: true as const, value }),
+                (error) => ({ ok: false as const, error }),
+            ),
+            deps.autopilotSettingsPort.load().then(
                 (value) => ({ ok: true as const, value }),
                 (error) => ({ ok: false as const, error }),
             ),
@@ -77,18 +90,24 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
         const nextDraft = draftResult.ok
             ? (draftResult.value ? sanitizeGenerateDraft(draftResult.value) : DEFAULT_GENERATE_DRAFT)
             : state.snapshot.generateDraft;
+        const nextAutopilot = autopilotResult.ok
+            ? (autopilotResult.value ? sanitizeAutopilotSettings(autopilotResult.value) : DEFAULT_AUTOPILOT_SETTINGS)
+            : state.snapshot.autopilotSettings;
 
         const loadError = !apiKeyResult.ok
             ? makeError('apiKey', 'load', apiKeyResult.error)
             : !draftResult.ok
                 ? makeError('generateDraft', 'load', draftResult.error)
-                : null;
+                : !autopilotResult.ok
+                    ? makeError('autopilotSettings', 'load', autopilotResult.error)
+                    : null;
 
         setState({
             snapshot: {
                 ...EMPTY_SESSION_SNAPSHOT,
                 apiKey: nextApiKey,
                 generateDraft: nextDraft,
+                autopilotSettings: nextAutopilot,
             },
             isHydrated: markHydrated || state.isHydrated,
             lastError: loadError,
@@ -127,6 +146,9 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
         },
         getDraft(): GenerateDraft {
             return state.snapshot.generateDraft;
+        },
+        getAutopilotSettings(): AutopilotSettings {
+            return state.snapshot.autopilotSettings;
         },
         subscribe(listener: () => void): () => void {
             listeners.add(listener);
@@ -167,6 +189,21 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 await deps.generateDraftPort.save(sanitized);
             } catch (error) {
                 recordError(makeError('generateDraft', 'save', error));
+            }
+        },
+        async setAutopilotSettings(value: AutopilotSettings): Promise<void> {
+            const sanitized = sanitizeAutopilotSettings(value);
+            const previousState = state;
+            setState({
+                ...previousState,
+                snapshot: { ...previousState.snapshot, autopilotSettings: sanitized },
+                lastError: null,
+            });
+
+            try {
+                await deps.autopilotSettingsPort.save(sanitized);
+            } catch (error) {
+                recordError(makeError('autopilotSettings', 'save', error));
             }
         },
     };

--- a/src/session/SessionHydrator.ts
+++ b/src/session/SessionHydrator.ts
@@ -1,13 +1,22 @@
 import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import {
+    DEFAULT_GENERATE_DRAFT,
+    sanitizeGenerateDraft,
+    type GenerateDraft,
+} from '../generate-session/GenerateSession';
 import {
     EMPTY_SESSION_SNAPSHOT,
     INITIAL_SESSION_STATE,
+    type SessionDomain,
     type SessionError,
+    type SessionOperation,
     type SessionState,
 } from './types';
 
 export interface SessionHydratorDeps {
     credentialsPort: CredentialsPort;
+    generateDraftPort: GenerateDraftPort;
     bootstrap?: () => Promise<void>;
 }
 
@@ -15,8 +24,10 @@ export interface SessionHydrator {
     hydrate(): Promise<void>;
     refresh(): Promise<void>;
     getState(): SessionState;
+    getDraft(): GenerateDraft;
     subscribe(listener: () => void): () => void;
     setApiKey(value: string): Promise<void>;
+    setGenerateDraft(value: GenerateDraft): Promise<void>;
 }
 
 export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrator {
@@ -46,25 +57,42 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
         return value instanceof Error ? value : new Error(String(value));
     }
 
-    async function loadFromPort(markHydrated: boolean): Promise<void> {
-        try {
-            const apiKey = await deps.credentialsPort.load();
-            setState({
-                snapshot: { ...EMPTY_SESSION_SNAPSHOT, apiKey: apiKey ?? '' },
-                isHydrated: markHydrated || state.isHydrated,
-                lastError: null,
-            });
-        } catch (error) {
-            setState({
-                snapshot: state.snapshot,
-                isHydrated: markHydrated || state.isHydrated,
-                lastError: {
-                    domain: 'apiKey',
-                    operation: 'load',
-                    cause: toError(error),
-                },
-            });
-        }
+    function makeError(domain: SessionDomain, operation: SessionOperation, cause: unknown): SessionError {
+        return { domain, operation, cause: toError(cause) };
+    }
+
+    async function loadFromPorts(markHydrated: boolean): Promise<void> {
+        const [apiKeyResult, draftResult] = await Promise.all([
+            deps.credentialsPort.load().then(
+                (value) => ({ ok: true as const, value }),
+                (error) => ({ ok: false as const, error }),
+            ),
+            deps.generateDraftPort.load().then(
+                (value) => ({ ok: true as const, value }),
+                (error) => ({ ok: false as const, error }),
+            ),
+        ]);
+
+        const nextApiKey = apiKeyResult.ok ? (apiKeyResult.value ?? '') : state.snapshot.apiKey;
+        const nextDraft = draftResult.ok
+            ? (draftResult.value ? sanitizeGenerateDraft(draftResult.value) : DEFAULT_GENERATE_DRAFT)
+            : state.snapshot.generateDraft;
+
+        const loadError = !apiKeyResult.ok
+            ? makeError('apiKey', 'load', apiKeyResult.error)
+            : !draftResult.ok
+                ? makeError('generateDraft', 'load', draftResult.error)
+                : null;
+
+        setState({
+            snapshot: {
+                ...EMPTY_SESSION_SNAPSHOT,
+                apiKey: nextApiKey,
+                generateDraft: nextDraft,
+            },
+            isHydrated: markHydrated || state.isHydrated,
+            lastError: loadError,
+        });
     }
 
     return {
@@ -81,25 +109,24 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                         setState({
                             snapshot: EMPTY_SESSION_SNAPSHOT,
                             isHydrated: true,
-                            lastError: {
-                                domain: 'apiKey',
-                                operation: 'load',
-                                cause: toError(error),
-                            },
+                            lastError: makeError('apiKey', 'load', error),
                         });
                         return;
                     }
                 }
-                await loadFromPort(true);
+                await loadFromPorts(true);
             })();
 
             return hydrationPromise;
         },
         refresh(): Promise<void> {
-            return loadFromPort(false);
+            return loadFromPorts(false);
         },
         getState(): SessionState {
             return state;
+        },
+        getDraft(): GenerateDraft {
+            return state.snapshot.generateDraft;
         },
         subscribe(listener: () => void): () => void {
             listeners.add(listener);
@@ -115,7 +142,7 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                 lastError: null,
             });
 
-            const operation = value === '' ? 'clear' : 'save';
+            const operation: SessionOperation = value === '' ? 'clear' : 'save';
 
             try {
                 if (operation === 'clear') {
@@ -124,11 +151,22 @@ export function createSessionHydrator(deps: SessionHydratorDeps): SessionHydrato
                     await deps.credentialsPort.save(value);
                 }
             } catch (error) {
-                recordError({
-                    domain: 'apiKey',
-                    operation,
-                    cause: toError(error),
-                });
+                recordError(makeError('apiKey', operation, error));
+            }
+        },
+        async setGenerateDraft(value: GenerateDraft): Promise<void> {
+            const sanitized = sanitizeGenerateDraft(value);
+            const previousState = state;
+            setState({
+                ...previousState,
+                snapshot: { ...previousState.snapshot, generateDraft: sanitized },
+                lastError: null,
+            });
+
+            try {
+                await deps.generateDraftPort.save(sanitized);
+            } catch (error) {
+                recordError(makeError('generateDraft', 'save', error));
             }
         },
     };

--- a/src/session/migrationContext.ts
+++ b/src/session/migrationContext.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export interface MigrationContextValue {
+    requestRerun: () => void;
+}
+
+export const MigrationContext = createContext<MigrationContextValue | null>(null);
+
+export function useMigrationCoordinator(): MigrationContextValue {
+    const value = useContext(MigrationContext);
+    if (!value) {
+        throw new Error('useMigrationCoordinator must be used within a MigrationGate');
+    }
+    return value;
+}

--- a/src/session/sessionBootstrap.ts
+++ b/src/session/sessionBootstrap.ts
@@ -1,4 +1,9 @@
-import { credentialsPort, generateDraftPort, initializeAuraPersistence } from '../db/AuraPersistence';
+import {
+    autopilotSettingsPort,
+    credentialsPort,
+    generateDraftPort,
+    initializeAuraPersistence,
+} from '../db/AuraPersistence';
 import { createGenerateSessionStore } from '../generate-session/GenerateSession';
 import { createLocalStorageMigrator } from './LocalStorageMigrator';
 import { createSessionHydrator } from './SessionHydrator';
@@ -6,12 +11,14 @@ import { createSessionHydrator } from './SessionHydrator';
 export const sessionHydrator = createSessionHydrator({
     credentialsPort,
     generateDraftPort,
+    autopilotSettingsPort,
     bootstrap: () => initializeAuraPersistence(),
 });
 
 export const localStorageMigrator = createLocalStorageMigrator({
     credentialsPort,
     generateDraftPort,
+    autopilotSettingsPort,
 });
 
 export const generateSessionStore = createGenerateSessionStore({

--- a/src/session/sessionBootstrap.ts
+++ b/src/session/sessionBootstrap.ts
@@ -1,12 +1,22 @@
-import { credentialsPort, initializeAuraPersistence } from '../db/AuraPersistence';
+import { credentialsPort, generateDraftPort, initializeAuraPersistence } from '../db/AuraPersistence';
+import { createGenerateSessionStore } from '../generate-session/GenerateSession';
 import { createLocalStorageMigrator } from './LocalStorageMigrator';
 import { createSessionHydrator } from './SessionHydrator';
 
 export const sessionHydrator = createSessionHydrator({
     credentialsPort,
+    generateDraftPort,
     bootstrap: () => initializeAuraPersistence(),
 });
 
 export const localStorageMigrator = createLocalStorageMigrator({
     credentialsPort,
+    generateDraftPort,
+});
+
+export const generateSessionStore = createGenerateSessionStore({
+    draftHandle: {
+        getDraft: () => sessionHydrator.getDraft(),
+        setDraft: (draft) => sessionHydrator.setGenerateDraft(draft),
+    },
 });

--- a/src/session/sessionBootstrap.ts
+++ b/src/session/sessionBootstrap.ts
@@ -2,6 +2,7 @@ import {
     autopilotSettingsPort,
     credentialsPort,
     generateDraftPort,
+    generateLineageSourcePort,
     initializeAuraPersistence,
 } from '../db/AuraPersistence';
 import { createGenerateSessionStore } from '../generate-session/GenerateSession';
@@ -12,6 +13,7 @@ export const sessionHydrator = createSessionHydrator({
     credentialsPort,
     generateDraftPort,
     autopilotSettingsPort,
+    generateLineageSourcePort,
     bootstrap: () => initializeAuraPersistence(),
 });
 
@@ -19,11 +21,17 @@ export const localStorageMigrator = createLocalStorageMigrator({
     credentialsPort,
     generateDraftPort,
     autopilotSettingsPort,
+    generateLineageSourcePort,
 });
 
 export const generateSessionStore = createGenerateSessionStore({
     draftHandle: {
         getDraft: () => sessionHydrator.getDraft(),
         setDraft: (draft) => sessionHydrator.setGenerateDraft(draft),
+    },
+    lineageSourceHandle: {
+        getLineageSource: () => sessionHydrator.getGenerateLineageSource(),
+        setLineageSource: (source) => sessionHydrator.setGenerateLineageSource(source),
+        clearLineageSource: () => sessionHydrator.clearGenerateLineageSource(),
     },
 });

--- a/src/session/sessionBootstrap.ts
+++ b/src/session/sessionBootstrap.ts
@@ -1,0 +1,12 @@
+import { credentialsPort, initializeAuraPersistence } from '../db/AuraPersistence';
+import { createLocalStorageMigrator } from './LocalStorageMigrator';
+import { createSessionHydrator } from './SessionHydrator';
+
+export const sessionHydrator = createSessionHydrator({
+    credentialsPort,
+    bootstrap: () => initializeAuraPersistence(),
+});
+
+export const localStorageMigrator = createLocalStorageMigrator({
+    credentialsPort,
+});

--- a/src/session/sessionContextValue.ts
+++ b/src/session/sessionContextValue.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+import type { SessionState } from './types';
+
+export interface SessionContextValue {
+    state: SessionState;
+    setApiKey: (value: string) => Promise<void>;
+}
+
+export const SessionContext = createContext<SessionContextValue | null>(null);
+
+export function useSessionContext(): SessionContextValue {
+    const value = useContext(SessionContext);
+    if (!value) {
+        throw new Error('useSessionContext must be used within a SessionProvider');
+    }
+    return value;
+}

--- a/src/session/sessionContextValue.ts
+++ b/src/session/sessionContextValue.ts
@@ -1,9 +1,11 @@
 import { createContext, useContext } from 'react';
+import type { GenerateDraft } from '../generate-session/GenerateSession';
 import type { SessionState } from './types';
 
 export interface SessionContextValue {
     state: SessionState;
     setApiKey: (value: string) => Promise<void>;
+    setGenerateDraft: (value: GenerateDraft) => Promise<void>;
 }
 
 export const SessionContext = createContext<SessionContextValue | null>(null);

--- a/src/session/sessionContextValue.ts
+++ b/src/session/sessionContextValue.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react';
+import type { AutopilotSettings } from '../autopilot/AutopilotSettings';
 import type { GenerateDraft } from '../generate-session/GenerateSession';
 import type { SessionState } from './types';
 
@@ -6,6 +7,7 @@ export interface SessionContextValue {
     state: SessionState;
     setApiKey: (value: string) => Promise<void>;
     setGenerateDraft: (value: GenerateDraft) => Promise<void>;
+    setAutopilotSettings: (value: AutopilotSettings) => Promise<void>;
 }
 
 export const SessionContext = createContext<SessionContextValue | null>(null);

--- a/src/session/sessionContextValue.ts
+++ b/src/session/sessionContextValue.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { AutopilotSettings } from '../autopilot/AutopilotSettings';
-import type { GenerateDraft } from '../generate-session/GenerateSession';
+import type { GenerateDraft, GenerateLineageSource } from '../generate-session/GenerateSession';
 import type { SessionState } from './types';
 
 export interface SessionContextValue {
@@ -8,6 +8,8 @@ export interface SessionContextValue {
     setApiKey: (value: string) => Promise<void>;
     setGenerateDraft: (value: GenerateDraft) => Promise<void>;
     setAutopilotSettings: (value: AutopilotSettings) => Promise<void>;
+    setGenerateLineageSource: (value: GenerateLineageSource) => Promise<void>;
+    clearGenerateLineageSource: () => Promise<void>;
 }
 
 export const SessionContext = createContext<SessionContextValue | null>(null);

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,12 +1,16 @@
+import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from '../generate-session/GenerateSession';
+
 export interface SessionSnapshot {
     apiKey: string;
+    generateDraft: GenerateDraft;
 }
 
 export const EMPTY_SESSION_SNAPSHOT: SessionSnapshot = {
     apiKey: '',
+    generateDraft: DEFAULT_GENERATE_DRAFT,
 };
 
-export type SessionDomain = 'apiKey';
+export type SessionDomain = 'apiKey' | 'generateDraft';
 
 export type SessionOperation = 'load' | 'save' | 'clear';
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -2,21 +2,27 @@ import {
     DEFAULT_AUTOPILOT_SETTINGS,
     type AutopilotSettings,
 } from '../autopilot/AutopilotSettings';
-import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from '../generate-session/GenerateSession';
+import {
+    DEFAULT_GENERATE_DRAFT,
+    type GenerateDraft,
+    type GenerateLineageSource,
+} from '../generate-session/GenerateSession';
 
 export interface SessionSnapshot {
     apiKey: string;
     generateDraft: GenerateDraft;
     autopilotSettings: AutopilotSettings;
+    generateLineageSource: GenerateLineageSource | null;
 }
 
 export const EMPTY_SESSION_SNAPSHOT: SessionSnapshot = {
     apiKey: '',
     generateDraft: DEFAULT_GENERATE_DRAFT,
     autopilotSettings: DEFAULT_AUTOPILOT_SETTINGS,
+    generateLineageSource: null,
 };
 
-export type SessionDomain = 'apiKey' | 'generateDraft' | 'autopilotSettings';
+export type SessionDomain = 'apiKey' | 'generateDraft' | 'autopilotSettings' | 'generateLineageSource';
 
 export type SessionOperation = 'load' | 'save' | 'clear';
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,29 @@
+export interface SessionSnapshot {
+    apiKey: string;
+}
+
+export const EMPTY_SESSION_SNAPSHOT: SessionSnapshot = {
+    apiKey: '',
+};
+
+export type SessionDomain = 'apiKey';
+
+export type SessionOperation = 'load' | 'save' | 'clear';
+
+export interface SessionError {
+    domain: SessionDomain;
+    operation: SessionOperation;
+    cause: Error;
+}
+
+export interface SessionState {
+    snapshot: SessionSnapshot;
+    isHydrated: boolean;
+    lastError: SessionError | null;
+}
+
+export const INITIAL_SESSION_STATE: SessionState = {
+    snapshot: EMPTY_SESSION_SNAPSHOT,
+    isHydrated: false,
+    lastError: null,
+};

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,16 +1,22 @@
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from '../generate-session/GenerateSession';
 
 export interface SessionSnapshot {
     apiKey: string;
     generateDraft: GenerateDraft;
+    autopilotSettings: AutopilotSettings;
 }
 
 export const EMPTY_SESSION_SNAPSHOT: SessionSnapshot = {
     apiKey: '',
     generateDraft: DEFAULT_GENERATE_DRAFT,
+    autopilotSettings: DEFAULT_AUTOPILOT_SETTINGS,
 };
 
-export type SessionDomain = 'apiKey' | 'generateDraft';
+export type SessionDomain = 'apiKey' | 'generateDraft' | 'autopilotSettings';
 
 export type SessionOperation = 'load' | 'save' | 'clear';
 

--- a/src/session/useApiKey.test.tsx
+++ b/src/session/useApiKey.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { SessionProvider } from './SessionContext';
+import { createSessionHydrator, type SessionHydrator } from './SessionHydrator';
+import { useApiKey } from './useApiKey';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+import type { AutopilotSettings } from '../autopilot/AutopilotSettings';
+import type { GenerateLineageSource } from '../generate-session/GenerateSession';
+
+class InMemoryCredentialsPort implements CredentialsPort {
+    apiKey: string | null;
+    saveCalls: string[] = [];
+    clearCalls = 0;
+
+    constructor(initial: string | null = null) {
+        this.apiKey = initial;
+    }
+
+    async init(): Promise<void> {}
+    async load(): Promise<string | null> {
+        return this.apiKey;
+    }
+    async save(apiKey: string): Promise<void> {
+        this.saveCalls.push(apiKey);
+        this.apiKey = apiKey;
+    }
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.apiKey = null;
+    }
+}
+
+class FailingOnSaveCredentialsPort implements CredentialsPort {
+    saveAttempts = 0;
+    async init(): Promise<void> {}
+    async load(): Promise<string | null> { return null; }
+    async save(): Promise<void> {
+        this.saveAttempts += 1;
+        throw new Error('save failed');
+    }
+    async clear(): Promise<void> {}
+}
+
+const emptyDraftPort: GenerateDraftPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyAutopilotPort: AutopilotSettingsPort = {
+    async init() {},
+    async load(): Promise<AutopilotSettings | null> { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyLineageSourcePort: GenerateLineageSourcePort = {
+    async init() {},
+    async load(): Promise<GenerateLineageSource | null> { return null; },
+    async save() {},
+    async clear() {},
+};
+
+function makeHydratorWithCredentials(credentialsPort: CredentialsPort): SessionHydrator {
+    return createSessionHydrator({
+        credentialsPort,
+        generateDraftPort: emptyDraftPort,
+        autopilotSettingsPort: emptyAutopilotPort,
+        generateLineageSourcePort: emptyLineageSourcePort,
+    });
+}
+
+async function renderUseApiKey(hydrator: SessionHydrator) {
+    await hydrator.hydrate();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+    );
+
+    const result = renderHook(() => useApiKey(), { wrapper });
+    await waitFor(() => {
+        expect(result.result.current).toBeDefined();
+    });
+    return result;
+}
+
+describe('useApiKey', () => {
+    it('reflects the hydrated api key from the session snapshot', async () => {
+        const port = new InMemoryCredentialsPort('sk-stored');
+        const hydrator = makeHydratorWithCredentials(port);
+
+        const { result } = await renderUseApiKey(hydrator);
+
+        expect(result.current.apiKey).toBe('sk-stored');
+        expect(result.current.lastError).toBeNull();
+    });
+
+    it('updates the snapshot optimistically and calls the credentials port on setApiKey', async () => {
+        const port = new InMemoryCredentialsPort('sk-initial');
+        const hydrator = makeHydratorWithCredentials(port);
+
+        const { result } = await renderUseApiKey(hydrator);
+
+        await act(async () => {
+            await result.current.setApiKey('sk-new');
+        });
+
+        expect(result.current.apiKey).toBe('sk-new');
+        expect(port.saveCalls).toEqual(['sk-new']);
+    });
+
+    it('surfaces a save error through lastError without corrupting the optimistic snapshot', async () => {
+        const port = new FailingOnSaveCredentialsPort();
+        const hydrator = makeHydratorWithCredentials(port);
+
+        const { result } = await renderUseApiKey(hydrator);
+
+        await act(async () => {
+            await result.current.setApiKey('sk-attempt');
+        });
+
+        expect(result.current.apiKey).toBe('sk-attempt');
+        expect(result.current.lastError?.domain).toBe('apiKey');
+        expect(result.current.lastError?.operation).toBe('save');
+        expect(result.current.lastError?.cause.message).toBe('save failed');
+        expect(port.saveAttempts).toBe(1);
+    });
+
+    it('routes empty values through clear on the credentials port', async () => {
+        const port = new InMemoryCredentialsPort('sk-stored');
+        const hydrator = makeHydratorWithCredentials(port);
+
+        const { result } = await renderUseApiKey(hydrator);
+
+        await act(async () => {
+            await result.current.setApiKey('');
+        });
+
+        expect(result.current.apiKey).toBe('');
+        expect(port.clearCalls).toBe(1);
+        expect(port.saveCalls).toEqual([]);
+    });
+
+    it('re-renders consumers when the api key changes', async () => {
+        const port = new InMemoryCredentialsPort('sk-initial');
+        const hydrator = makeHydratorWithCredentials(port);
+
+        const spy = vi.fn();
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+        );
+
+        await hydrator.hydrate();
+        const { result } = renderHook(() => {
+            const controller = useApiKey();
+            spy(controller.apiKey);
+            return controller;
+        }, { wrapper });
+
+        await waitFor(() => expect(spy).toHaveBeenCalled());
+        const callsAfterInitial = spy.mock.calls.length;
+
+        await act(async () => {
+            await result.current.setApiKey('sk-new');
+        });
+
+        expect(spy.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+    });
+});

--- a/src/session/useApiKey.ts
+++ b/src/session/useApiKey.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useSessionContext } from './sessionContextValue';
+import type { SessionError } from './types';
+
+export interface ApiKeyController {
+    apiKey: string;
+    setApiKey: (value: string) => Promise<void>;
+    lastError: SessionError | null;
+}
+
+export function useApiKey(): ApiKeyController {
+    const { state, setApiKey } = useSessionContext();
+
+    const update = useCallback(
+        (value: string) => setApiKey(value),
+        [setApiKey],
+    );
+
+    return {
+        apiKey: state.snapshot.apiKey,
+        setApiKey: update,
+        lastError: state.lastError,
+    };
+}

--- a/src/session/useAutopilotSettings.test.tsx
+++ b/src/session/useAutopilotSettings.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { SessionProvider } from './SessionContext';
+import { createSessionHydrator, type SessionHydrator } from './SessionHydrator';
+import { useAutopilotSettings } from './useAutopilotSettings';
+import {
+    DEFAULT_AUTOPILOT_SETTINGS,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
+
+class InMemoryAutopilotSettingsPort implements AutopilotSettingsPort {
+    settings: AutopilotSettings | null;
+    saveCalls: AutopilotSettings[] = [];
+    clearCalls = 0;
+
+    constructor(initial: AutopilotSettings | null = null) {
+        this.settings = initial;
+    }
+
+    async init(): Promise<void> {}
+    async load(): Promise<AutopilotSettings | null> { return this.settings; }
+    async save(settings: AutopilotSettings): Promise<void> {
+        this.saveCalls.push(settings);
+        this.settings = settings;
+    }
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.settings = null;
+    }
+}
+
+class FailingOnSaveAutopilotPort implements AutopilotSettingsPort {
+    saveAttempts = 0;
+    async init(): Promise<void> {}
+    async load(): Promise<AutopilotSettings | null> { return null; }
+    async save(): Promise<void> {
+        this.saveAttempts += 1;
+        throw new Error('save autopilot failed');
+    }
+    async clear(): Promise<void> {}
+}
+
+const emptyCredentialsPort: CredentialsPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyDraftPort: GenerateDraftPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyLineageSourcePort: GenerateLineageSourcePort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+function makeHydrator(autopilotPort: AutopilotSettingsPort): SessionHydrator {
+    return createSessionHydrator({
+        credentialsPort: emptyCredentialsPort,
+        generateDraftPort: emptyDraftPort,
+        autopilotSettingsPort: autopilotPort,
+        generateLineageSourcePort: emptyLineageSourcePort,
+    });
+}
+
+async function renderUseAutopilot(hydrator: SessionHydrator) {
+    await hydrator.hydrate();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+    );
+
+    const result = renderHook(() => useAutopilotSettings(), { wrapper });
+    await waitFor(() => {
+        expect(result.result.current).toBeDefined();
+    });
+    return result;
+}
+
+function makeSettings(overrides: Partial<AutopilotSettings> = {}): AutopilotSettings {
+    return {
+        mode: 'autopilot',
+        goal: 'A cozy scene',
+        maxIterations: 6,
+        satisfactionThreshold: 85,
+        ...overrides,
+    };
+}
+
+describe('useAutopilotSettings', () => {
+    it('reflects the hydrated autopilot settings from the session snapshot', async () => {
+        const stored = makeSettings({ goal: 'stored goal' });
+        const port = new InMemoryAutopilotSettingsPort(stored);
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        expect(result.current.settings).toEqual(stored);
+        expect(result.current.lastError).toBeNull();
+    });
+
+    it('falls back to defaults when the port is empty', async () => {
+        const port = new InMemoryAutopilotSettingsPort(null);
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        expect(result.current.settings).toEqual(DEFAULT_AUTOPILOT_SETTINGS);
+    });
+
+    it('updates the snapshot optimistically when setSettings is called', async () => {
+        const port = new InMemoryAutopilotSettingsPort(makeSettings());
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        const next = makeSettings({ goal: 'new goal' });
+        await act(async () => {
+            await result.current.setSettings(next);
+        });
+
+        expect(result.current.settings).toEqual(next);
+        expect(port.saveCalls.at(-1)).toEqual(next);
+    });
+
+    it('exposes per-field setters that update the snapshot and call the port', async () => {
+        const port = new InMemoryAutopilotSettingsPort(makeSettings());
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        await act(async () => {
+            await result.current.setMode('single-shot');
+        });
+        expect(result.current.settings.mode).toBe('single-shot');
+
+        await act(async () => {
+            await result.current.setGoal('updated goal');
+        });
+        expect(result.current.settings.goal).toBe('updated goal');
+
+        await act(async () => {
+            await result.current.setMaxIterations(8);
+        });
+        expect(result.current.settings.maxIterations).toBe(8);
+
+        await act(async () => {
+            await result.current.setSatisfactionThreshold(95);
+        });
+        expect(result.current.settings.satisfactionThreshold).toBe(95);
+
+        expect(port.saveCalls.length).toBe(4);
+        expect(port.saveCalls.at(-1)).toEqual({
+            mode: 'single-shot',
+            goal: 'updated goal',
+            maxIterations: 8,
+            satisfactionThreshold: 95,
+        });
+    });
+
+    it('surfaces save errors via lastError while keeping the optimistic snapshot', async () => {
+        const port = new FailingOnSaveAutopilotPort();
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        const next = makeSettings({ goal: 'doomed goal' });
+        await act(async () => {
+            await result.current.setSettings(next);
+        });
+
+        expect(result.current.settings).toEqual(next);
+        expect(result.current.lastError?.domain).toBe('autopilotSettings');
+        expect(result.current.lastError?.operation).toBe('save');
+        expect(result.current.lastError?.cause.message).toBe('save autopilot failed');
+        expect(port.saveAttempts).toBe(1);
+    });
+
+    it('notifies consumers on every setting change', async () => {
+        const port = new InMemoryAutopilotSettingsPort(makeSettings());
+        const hydrator = makeHydrator(port);
+
+        const spy = vi.fn();
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+        );
+
+        await hydrator.hydrate();
+        const { result } = renderHook(() => {
+            const value = useAutopilotSettings();
+            spy(value.settings.goal);
+            return value;
+        }, { wrapper });
+
+        await waitFor(() => expect(spy).toHaveBeenCalled());
+        const callsAfterInitial = spy.mock.calls.length;
+
+        await act(async () => {
+            await result.current.setGoal('trigger-change');
+        });
+
+        expect(spy.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+    });
+
+    it('scopes lastError to the autopilot domain', async () => {
+        // Force an error by using a failing autopilot port.
+        const port = new FailingOnSaveAutopilotPort();
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseAutopilot(hydrator);
+
+        await act(async () => {
+            await result.current.setGoal('changes');
+        });
+
+        expect(result.current.lastError?.domain).toBe('autopilotSettings');
+    });
+});

--- a/src/session/useAutopilotSettings.ts
+++ b/src/session/useAutopilotSettings.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react';
+import {
+    sanitizeAutopilotSettings,
+    type AutopilotMode,
+    type AutopilotSettings,
+} from '../autopilot/AutopilotSettings';
+import { useSessionContext } from './sessionContextValue';
+import type { SessionError } from './types';
+
+export interface AutopilotSettingsController {
+    settings: AutopilotSettings;
+    setSettings: (value: AutopilotSettings) => Promise<void>;
+    setMode: (value: AutopilotMode) => Promise<void>;
+    setGoal: (value: string) => Promise<void>;
+    setMaxIterations: (value: number) => Promise<void>;
+    setSatisfactionThreshold: (value: number) => Promise<void>;
+    lastError: SessionError | null;
+}
+
+export function useAutopilotSettings(): AutopilotSettingsController {
+    const { state, setAutopilotSettings } = useSessionContext();
+    const settings = state.snapshot.autopilotSettings;
+
+    const update = useCallback(
+        (value: AutopilotSettings) => setAutopilotSettings(sanitizeAutopilotSettings(value)),
+        [setAutopilotSettings],
+    );
+
+    const setMode = useCallback(
+        (value: AutopilotMode) => setAutopilotSettings(sanitizeAutopilotSettings({ ...settings, mode: value })),
+        [setAutopilotSettings, settings],
+    );
+
+    const setGoal = useCallback(
+        (value: string) => setAutopilotSettings(sanitizeAutopilotSettings({ ...settings, goal: value })),
+        [setAutopilotSettings, settings],
+    );
+
+    const setMaxIterations = useCallback(
+        (value: number) => setAutopilotSettings(sanitizeAutopilotSettings({ ...settings, maxIterations: value })),
+        [setAutopilotSettings, settings],
+    );
+
+    const setSatisfactionThreshold = useCallback(
+        (value: number) => setAutopilotSettings(sanitizeAutopilotSettings({ ...settings, satisfactionThreshold: value })),
+        [setAutopilotSettings, settings],
+    );
+
+    return {
+        settings,
+        setSettings: update,
+        setMode,
+        setGoal,
+        setMaxIterations,
+        setSatisfactionThreshold,
+        lastError: state.lastError?.domain === 'autopilotSettings' ? state.lastError : null,
+    };
+}

--- a/src/session/useGenerateLineageSource.test.tsx
+++ b/src/session/useGenerateLineageSource.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
+import { SessionProvider } from './SessionContext';
+import { createSessionHydrator, type SessionHydrator } from './SessionHydrator';
+import { useGenerateLineageSource } from './useGenerateLineageSource';
+import type { GenerateLineageSource } from '../generate-session/GenerateSession';
+import type { GenerateLineageSourcePort } from '../generate-session/SQLiteGenerateLineageSourcePort';
+import type { CredentialsPort } from '../credentials/SQLiteCredentialsPort';
+import type { GenerateDraftPort } from '../generate-session/SQLiteGenerateDraftPort';
+import type { AutopilotSettingsPort } from '../autopilot/SQLiteAutopilotSettingsPort';
+
+class InMemoryLineageSourcePort implements GenerateLineageSourcePort {
+    source: GenerateLineageSource | null;
+    saveCalls: GenerateLineageSource[] = [];
+    clearCalls = 0;
+
+    constructor(initial: GenerateLineageSource | null = null) {
+        this.source = initial;
+    }
+
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateLineageSource | null> { return this.source; }
+    async save(source: GenerateLineageSource): Promise<void> {
+        this.saveCalls.push(source);
+        this.source = source;
+    }
+    async clear(): Promise<void> {
+        this.clearCalls += 1;
+        this.source = null;
+    }
+}
+
+class FailingOnSaveLineageSourcePort implements GenerateLineageSourcePort {
+    saveAttempts = 0;
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateLineageSource | null> { return null; }
+    async save(): Promise<void> {
+        this.saveAttempts += 1;
+        throw new Error('save lineage source failed');
+    }
+    async clear(): Promise<void> {}
+}
+
+class FailingOnClearLineageSourcePort implements GenerateLineageSourcePort {
+    clearAttempts = 0;
+    async init(): Promise<void> {}
+    async load(): Promise<GenerateLineageSource | null> {
+        return { archiveImageId: 'archive-1', stepId: 'step-1' };
+    }
+    async save(): Promise<void> {}
+    async clear(): Promise<void> {
+        this.clearAttempts += 1;
+        throw new Error('clear lineage source failed');
+    }
+}
+
+const emptyCredentialsPort: CredentialsPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyDraftPort: GenerateDraftPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+const emptyAutopilotPort: AutopilotSettingsPort = {
+    async init() {},
+    async load() { return null; },
+    async save() {},
+    async clear() {},
+};
+
+function makeHydrator(lineagePort: GenerateLineageSourcePort): SessionHydrator {
+    return createSessionHydrator({
+        credentialsPort: emptyCredentialsPort,
+        generateDraftPort: emptyDraftPort,
+        autopilotSettingsPort: emptyAutopilotPort,
+        generateLineageSourcePort: lineagePort,
+    });
+}
+
+async function renderUseLineageSource(hydrator: SessionHydrator) {
+    await hydrator.hydrate();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <SessionProvider hydrator={hydrator}>{children}</SessionProvider>
+    );
+
+    const result = renderHook(() => useGenerateLineageSource(), { wrapper });
+    await waitFor(() => {
+        expect(result.result.current).toBeDefined();
+    });
+    return result;
+}
+
+describe('useGenerateLineageSource', () => {
+    it('reflects the hydrated lineage source from the session snapshot', async () => {
+        const stored: GenerateLineageSource = { archiveImageId: 'archive-1', stepId: 'step-1' };
+        const port = new InMemoryLineageSourcePort(stored);
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        expect(result.current.lineageSource).toEqual(stored);
+        expect(result.current.lastError).toBeNull();
+    });
+
+    it('returns null when no lineage source is persisted', async () => {
+        const port = new InMemoryLineageSourcePort(null);
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        expect(result.current.lineageSource).toBeNull();
+    });
+
+    it('updates the snapshot optimistically and writes through the port on setLineageSource', async () => {
+        const port = new InMemoryLineageSourcePort(null);
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        const next: GenerateLineageSource = { archiveImageId: 'archive-next', stepId: 'step-next' };
+        await act(async () => {
+            await result.current.setLineageSource(next);
+        });
+
+        expect(result.current.lineageSource).toEqual(next);
+        expect(port.saveCalls.at(-1)).toEqual(next);
+    });
+
+    it('routes invalid sources (empty archiveImageId) through clear()', async () => {
+        const port = new InMemoryLineageSourcePort({ archiveImageId: 'archive-1', stepId: 'step-1' });
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        await act(async () => {
+            await result.current.setLineageSource({ archiveImageId: '', stepId: null } as GenerateLineageSource);
+        });
+
+        expect(result.current.lineageSource).toBeNull();
+        expect(port.clearCalls).toBe(1);
+        expect(port.saveCalls.length).toBe(0);
+    });
+
+    it('clears the lineage source via clearLineageSource', async () => {
+        const port = new InMemoryLineageSourcePort({ archiveImageId: 'archive-1', stepId: 'step-1' });
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        await act(async () => {
+            await result.current.clearLineageSource();
+        });
+
+        expect(result.current.lineageSource).toBeNull();
+        expect(port.clearCalls).toBe(1);
+    });
+
+    it('surfaces save errors via lastError without corrupting the optimistic snapshot', async () => {
+        const port = new FailingOnSaveLineageSourcePort();
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        const next: GenerateLineageSource = { archiveImageId: 'archive-next', stepId: 'step-next' };
+        await act(async () => {
+            await result.current.setLineageSource(next);
+        });
+
+        expect(result.current.lineageSource).toEqual(next);
+        expect(result.current.lastError?.domain).toBe('generateLineageSource');
+        expect(result.current.lastError?.operation).toBe('save');
+        expect(result.current.lastError?.cause.message).toBe('save lineage source failed');
+        expect(port.saveAttempts).toBe(1);
+    });
+
+    it('surfaces clear errors via lastError without resurrecting the snapshot value', async () => {
+        const port = new FailingOnClearLineageSourcePort();
+        const hydrator = makeHydrator(port);
+
+        const { result } = await renderUseLineageSource(hydrator);
+
+        await act(async () => {
+            await result.current.clearLineageSource();
+        });
+
+        expect(result.current.lineageSource).toBeNull();
+        expect(result.current.lastError?.domain).toBe('generateLineageSource');
+        expect(result.current.lastError?.operation).toBe('clear');
+        expect(result.current.lastError?.cause.message).toBe('clear lineage source failed');
+        expect(port.clearAttempts).toBe(1);
+    });
+});

--- a/src/session/useGenerateLineageSource.ts
+++ b/src/session/useGenerateLineageSource.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import {
+    sanitizeGenerateLineageSource,
+    type GenerateLineageSource,
+} from '../generate-session/GenerateSession';
+import { useSessionContext } from './sessionContextValue';
+import type { SessionError } from './types';
+
+export interface GenerateLineageSourceController {
+    lineageSource: GenerateLineageSource | null;
+    setLineageSource: (value: GenerateLineageSource) => Promise<void>;
+    clearLineageSource: () => Promise<void>;
+    lastError: SessionError | null;
+}
+
+export function useGenerateLineageSource(): GenerateLineageSourceController {
+    const { state, setGenerateLineageSource, clearGenerateLineageSource } = useSessionContext();
+
+    const setLineageSource = useCallback(
+        async (value: GenerateLineageSource) => {
+            const sanitized = sanitizeGenerateLineageSource(value);
+            if (!sanitized) {
+                await clearGenerateLineageSource();
+                return;
+            }
+            await setGenerateLineageSource(sanitized);
+        },
+        [clearGenerateLineageSource, setGenerateLineageSource],
+    );
+
+    const clearLineageSource = useCallback(
+        () => clearGenerateLineageSource(),
+        [clearGenerateLineageSource],
+    );
+
+    return {
+        lineageSource: state.snapshot.generateLineageSource,
+        setLineageSource,
+        clearLineageSource,
+        lastError: state.lastError?.domain === 'generateLineageSource' ? state.lastError : null,
+    };
+}

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -5,9 +5,9 @@ import { useGenerateDraft } from '../generate-session/GenerateSession';
 import { useGenerateController } from '../generate-session/useGenerateController';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
-import { useLocalStorage } from '../hooks/useLocalStorage';
-import { DEFAULT_AUTOPILOT_MAX_ITERATIONS, DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD, MAX_AUTOPILOT_ITERATIONS } from '../autopilot/AutopilotSession';
+import { MAX_AUTOPILOT_ITERATIONS } from '../autopilot/AutopilotSession';
 import { goalPromptTranslator } from '../autopilot/GoalPromptTranslator';
+import { useAutopilotSettings } from '../session/useAutopilotSettings';
 
 interface GenerateViewProps {
     apiKey: string | null;
@@ -169,10 +169,14 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ value, options, onChange })
 
 const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
     const [draft, setDraft] = useGenerateDraft();
-    const [mode, setMode] = useLocalStorage<'single-shot' | 'autopilot'>('generate_mode', 'single-shot');
-    const [goal, setGoal] = useLocalStorage('generate_autopilot_goal', '');
-    const [maxIterations, setMaxIterations] = useLocalStorage('generate_autopilot_max_iterations', DEFAULT_AUTOPILOT_MAX_ITERATIONS);
-    const [satisfactionThreshold, setSatisfactionThreshold] = useLocalStorage('generate_autopilot_threshold', DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD);
+    const {
+        settings: autopilotSettings,
+        setMode,
+        setGoal,
+        setMaxIterations,
+        setSatisfactionThreshold,
+    } = useAutopilotSettings();
+    const { mode, goal, maxIterations, satisfactionThreshold } = autopilotSettings;
     const [isDragging, setIsDragging] = useState(false);
     const [viewingReferenceIndex, setViewingReferenceIndex] = useState<number | null>(null);
     const [showCostDisclosure, setShowCostDisclosure] = useState(false);
@@ -303,11 +307,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                         <div className="toggle-group">
                             <button
                                 className={!isAutopilotMode ? 'active' : ''}
-                                onClick={() => setMode('single-shot')}
+                                onClick={() => { void setMode('single-shot'); }}
                             >Single Shot</button>
                             <button
                                 className={isAutopilotMode ? 'active' : ''}
-                                onClick={() => setMode('autopilot')}
+                                onClick={() => { void setMode('autopilot'); }}
                             >Autopilot</button>
                         </div>
                     </div>
@@ -328,7 +332,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                 <textarea
                                     placeholder="Describe the outcome you want in plain language..."
                                     value={goal}
-                                    onChange={(e) => setGoal(e.target.value)}
+                                    onChange={(e) => { void setGoal(e.target.value); }}
                                     className="prompt-input autopilot-goal-input"
                                 />
                             </div>
@@ -341,7 +345,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                         min={1}
                                         max={MAX_AUTOPILOT_ITERATIONS}
                                         value={maxIterations}
-                                        onChange={(e) => setMaxIterations(Number(e.target.value))}
+                                        onChange={(e) => { void setMaxIterations(Number(e.target.value)); }}
                                         className="range-input"
                                     />
                                     <span className="autopilot-metric">{maxIterations}</span>
@@ -354,7 +358,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ apiKey, onSaveImage }) => {
                                         min={50}
                                         max={100}
                                         value={satisfactionThreshold}
-                                        onChange={(e) => setSatisfactionThreshold(Number(e.target.value))}
+                                        onChange={(e) => { void setSatisfactionThreshold(Number(e.target.value)); }}
                                         className="range-input"
                                     />
                                     <span className="autopilot-metric">{satisfactionThreshold}/100</span>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Key, Save, AlertCircle, CheckCircle2, ShieldCheck } from 'lucide-react';
+import { Key, Save, AlertCircle, CheckCircle2, ShieldCheck, DatabaseZap, RefreshCw } from 'lucide-react';
+import { useMigrationCoordinator } from '../session/migrationContext';
 
 interface SettingsViewProps {
     apiKey: string | null;
@@ -7,6 +8,7 @@ interface SettingsViewProps {
 }
 
 const SettingsView: React.FC<SettingsViewProps> = ({ apiKey, onApiKeyChange }) => {
+    const { requestRerun } = useMigrationCoordinator();
     const [tempKey, setTempKey] = useState(() => apiKey ?? '');
     const [status, setStatus] = useState<'idle' | 'saved'>('idle');
 
@@ -72,6 +74,27 @@ const SettingsView: React.FC<SettingsViewProps> = ({ apiKey, onApiKeyChange }) =
                         <span>Key is stored and ready for generation. Masked for security.</span>
                     </div>
                 )}
+            </section>
+
+            <section className="settings-section glass-panel">
+                <div className="section-title">
+                    <DatabaseZap size={20} className="icon-purple" />
+                    <h2>Storage Migration</h2>
+                </div>
+
+                <p className="section-desc">
+                    Move legacy session data from your browser's localStorage into the local SQLite database.
+                    Use this if you previously declined the prompt or want to re-check for migratable data.
+                </p>
+
+                <button
+                    className="aura-btn aura-btn--glass"
+                    onClick={requestRerun}
+                    type="button"
+                >
+                    <RefreshCw size={16} />
+                    Re-run migration
+                </button>
             </section>
         </div>
     );


### PR DESCRIPTION
Closes #16

Implements the full plan in `plans/localstorage-to-sqlite.md`: move API key, generate draft, autopilot settings, and lineage source from `localStorage` to the existing OPFS-backed SQLite database, with an explicit one-time migration prompt.

## What's in the PR

### New SQLite ports (all singleton tables, `CHECK(id=1)`)
- `SQLiteCredentialsPort` → `app_credentials`
- `SQLiteGenerateDraftPort` → `generate_draft`
- `SQLiteAutopilotSettingsPort` → `autopilot_settings`
- `SQLiteGenerateLineageSourcePort` → `generate_lineage_source`

All ports expose `init / load / save / clear`. Lineage source distinguishes row-absent from row-present-with-null-fields.

### Session infrastructure
- `SessionHydrator` — bootstraps `initializeAuraPersistence()`, loads all four ports in parallel into an in-memory snaps- `SessionHydrator` — bootstraps `initializeAuraPersistence()`, loads all four ports in parallel into an in-memory snaps- `SessionHydrator` — bootstraps `initializeAur� React bridge; shows a hydration loader until the snapshot is ready; synchronous reads, async writes.
- `useApiKey`, `useGenerateDraft`, `useAutopilotSettings`, `useGenerateLineageSource` — thin adapter hooks replacing the migrated `useL- `useApiKey`, \ si- `useApiKey`, `useGenerateDraft`, `useAutopilotSettinet- `useApiKey`, `useGenerateDraft`, `useAutopiec- `useApiKey`, `useGenerateDraft`, `useAutopilg - `useApiKey`, `useGenerateDraft`, `useAutopilotSettinde- `useApiKey`, `useGenerateDraft`, `useAutopilotSettings`, `u.
--------------------------------------------------------------------------------------------------------------------------- `-------------------------ra_storage_migration_decision` so it survives OPFS loss.
- `MigrationGate` + `MigrationPrompt` — modal rendered when decision is `null` and any migratable data is detected. API key value is **never** rendered (presence/absence only).
- Settings "Re-run migration" control resets the decision and re-shows the prompt immediately.

### Retained in `localStorage`
Transient UI state only: `aura_current_view`, `aura_theme`, `archive_search`, `archive_detail_lineage_collapsed`, `editor_<imageId>_*`, and the new `aura_storage_migration_decision` flag.

### Refactors
- `useAppPreferences` no longer manages the API key (defers to `useApiKey`).
- `GenerateSessionStore` internals route draft/lineage through the ports; public interface unchanged for consumers like `saveGeneratedImage`.
- `GenerateView` uses `useAutopilotSettings` instead of four `useLocalStorage` calls.

## Tests

**21 test files, 160 tests, all green.** Typecheck + lint clean.

New coverage:
- Port contract tests for all four ports (round-trip, overwrite, empty-load, single- Port contract tests for all four ports (round-trip, overwrite, empty-load, single- Port contract tests for all four ports (round-trip, overwrite, empty-load, single- Port contract(36 - Port contract tests for all four ports (round-trip, overwrite, empty-load, single- Port contrs.
- Adapter hook tests with React Testing Library (25 tests across the four hooks): hydrated state, optimistic updates, port invocation, error surfacing, consumer notification.

## Dependencies

- **No new runtime dependencies.**