### PR TITLE
refactor: dedup autopilot best-iteration selection

### DIFF
--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -67,12 +67,39 @@ describe('AutopilotSession', () => {
         expect(generate).toHaveBeenCalledTimes(3);
         expect(refine).toHaveBeenCalledTimes(2);
         expect(callbacks.onIterationComplete).toHaveBeenCalledTimes(3);
+        expect(callbacks.onIterationComplete.mock.calls.map(([, runningBest]) => runningBest.iterationNumber)).toEqual([1, 2, 2]);
         await expect(lineage.getChildren('step-1')).resolves.toEqual([
             expect.objectContaining({ id: 'step-2', parentStepId: 'step-1' }),
         ]);
         await expect(lineage.getChildren('step-2')).resolves.toEqual([
             expect.objectContaining({ id: 'step-3', parentStepId: 'step-2' }),
         ]);
+    });
+
+    it('exposes a running best that breaks score ties by earliest iteration', async () => {
+        const lineage = createStore();
+        const callbacks = { onIterationComplete: vi.fn(), onError: vi.fn() };
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 2,
+            satisfactionThreshold: 90,
+            generate: vi.fn()
+                .mockResolvedValueOnce('data:image/png;base64,one')
+                .mockResolvedValueOnce('data:image/png;base64,two'),
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ score: 80, feedback: ['Good.'] })
+                .mockResolvedValueOnce({ score: 80, feedback: ['Also good.'] }),
+            refine: vi.fn().mockResolvedValueOnce('prompt 2'),
+            lineageStore: lineage,
+            callbacks,
+        }).run();
+
+        expect(result.bestIteration).toEqual(expect.objectContaining({ iterationNumber: 1 }));
+        expect(callbacks.onIterationComplete.mock.calls.map(([, runningBest]) => runningBest.iterationNumber)).toEqual([1, 1]);
     });
 
     it('stops early when the satisfaction threshold is met', async () => {

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -26,7 +26,7 @@ export interface AutopilotSessionResult {
 }
 
 interface ProgressCallbacks {
-    onIterationComplete?: (iteration: AutopilotIteration) => void;
+    onIterationComplete?: (iteration: AutopilotIteration, runningBest: AutopilotIteration) => void;
     onError?: (error: Error, iterationNumber: number) => void;
 }
 
@@ -73,6 +73,7 @@ class DefaultAutopilotSession implements AutopilotSession {
         const runId = this.input.makeRunId?.() ?? crypto.randomUUID();
         let currentPrompt = this.input.initialPrompt;
         let parentStepId = this.input.initialParentStepId ?? null;
+        let runningBest: AutopilotIteration | null = null;
 
         for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
             try {
@@ -121,7 +122,8 @@ class DefaultAutopilotSession implements AutopilotSession {
                 };
 
                 iterations.push(completedIteration);
-                this.input.callbacks?.onIterationComplete?.(completedIteration);
+                runningBest = pickBetterIteration(runningBest, completedIteration);
+                this.input.callbacks?.onIterationComplete?.(completedIteration, runningBest);
                 parentStepId = step.id;
 
                 if (evaluation.score >= satisfactionThreshold) {
@@ -162,22 +164,25 @@ function buildResult(status: AutopilotSessionResult['status'], iterations: Autop
     };
 }
 
-function getBestIteration(iterations: AutopilotIteration[]) {
-    return iterations.reduce<AutopilotIteration | null>((best, iteration) => {
-        if (!best) {
-            return iteration;
-        }
+function getBestIteration(iterations: AutopilotIteration[]): AutopilotIteration | null {
+    return iterations.reduce<AutopilotIteration | null>(pickBetterIteration, null);
+}
 
-        if (iteration.score > best.score) {
-            return iteration;
-        }
+// Single source of truth for "what counts as best": highest score, ties broken by earliest iteration.
+function pickBetterIteration(best: AutopilotIteration | null, candidate: AutopilotIteration): AutopilotIteration {
+    if (!best) {
+        return candidate;
+    }
 
-        if (iteration.score === best.score && iteration.iterationNumber < best.iterationNumber) {
-            return iteration;
-        }
+    if (candidate.score > best.score) {
+        return candidate;
+    }
 
-        return best;
-    }, null);
+    if (candidate.score === best.score && candidate.iterationNumber < best.iterationNumber) {
+        return candidate;
+    }
+
+    return best;
 }
 
 export function createAutopilotSession(input: CreateAutopilotSessionInput): AutopilotSession {

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -20,7 +20,7 @@ interface RunGenerateAutopilotInput {
     maxIterations?: number;
     satisfactionThreshold?: number;
     onSessionCreated?: (session: ReturnType<typeof createAutopilotSession>) => void;
-    onIterationComplete?: (iteration: AutopilotSessionResult['iterations'][number]) => void;
+    onIterationComplete?: (iteration: AutopilotSessionResult['iterations'][number], runningBest: AutopilotSessionResult['iterations'][number]) => void;
     onError?: (error: Error, iterationNumber: number) => void;
 }
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -165,27 +165,12 @@ export function useGenerateController({
                 },
                 maxIterations: input.maxIterations,
                 satisfactionThreshold: input.satisfactionThreshold,
-                onIterationComplete: (iteration) => {
-                    setAutopilot((current) => {
-                        const iterations = [...current.iterations, iteration];
-                        const bestIteration = iterations.reduce<typeof iteration | null>((best, candidate) => {
-                            if (!best || candidate.score > best.score) {
-                                return candidate;
-                            }
-
-                            if (candidate.score === best.score && candidate.iterationNumber < best.iterationNumber) {
-                                return candidate;
-                            }
-
-                            return best;
-                        }, null);
-
-                        return {
-                            ...current,
-                            iterations,
-                            bestIterationNumber: bestIteration?.iterationNumber ?? null,
-                        };
-                    });
+                onIterationComplete: (iteration, runningBest) => {
+                    setAutopilot((current) => ({
+                        ...current,
+                        iterations: [...current.iterations, iteration],
+                        bestIterationNumber: runningBest.iterationNumber,
+                    }));
                     setCurrentResult(iteration.imageDataUrl);
                 },
                 onError: (error, iterationNumber) => {


### PR DESCRIPTION
## What

Dedup autopilot best-iteration selection. Closes #22.

The generate controller hook re-derived the best iteration on every iteration-complete event with its own max-score/earliest-tie reducer, duplicating `AutopilotSession`'s selection rule. A change to "what counts as best" had to be made in two places.

## How

- Extract the rule into a single `pickBetterIteration` in `AutopilotSession`, used by both terminal `getBestIteration` and a `runningBest` tracked across the loop.
- Session passes that running best to `onIterationComplete`; the hook consumes it for progressive display instead of re-computing it.
- On-screen behavior (best thumbnail highlight updating as iterations stream) unchanged.

## Acceptance criteria

- [x] Hook no longer contains its own best-iteration reducer
- [x] Progressive display still shows the running best as autopilot streams
- [x] Selection rule (max score, tie-break earliest) in exactly one place
- [x] Typecheck, lint, build pass

## Tests

- Added running-best assertions to `AutopilotSession.test.ts` (`[1,2,2]` over scores 40/88/72) and a dedicated tie-break test (equal scores → earliest wins).
- Full suite: 47 passing. Typecheck, lint, build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
