### PR TITLE
Fix layer editing and persistence edge cases

### DIFF
--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -61,8 +61,8 @@ export class SQLiteArchiveMetadataPort {
                 ${record.background},
                 ${record.timestamp},
                 ${record.model || OPENAI_IMAGE_MODEL},
-                ${record.width || 1024},
-                ${record.height || 1024},
+                ${record.width ?? null},
+                ${record.height ?? null},
                 ${JSON.stringify(record.referenceIds)},
                 ${record.style || null},
                 ${record.lighting || null},
@@ -86,8 +86,8 @@ export class SQLiteArchiveMetadataPort {
             background: image.background,
             timestamp: image.timestamp,
             model: image.model,
-            width: image.width,
-            height: image.height,
+            width: optionalNumber(image.width),
+            height: optionalNumber(image.height),
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
@@ -114,8 +114,8 @@ export class SQLiteArchiveMetadataPort {
             background: row.background,
             timestamp: row.timestamp,
             model: row.model,
-            width: row.width,
-            height: row.height,
+            width: optionalNumber(row.width),
+            height: optionalNumber(row.height),
             style: row.style,
             lighting: row.lighting,
             palette: row.palette,
@@ -140,6 +140,10 @@ const parseReferenceIds = (value?: string): number[] => {
     } catch {
         return [];
     }
+};
+
+const optionalNumber = (value: unknown): number | undefined => {
+    return typeof value === 'number' ? value : undefined;
 };
 
 const parseLayerStack = (value?: string): ArchiveLayerStack | undefined => {

--- a/src/editor/LayerPanel.tsx
+++ b/src/editor/LayerPanel.tsx
@@ -27,32 +27,49 @@ export function LayerPanel({
     onMove,
 }: LayerPanelProps) {
     const primaryLayer = layerStack.layers.find((layer) => layer.id === primarySelectedLayerId);
-    const canEditPrimary = !!primaryLayer && !primaryLayer.locked;
+    const primaryLayerIndex = primarySelectedLayerId
+        ? layerStack.layers.findIndex((layer) => layer.id === primarySelectedLayerId)
+        : -1;
+    const canEditPrimary = !!primaryLayer && primaryLayer.kind !== 'base' && !primaryLayer.locked;
+    const selectedEditableCount = layerStack.layers.filter((layer) => (
+        selectedLayerIds.includes(layer.id) && layer.kind !== 'base' && !layer.locked
+    )).length;
+    const canMoveUp = canEditPrimary && primaryLayerIndex < layerStack.layers.length - 1;
+    const canMoveDown = canEditPrimary && primaryLayerIndex > 1;
+    const canDuplicate = selectedEditableCount > 0;
+    const canDelete = selectedEditableCount > 0;
 
     return (
         <div className="layer-panel">
             <div className="layer-panel-actions">
-                <button className="btn-icon" title="Move layer up" disabled={!canEditPrimary} onClick={() => onMove(1)}>
+                <button className="btn-icon" title="Move layer up" disabled={!canMoveUp} onClick={() => onMove(1)}>
                     <ChevronUp size={16} />
                 </button>
-                <button className="btn-icon" title="Move layer down" disabled={!canEditPrimary} onClick={() => onMove(-1)}>
+                <button className="btn-icon" title="Move layer down" disabled={!canMoveDown} onClick={() => onMove(-1)}>
                     <ChevronDown size={16} />
                 </button>
-                <button className="btn-icon" title="Duplicate selected layers" disabled={!canEditPrimary} onClick={onDuplicate}>
+                <button className="btn-icon" title="Duplicate selected layers" disabled={!canDuplicate} onClick={onDuplicate}>
                     <Copy size={16} />
                 </button>
-                <button className="btn-icon" title="Delete selected layers" disabled={!canEditPrimary} onClick={onDelete}>
+                <button className="btn-icon" title="Delete selected layers" disabled={!canDelete} onClick={onDelete}>
                     <Trash2 size={16} />
                 </button>
             </div>
+            {selectedLayerIds.length > 0 && (
+                <div className="layer-selection-summary">
+                    {selectedLayerIds.length} selected - {selectedEditableCount} editable
+                </div>
+            )}
             <div className="layer-list">
                 {[...layerStack.layers].reverse().map((layer) => {
                     const selected = selectedLayerIds.includes(layer.id);
+                    const opacityPercent = Math.round(layer.opacity * 100);
                     return (
-                        <div key={layer.id} className={`layer-row ${selected ? 'selected' : ''}`}>
+                        <div key={layer.id} className={`layer-row ${selected ? 'selected' : ''} ${!layer.visible ? 'hidden' : ''}`}>
                             <button
                                 className="btn-icon"
                                 title={layer.visible ? 'Hide layer' : 'Show layer'}
+                                aria-label={layer.visible ? `Hide ${layer.name}` : `Show ${layer.name}`}
                                 disabled={layer.kind === 'base'}
                                 onClick={() => onSetVisible(layer.id, !layer.visible)}
                             >
@@ -60,26 +77,32 @@ export function LayerPanel({
                             </button>
                             <button
                                 className="layer-name"
+                                aria-pressed={selected}
                                 onClick={(event) => onSelectLayer(layer.id, event.shiftKey || event.metaKey)}
                             >
                                 {layer.locked && <Lock size={12} />}
                                 <span>{layer.name}</span>
+                                <small>{layer.kind === 'base' ? 'Base' : `${opacityPercent}%`}</small>
                             </button>
                             <input
+                                type="text"
                                 aria-label={`${layer.name} name`}
                                 value={layer.name}
                                 disabled={layer.locked}
                                 onChange={(event) => onRenameLayer(layer.id, event.target.value)}
                             />
-                            <input
-                                aria-label={`${layer.name} opacity`}
-                                type="range"
-                                min="0"
-                                max="100"
-                                value={Math.round(layer.opacity * 100)}
-                                disabled={layer.locked}
-                                onChange={(event) => onSetOpacity(layer.id, Number(event.target.value) / 100)}
-                            />
+                            <div className="layer-opacity-control">
+                                <input
+                                    aria-label={`${layer.name} opacity`}
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    value={opacityPercent}
+                                    disabled={layer.locked}
+                                    onChange={(event) => onSetOpacity(layer.id, Number(event.target.value) / 100)}
+                                />
+                                <span>{opacityPercent}%</span>
+                            </div>
                         </div>
                     );
                 })}

--- a/src/editor/layers.test.ts
+++ b/src/editor/layers.test.ts
@@ -6,6 +6,7 @@ import {
     createBaseLayerStack,
     deleteLayers,
     duplicateLayers,
+    getEditableLayerIds,
     getCombinedLayerBounds,
     insertAiResultLayer,
     moveLayer,
@@ -54,6 +55,36 @@ describe('layer editor helpers', () => {
         }));
     });
 
+    it('fits uploaded layers to the canvas without distorting their source aspect ratio', () => {
+        const landscape = addUploadedLayer(
+            createStack(),
+            'data:image/png;base64,landscape',
+            () => 'landscape-layer',
+            'landscape.png',
+            { width: 1600, height: 800 },
+        ).layerStack.layers.at(-1);
+        const portrait = addUploadedLayer(
+            createStack(),
+            'data:image/png;base64,portrait',
+            () => 'portrait-layer',
+            'portrait.png',
+            { width: 800, height: 1600 },
+        ).layerStack.layers.at(-1);
+
+        expect(landscape).toEqual(expect.objectContaining({
+            width: 614.4,
+            height: 307.2,
+            x: 204.8,
+            y: 358.4,
+        }));
+        expect(portrait).toEqual(expect.objectContaining({
+            width: 307.2,
+            height: 614.4,
+            x: 358.4,
+            y: 204.8,
+        }));
+    });
+
     it('applies stack operations while preserving base-layer guardrails', () => {
         const stack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
         const renamed = updateLayer(stack, 'layer-1', { name: 'Glow', opacity: 0.4, visible: false });
@@ -65,6 +96,22 @@ describe('layer editor helpers', () => {
         expect(duplicated.duplicatedIds).toEqual(['layer-2']);
         expect(moved.layers.map((layer) => layer.id)).toEqual(['base', 'layer-2', 'layer-1']);
         expect(deleted.layers.map((layer) => layer.id)).toEqual(['base', 'layer-2']);
+    });
+
+    it('filters shared layer actions to editable non-base layers', () => {
+        const stack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+        const lockedStack = updateLayer(stack, 'layer-1', { locked: true });
+
+        expect(getEditableLayerIds(stack, ['base', 'layer-1', 'missing'])).toEqual(['layer-1']);
+        expect(getEditableLayerIds(lockedStack, ['base', 'layer-1'])).toEqual([]);
+    });
+
+    it('does not create a new stack for invalid layer reorders', () => {
+        const stack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        expect(moveLayer(stack, 'base', 1)).toBe(stack);
+        expect(moveLayer(stack, 'layer-1', 1)).toBe(stack);
+        expect(moveLayer(stack, 'layer-1', -1)).toBe(stack);
     });
 
     it('inserts AI results above targets and hides non-base targets', () => {

--- a/src/editor/layers.test.ts
+++ b/src/editor/layers.test.ts
@@ -8,9 +8,11 @@ import {
     duplicateLayers,
     getEditableLayerIds,
     getCombinedLayerBounds,
+    hydrateLayerStack,
     insertAiResultLayer,
     moveLayer,
     pushHistory,
+    repairEditorDraftForImage,
     redoHistory,
     removeDraftReferenceAt,
     undoHistory,
@@ -35,6 +37,90 @@ describe('layer editor helpers', () => {
                 }),
             ],
         });
+    });
+
+    it('hydrates base-only images from aspect ratio metadata when dimensions are missing', () => {
+        const stack = createBaseLayerStack({
+            ...createImage(),
+            aspectRatio: '16:9',
+            width: undefined,
+            height: undefined,
+        });
+
+        expect(stack).toEqual(expect.objectContaining({
+            canvasWidth: 1024,
+            canvasHeight: 576,
+        }));
+        expect(stack.layers[0]).toEqual(expect.objectContaining({
+            width: 1024,
+            height: 576,
+        }));
+    });
+
+    it('repairs old square fallback dimensions when they conflict with non-square aspect ratio metadata', () => {
+        const stack = createBaseLayerStack({
+            ...createImage(),
+            aspectRatio: '1536x1024',
+            width: 1024,
+            height: 1024,
+        });
+
+        expect(stack).toEqual(expect.objectContaining({
+            canvasWidth: 1536,
+            canvasHeight: 1024,
+        }));
+        expect(stack.layers[0]).toEqual(expect.objectContaining({
+            width: 1536,
+            height: 1024,
+        }));
+    });
+
+    it('repairs stale persisted editor drafts that were created with square fallback dimensions', () => {
+        const draft = {
+            layerStack: createStack(),
+            adjustments: { brightness: 100, contrast: 100, saturation: 100, filter: 'none' },
+            references: [],
+            selectedLayerIds: ['layer-1'],
+            primarySelectedLayerId: 'layer-1',
+        };
+        const repaired = repairEditorDraftForImage(draft, {
+            ...createImage(),
+            aspectRatio: '16:9',
+            width: 1024,
+            height: 1024,
+        });
+
+        expect(repaired.layerStack.canvasWidth).toBe(1024);
+        expect(repaired.layerStack.canvasHeight).toBe(576);
+        expect(repaired.layerStack.layers[0]).toEqual(expect.objectContaining({
+            width: 1024,
+            height: 576,
+        }));
+        expect(repaired.selectedLayerIds).toEqual(['layer-1']);
+    });
+
+    it('repairs durable layer stacks that were saved with old square fallback dimensions', () => {
+        const layeredStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+        const repaired = hydrateLayerStack({
+            ...createImage(),
+            aspectRatio: '16:9',
+            width: 1024,
+            height: 1024,
+            layerStack: layeredStack,
+        });
+
+        expect(repaired.canvasWidth).toBe(1024);
+        expect(repaired.canvasHeight).toBe(576);
+        expect(repaired.layers[0]).toEqual(expect.objectContaining({
+            width: 1024,
+            height: 576,
+        }));
+        expect(repaired.layers[1]).toEqual(expect.objectContaining({
+            x: 204.8,
+            y: 115.2,
+            width: 614.4,
+            height: expect.closeTo(345.6),
+        }));
     });
 
     it('adds uploaded layers centered, selected-ready, visible, and opaque', () => {
@@ -198,6 +284,7 @@ function createImage(): ArchiveImage {
 function createStack(): ArchiveLayerStack {
     return createBaseLayerStack({
         ...createImage(),
+        aspectRatio: '1024x1024',
         width: 1024,
         height: 1024,
     });

--- a/src/editor/layers.ts
+++ b/src/editor/layers.ts
@@ -98,8 +98,9 @@ export function addUploadedLayer(
     assetUrl: string,
     makeId: () => string,
     name = 'Uploaded layer',
+    sourceSize?: { width: number; height: number },
 ): { layerStack: ArchiveLayerStack; layerId: string } {
-    const { width, height } = fitLayerToCanvas(layerStack.canvasWidth, layerStack.canvasHeight);
+    const { width, height } = fitLayerToCanvas(layerStack.canvasWidth, layerStack.canvasHeight, sourceSize);
     const layerId = makeId();
     const layer: ArchiveLayer = {
         id: layerId,
@@ -204,6 +205,13 @@ export function moveLayer(layerStack: ArchiveLayerStack, layerId: string, direct
     const [removed] = layers.splice(index, 1);
     layers.splice(nextIndex, 0, removed);
     return { ...layerStack, layers };
+}
+
+export function getEditableLayerIds(layerStack: ArchiveLayerStack, layerIds: string[]): string[] {
+    const selected = new Set(layerIds);
+    return layerStack.layers
+        .filter((layer) => selected.has(layer.id) && layer.kind !== 'base' && !layer.locked)
+        .map((layer) => layer.id);
 }
 
 export function updateLayer(layerStack: ArchiveLayerStack, layerId: string, patch: Partial<ArchiveLayer>): ArchiveLayerStack {
@@ -340,11 +348,17 @@ export function redoHistory(history: LayerHistoryState): LayerHistoryState {
     };
 }
 
-function fitLayerToCanvas(canvasWidth: number, canvasHeight: number) {
+function fitLayerToCanvas(canvasWidth: number, canvasHeight: number, sourceSize?: { width: number; height: number }) {
     const maxWidth = canvasWidth * 0.6;
     const maxHeight = canvasHeight * 0.6;
-    const size = Math.max(1, Math.min(maxWidth, maxHeight));
-    return { width: size, height: size };
+    const sourceWidth = Math.max(1, sourceSize?.width ?? 1);
+    const sourceHeight = Math.max(1, sourceSize?.height ?? 1);
+    const scale = Math.min(maxWidth / sourceWidth, maxHeight / sourceHeight);
+
+    return {
+        width: sourceWidth * scale,
+        height: sourceHeight * scale,
+    };
 }
 
 function clampOpacity(opacity: number) {

--- a/src/editor/layers.ts
+++ b/src/editor/layers.ts
@@ -24,8 +24,7 @@ export interface LayerHistoryState {
 }
 
 export function createBaseLayerStack(image: ArchiveImage): ArchiveLayerStack {
-    const canvasWidth = image.width ?? 1024;
-    const canvasHeight = image.height ?? 1024;
+    const { width: canvasWidth, height: canvasHeight } = resolveImageDimensions(image);
 
     return {
         canvasWidth,
@@ -51,7 +50,7 @@ export function createBaseLayerStack(image: ArchiveImage): ArchiveLayerStack {
 
 export function hydrateLayerStack(image: ArchiveImage): ArchiveLayerStack {
     if (image.layerStack?.layers.length) {
-        return normalizeLayerStack(image.layerStack);
+        return repairLayerStackDimensions(normalizeLayerStack(image.layerStack), image);
     }
 
     return createBaseLayerStack(image);
@@ -86,6 +85,13 @@ export function createEditorDraft(image: ArchiveImage): EditorDraft {
         references: image.references ?? [],
         selectedLayerIds: ['base'],
         primarySelectedLayerId: 'base',
+    };
+}
+
+export function repairEditorDraftForImage(draft: EditorDraft, image: ArchiveImage): EditorDraft {
+    return {
+        ...draft,
+        layerStack: repairLayerStackDimensions(normalizeLayerStack(draft.layerStack), image),
     };
 }
 
@@ -363,4 +369,126 @@ function fitLayerToCanvas(canvasWidth: number, canvasHeight: number, sourceSize?
 
 function clampOpacity(opacity: number) {
     return Math.min(1, Math.max(0, opacity));
+}
+
+function resolveImageDimensions(image: Pick<ArchiveImage, 'width' | 'height' | 'aspectRatio' | 'quality'>) {
+    const explicitDimensions = getValidDimensions(image.width, image.height);
+    const aspectDimensions = getAspectRatioDimensions(image.aspectRatio, image.quality);
+
+    if (!explicitDimensions) {
+        return aspectDimensions ?? { width: 1024, height: 1024 };
+    }
+
+    if (aspectDimensions && shouldRepairSquareFallback(explicitDimensions, aspectDimensions)) {
+        return aspectDimensions;
+    }
+
+    return explicitDimensions;
+}
+
+function repairLayerStackDimensions(layerStack: ArchiveLayerStack, image: ArchiveImage): ArchiveLayerStack {
+    const targetDimensions = resolveImageDimensions(image);
+    if (layerStack.canvasWidth === targetDimensions.width && layerStack.canvasHeight === targetDimensions.height) {
+        return layerStack;
+    }
+
+    if (!shouldRepairSquareFallback({
+        width: layerStack.canvasWidth,
+        height: layerStack.canvasHeight,
+    }, targetDimensions)) {
+        return layerStack;
+    }
+
+    const scaleX = targetDimensions.width / layerStack.canvasWidth;
+    const scaleY = targetDimensions.height / layerStack.canvasHeight;
+
+    return {
+        ...layerStack,
+        canvasWidth: targetDimensions.width,
+        canvasHeight: targetDimensions.height,
+        layers: layerStack.layers.map((layer) => ({
+            ...layer,
+            x: layer.kind === 'base' ? 0 : layer.x * scaleX,
+            y: layer.kind === 'base' ? 0 : layer.y * scaleY,
+            width: layer.width * scaleX,
+            height: layer.height * scaleY,
+        })),
+    };
+}
+
+function getValidDimensions(width: number | undefined, height: number | undefined) {
+    if (!width || !height || width <= 0 || height <= 0) {
+        return null;
+    }
+
+    return { width, height };
+}
+
+function getAspectRatioDimensions(aspectRatio: string, quality: string) {
+    const exactDimensions = parseExactDimensions(aspectRatio);
+    if (exactDimensions) {
+        return exactDimensions;
+    }
+
+    const ratioDimensions = parseRatioDimensions(aspectRatio, getLongEdgeFromQuality(quality));
+    return ratioDimensions;
+}
+
+function parseExactDimensions(aspectRatio: string) {
+    const match = aspectRatio.match(/^(\d+)x(\d+)$/);
+    if (!match) {
+        return null;
+    }
+
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    return getValidDimensions(width, height);
+}
+
+function parseRatioDimensions(aspectRatio: string, longEdge: number) {
+    const match = aspectRatio.match(/^(\d+):(\d+)$/);
+    if (!match) {
+        return null;
+    }
+
+    const widthRatio = Number(match[1]);
+    const heightRatio = Number(match[2]);
+    if (!widthRatio || !heightRatio) {
+        return null;
+    }
+
+    if (widthRatio >= heightRatio) {
+        return {
+            width: longEdge,
+            height: Math.max(1, Math.round(longEdge * (heightRatio / widthRatio))),
+        };
+    }
+
+    return {
+        width: Math.max(1, Math.round(longEdge * (widthRatio / heightRatio))),
+        height: longEdge,
+    };
+}
+
+function getLongEdgeFromQuality(quality: string) {
+    if (quality === '4K') {
+        return 4096;
+    }
+
+    if (quality === '2K') {
+        return 2048;
+    }
+
+    return 1024;
+}
+
+function shouldRepairSquareFallback(
+    explicitDimensions: { width: number; height: number },
+    aspectDimensions: { width: number; height: number } | null,
+) {
+    if (!aspectDimensions || aspectDimensions.width === aspectDimensions.height) {
+        return false;
+    }
+
+    return explicitDimensions.width === 1024 && explicitDimensions.height === 1024;
 }

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -13,6 +13,7 @@ import {
     hasDurableLayerStack,
     moveLayer,
     pushHistory,
+    repairEditorDraftForImage,
     redoHistory,
     removeDraftReferenceAt,
     undoHistory,
@@ -30,7 +31,10 @@ export function useEditorSession(image: ArchiveImage | null) {
     const sessionKey = image?.id ?? 'default';
     const savedDraft = useMemo(() => image ? createEditorDraft(image) : null, [image]);
     const [persistedDraft, setPersistedDraft] = useLocalStorage<EditorDraft | null>(`editor_${sessionKey}_draft`, savedDraft);
-    const initialDraft = persistedDraft ?? savedDraft;
+    const repairedPersistedDraft = useMemo(() => {
+        return image && persistedDraft ? repairEditorDraftForImage(persistedDraft, image) : persistedDraft;
+    }, [image, persistedDraft]);
+    const initialDraft = repairedPersistedDraft ?? savedDraft;
     const [history, setHistory] = useState<LayerHistoryState | null>(() => initialDraft ? {
         past: [],
         present: initialDraft,
@@ -201,6 +205,14 @@ export function useEditorSession(image: ArchiveImage | null) {
     useEffect(() => {
         replaceReferenceDataUrls(draft?.references ?? []);
     }, [draft?.references, replaceReferenceDataUrls]);
+
+    useEffect(() => {
+        if (!persistedDraft || !repairedPersistedDraft || JSON.stringify(persistedDraft) === JSON.stringify(repairedPersistedDraft)) {
+            return;
+        }
+
+        setPersistedDraft(repairedPersistedDraft);
+    }, [persistedDraft, repairedPersistedDraft, setPersistedDraft]);
 
     const addReferenceFiles = useCallback(async (files: File[]) => {
         if (!draft || files.length === 0) {

--- a/src/editor/useEditorSession.ts
+++ b/src/editor/useEditorSession.ts
@@ -9,6 +9,7 @@ import {
     addDraftReferences,
     deleteLayers,
     duplicateLayers,
+    getEditableLayerIds,
     hasDurableLayerStack,
     moveLayer,
     pushHistory,
@@ -91,7 +92,8 @@ export function useEditorSession(image: ArchiveImage | null) {
         let nextDraft = draft;
         for (const file of files) {
             const dataUrl = await fileToDataURL(file);
-            const result = addUploadedLayer(nextDraft.layerStack, dataUrl, makeId, file.name || 'Uploaded layer');
+            const imageSize = await readImageSize(dataUrl);
+            const result = addUploadedLayer(nextDraft.layerStack, dataUrl, makeId, file.name || 'Uploaded layer', imageSize);
             nextDraft = {
                 ...nextDraft,
                 layerStack: result.layerStack,
@@ -108,13 +110,22 @@ export function useEditorSession(image: ArchiveImage | null) {
             return;
         }
 
+        const alreadySelected = draft.selectedLayerIds.includes(layerId);
         const selectedLayerIds = additive
-            ? Array.from(new Set([...draft.selectedLayerIds, layerId]))
+            ? alreadySelected
+                ? draft.selectedLayerIds.filter((id) => id !== layerId)
+                : [...draft.selectedLayerIds, layerId]
             : [layerId];
+        const primarySelectedLayerId = alreadySelected && additive
+            ? selectedLayerIds.includes(draft.primarySelectedLayerId ?? '')
+                ? draft.primarySelectedLayerId
+                : selectedLayerIds.at(-1) ?? null
+            : layerId;
+
         commitDraft({
             ...draft,
             selectedLayerIds,
-            primarySelectedLayerId: layerId,
+            primarySelectedLayerId,
         }, false);
     }, [commitDraft, draft]);
 
@@ -124,11 +135,17 @@ export function useEditorSession(image: ArchiveImage | null) {
         }
 
         const selectedLayerIds = nextSelection ?? draft.selectedLayerIds.filter((id) => nextLayerStack.layers.some((layer) => layer.id === id));
+        const primarySelectedLayerId = nextSelection
+            ? selectedLayerIds[0] ?? null
+            : selectedLayerIds.includes(draft.primarySelectedLayerId ?? '')
+                ? draft.primarySelectedLayerId
+                : selectedLayerIds[0] ?? null;
+
         commitDraft({
             ...draft,
             layerStack: nextLayerStack,
             selectedLayerIds,
-            primarySelectedLayerId: selectedLayerIds[0] ?? 'base',
+            primarySelectedLayerId,
         });
     }, [commitDraft, draft]);
 
@@ -248,13 +265,22 @@ export function useEditorSession(image: ArchiveImage | null) {
         updateLayerTransform: (layerId: string, patch: { x?: number; y?: number; width?: number; height?: number; rotation?: number }) => draft && mutateLayerStack(updateLayer(draft.layerStack, layerId, patch)),
         duplicateSelectedLayers: () => {
             if (!draft) return;
-            const result = duplicateLayers(draft.layerStack, draft.selectedLayerIds, makeId);
+            const editableLayerIds = getEditableLayerIds(draft.layerStack, draft.selectedLayerIds);
+            if (!editableLayerIds.length) return;
+            const result = duplicateLayers(draft.layerStack, editableLayerIds, makeId);
             mutateLayerStack(result.layerStack, result.duplicatedIds);
         },
-        deleteSelectedLayers: () => draft && mutateLayerStack(deleteLayers(draft.layerStack, draft.selectedLayerIds)),
+        deleteSelectedLayers: () => {
+            if (!draft) return;
+            const editableLayerIds = getEditableLayerIds(draft.layerStack, draft.selectedLayerIds);
+            if (!editableLayerIds.length) return;
+            mutateLayerStack(deleteLayers(draft.layerStack, editableLayerIds));
+        },
         moveSelectedLayer: (direction: -1 | 1) => {
             if (!draft?.primarySelectedLayerId) return;
-            mutateLayerStack(moveLayer(draft.layerStack, draft.primarySelectedLayerId, direction));
+            const nextLayerStack = moveLayer(draft.layerStack, draft.primarySelectedLayerId, direction);
+            if (nextLayerStack === draft.layerStack) return;
+            mutateLayerStack(nextLayerStack);
         },
         commitDraft,
         undo,
@@ -266,4 +292,16 @@ export function useEditorSession(image: ArchiveImage | null) {
         resetAdjustments,
         serializeReferences,
     };
+}
+
+function readImageSize(source: string): Promise<{ width: number; height: number } | undefined> {
+    return new Promise((resolve) => {
+        const image = new Image();
+        image.onload = () => resolve({
+            width: image.naturalWidth || image.width,
+            height: image.naturalHeight || image.height,
+        });
+        image.onerror = () => resolve(undefined);
+        image.src = source;
+    });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -507,6 +507,7 @@ textarea {
 
 .section-title h2,
 .section-title h3,
+.section-heading,
 .editor-sidebar h3,
 .empty-state h3,
 .confirm-body h3,
@@ -515,6 +516,32 @@ textarea {
     font-size: var(--text-heading-sm);
     font-weight: var(--font-weight-regular);
     line-height: var(--leading-heading-sm);
+}
+
+.section-toggle {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0;
+    text-align: left;
+}
+
+.section-toggle .section-heading {
+    flex: 1;
+}
+
+.section-toggle svg:last-child {
+    color: var(--color-steel);
+}
+
+.section-toggle:hover .section-heading,
+.section-toggle:hover svg:last-child {
+    color: var(--color-amber-glow);
+}
+
+.collapsible-section-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
 }
 
 .section-desc,

--- a/src/index.css
+++ b/src/index.css
@@ -1052,16 +1052,29 @@ textarea.aura-input {
     grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.layer-selection-summary {
+    color: var(--color-steel);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+}
+
 .layer-row {
     display: grid;
     grid-template-columns: 32px minmax(0, 1fr);
     gap: var(--element-gap);
     padding: var(--spacing-8);
     border: 1px solid color-mix(in srgb, var(--color-steel) 40%, transparent);
+    background: color-mix(in srgb, var(--color-snow) 70%, transparent);
+    transition: var(--transition-smooth);
 }
 
 .layer-row.selected {
     border-color: var(--color-amber-glow);
+    background: color-mix(in srgb, var(--color-amber-glow) 10%, var(--color-snow));
+}
+
+.layer-row.hidden {
+    opacity: 0.64;
 }
 
 .layer-name {
@@ -1074,9 +1087,18 @@ textarea.aura-input {
 }
 
 .layer-name span {
+    flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.layer-name small {
+    flex: 0 0 auto;
+    color: var(--color-steel);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: 0.65rem;
+    text-transform: uppercase;
 }
 
 .layer-row input[type="text"],
@@ -1084,8 +1106,19 @@ textarea.aura-input {
     grid-column: 1 / -1;
 }
 
-.layer-row input[type="range"] {
+.layer-opacity-control {
     grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 42px;
+    align-items: center;
+    gap: var(--element-gap);
+}
+
+.layer-opacity-control span {
+    color: var(--color-steel);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    text-align: right;
 }
 
 .slider-group {

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Undo2, Redo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy, Layers, RotateCcw } from 'lucide-react';
+import { Undo2, Redo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy, Layers, RotateCcw, ChevronDown, ChevronRight } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { EditorCanvas, type EditorCanvasHandle } from '../editor/EditorCanvas';
 import { LayerPanel } from '../editor/LayerPanel';
@@ -18,6 +18,8 @@ interface EditorViewProps {
 const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }) => {
     const defaultModel = image && isImageModelSlug(image.model) ? image.model : OPENAI_IMAGE_MODEL;
     const [aiEditModel, setAiEditModel] = useState<ImageModelSlug>(defaultModel);
+    const [adjustmentsOpen, setAdjustmentsOpen] = useState(true);
+    const [filtersOpen, setFiltersOpen] = useState(true);
     const canvasRef = useRef<EditorCanvasHandle>(null);
     const activeModel = resolveImageModelConfig(aiEditModel);
     const activeApiKey = getProviderKey(activeModel.provider);
@@ -203,70 +205,88 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
                     )}
 
                     <div className="sidebar-group">
-                        <div className="section-title">
+                        <button
+                            className="section-title section-toggle"
+                            type="button"
+                            aria-expanded={adjustmentsOpen}
+                            aria-controls="editor-adjustments-panel"
+                            onClick={() => setAdjustmentsOpen((open) => !open)}
+                        >
                             <Sliders size={18} className="icon-purple" />
-                            <h3>Adjustments</h3>
-                        </div>
+                            <span className="section-heading">Adjustments</span>
+                            {adjustmentsOpen ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+                        </button>
 
-                        <div className="slider-group">
-                            <div className="slider-label">
-                                <span>Brightness</span>
-                                <span>{brightness}%</span>
+                        <div id="editor-adjustments-panel" className="collapsible-section-body" hidden={!adjustmentsOpen}>
+                            <div className="slider-group">
+                                <div className="slider-label">
+                                    <span>Brightness</span>
+                                    <span>{brightness}%</span>
+                                </div>
+                                <input
+                                    type="range" min="0" max="200" value={brightness}
+                                    onChange={(e) => setBrightness(Number(e.target.value))}
+                                    className="editor-slider"
+                                />
                             </div>
-                            <input
-                                type="range" min="0" max="200" value={brightness}
-                                onChange={(e) => setBrightness(Number(e.target.value))}
-                                className="editor-slider"
-                            />
-                        </div>
 
-                        <div className="slider-group">
-                            <div className="slider-label">
-                                <span>Contrast</span>
-                                <span>{contrast}%</span>
+                            <div className="slider-group">
+                                <div className="slider-label">
+                                    <span>Contrast</span>
+                                    <span>{contrast}%</span>
+                                </div>
+                                <input
+                                    type="range" min="0" max="200" value={contrast}
+                                    onChange={(e) => setContrast(Number(e.target.value))}
+                                    className="editor-slider"
+                                />
                             </div>
-                            <input
-                                type="range" min="0" max="200" value={contrast}
-                                onChange={(e) => setContrast(Number(e.target.value))}
-                                className="editor-slider"
-                            />
-                        </div>
 
-                        <div className="slider-group">
-                            <div className="slider-label">
-                                <span>Saturation</span>
-                                <span>{saturation}%</span>
+                            <div className="slider-group">
+                                <div className="slider-label">
+                                    <span>Saturation</span>
+                                    <span>{saturation}%</span>
+                                </div>
+                                <input
+                                    type="range" min="0" max="200" value={saturation}
+                                    onChange={(e) => setSaturation(Number(e.target.value))}
+                                    className="editor-slider"
+                                />
                             </div>
-                            <input
-                                type="range" min="0" max="200" value={saturation}
-                                onChange={(e) => setSaturation(Number(e.target.value))}
-                                className="editor-slider"
-                            />
                         </div>
                     </div>
 
                     <div className="sidebar-group">
-                        <div className="section-title">
+                        <button
+                            className="section-title section-toggle"
+                            type="button"
+                            aria-expanded={filtersOpen}
+                            aria-controls="editor-filters-panel"
+                            onClick={() => setFiltersOpen((open) => !open)}
+                        >
                             <MoveHorizontal size={18} className="icon-purple" />
-                            <h3>Filters</h3>
-                        </div>
-                        <div className="filter-grid">
-                            <button
-                                className={`filter-btn ${filter === 'none' ? 'active' : ''}`}
-                                onClick={() => setFilter('none')}
-                            >Normal</button>
-                            <button
-                                className={`filter-btn ${filter === 'grayscale(100%)' ? 'active' : ''}`}
-                                onClick={() => setFilter('grayscale(100%)')}
-                            >B&W</button>
-                            <button
-                                className={`filter-btn ${filter === 'sepia(100%)' ? 'active' : ''}`}
-                                onClick={() => setFilter('sepia(100%)')}
-                            >Sepia</button>
-                            <button
-                                className={`filter-btn ${filter === 'blur(5px)' ? 'active' : ''}`}
-                                onClick={() => setFilter('blur(5px)')}
-                            >Soft</button>
+                            <span className="section-heading">Filters</span>
+                            {filtersOpen ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+                        </button>
+                        <div id="editor-filters-panel" className="collapsible-section-body" hidden={!filtersOpen}>
+                            <div className="filter-grid">
+                                <button
+                                    className={`filter-btn ${filter === 'none' ? 'active' : ''}`}
+                                    onClick={() => setFilter('none')}
+                                >Normal</button>
+                                <button
+                                    className={`filter-btn ${filter === 'grayscale(100%)' ? 'active' : ''}`}
+                                    onClick={() => setFilter('grayscale(100%)')}
+                                >B&W</button>
+                                <button
+                                    className={`filter-btn ${filter === 'sepia(100%)' ? 'active' : ''}`}
+                                    onClick={() => setFilter('sepia(100%)')}
+                                >Sepia</button>
+                                <button
+                                    className={`filter-btn ${filter === 'blur(5px)' ? 'active' : ''}`}
+                                    onClick={() => setFilter('blur(5px)')}
+                                >Soft</button>
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Make the editor treat missing archive dimensions as nullable and hydrate them safely from persisted metadata.
- Harden layer panel actions so base layers and locked layers are excluded from move, duplicate, and delete operations.
- Repair old square-fallback editor drafts and layer stacks to match real image dimensions.
- Improve uploaded layer sizing so source aspect ratio is preserved when available.

## Testing
- Added unit coverage for dimension repair, draft hydration, editable-layer filtering, invalid reorders, and source-aware upload fitting.
- Not run (not requested).