### PR TITLE
Implement archive manifest and Image model issue set

### DIFF
--- a/src/archive/ArchiveAssets.ts
+++ b/src/archive/ArchiveAssets.ts
@@ -1,0 +1,154 @@
+import type { ArchiveLayerStack } from '../db/types';
+
+export interface ArchiveBlobPort {
+    save(key: string, data: string): Promise<void>;
+    load(key: string): Promise<string | null>;
+    remove(key: string): Promise<void>;
+    listKeys(): Promise<string[]>;
+}
+
+interface ArchiveAssetSnapshot {
+    image: string | null;
+    references: Map<number, string>;
+    layers: Map<string, string>;
+}
+
+export const getArchiveImageBlobKey = (id: string) => `img_${id}`;
+
+export const getArchiveReferenceBlobKey = (id: string, index: number) => `ref_${id}_${index}`;
+
+export const getArchiveLayerBlobKey = (id: string, layerId: string) => `layer_${id}_${layerId}`;
+
+export const getArchiveImageIdFromBlobKey = (key: string) => {
+    if (!key.startsWith('img_') || key.length === 'img_'.length) {
+        return null;
+    }
+
+    return key.slice('img_'.length);
+};
+
+export const getLayerIds = (layerStack?: ArchiveLayerStack) => {
+    return layerStack?.layers.map((layer) => layer.id) ?? [];
+};
+
+export const getTouchedReferenceIds = (left: number[], right: number[]) => {
+    return Array.from(new Set([...left, ...right]));
+};
+
+export const getTouchedLayerIds = (left: string[], right: string[]) => {
+    return Array.from(new Set([...left, ...right]));
+};
+
+export function createDurableLayerStackMetadata(layerStack?: ArchiveLayerStack): ArchiveLayerStack | undefined {
+    if (!layerStack) {
+        return undefined;
+    }
+
+    return {
+        ...layerStack,
+        layers: layerStack.layers.map((layer) => ({
+            ...layer,
+            assetUrl: '',
+        })),
+    };
+}
+
+export async function syncReferenceAssets(
+    blobs: Pick<ArchiveBlobPort, 'save' | 'remove'>,
+    id: string,
+    previousReferenceIds: number[],
+    nextReferences: string[],
+): Promise<void> {
+    await Promise.all(nextReferences.map((reference, index) => blobs.save(getArchiveReferenceBlobKey(id, index), reference)));
+
+    const nextReferenceIds = new Set(nextReferences.map((_, index) => index));
+    const staleReferenceIds = previousReferenceIds.filter((index) => !nextReferenceIds.has(index));
+
+    await Promise.all(staleReferenceIds.map((index) => blobs.remove(getArchiveReferenceBlobKey(id, index))));
+}
+
+export async function syncLayerAssets(
+    blobs: Pick<ArchiveBlobPort, 'save' | 'remove'>,
+    id: string,
+    previousLayerIds: string[],
+    nextLayerStack?: ArchiveLayerStack,
+): Promise<void> {
+    await Promise.all((nextLayerStack?.layers ?? []).map((layer) => blobs.save(getArchiveLayerBlobKey(id, layer.id), layer.assetUrl)));
+
+    const nextLayerIds = new Set(getLayerIds(nextLayerStack));
+    const staleLayerIds = previousLayerIds.filter((layerId) => !nextLayerIds.has(layerId));
+
+    await Promise.all(staleLayerIds.map((layerId) => blobs.remove(getArchiveLayerBlobKey(id, layerId))));
+}
+
+export async function hydrateLayerStackAssets(
+    blobs: Pick<ArchiveBlobPort, 'load'>,
+    id: string,
+    layerStack?: ArchiveLayerStack,
+): Promise<ArchiveLayerStack | undefined> {
+    if (!layerStack) {
+        return undefined;
+    }
+
+    const layers = await Promise.all(layerStack.layers.map(async (layer) => ({
+        ...layer,
+        assetUrl: await blobs.load(getArchiveLayerBlobKey(id, layer.id)) ?? layer.assetUrl,
+    })));
+
+    return { ...layerStack, layers };
+}
+
+export async function captureArchiveAssetSnapshot(
+    blobs: Pick<ArchiveBlobPort, 'load'>,
+    id: string,
+    referenceIds: number[],
+    layerIds: string[],
+): Promise<ArchiveAssetSnapshot> {
+    const [image, references, layers] = await Promise.all([
+        blobs.load(getArchiveImageBlobKey(id)),
+        Promise.all(referenceIds.map(async (index) => [index, await blobs.load(getArchiveReferenceBlobKey(id, index))] as const)),
+        Promise.all(layerIds.map(async (layerId) => [layerId, await blobs.load(getArchiveLayerBlobKey(id, layerId))] as const)),
+    ]);
+
+    return {
+        image,
+        references: new Map(references.filter((entry): entry is readonly [number, string] => entry[1] !== null)),
+        layers: new Map(layers.filter((entry): entry is readonly [string, string] => entry[1] !== null)),
+    };
+}
+
+export async function restoreArchiveAssetSnapshot(
+    blobs: Pick<ArchiveBlobPort, 'save' | 'remove'>,
+    id: string,
+    snapshot: ArchiveAssetSnapshot,
+    touchedReferenceIds: number[],
+    touchedLayerIds: string[],
+): Promise<void> {
+    if (snapshot.image !== null) {
+        await blobs.save(getArchiveImageBlobKey(id), snapshot.image);
+    } else {
+        await blobs.remove(getArchiveImageBlobKey(id));
+    }
+
+    const referenceIds = getTouchedReferenceIds(Array.from(snapshot.references.keys()), touchedReferenceIds);
+    await Promise.all(referenceIds.map(async (index) => {
+        const previousReference = snapshot.references.get(index);
+        if (previousReference !== undefined) {
+            await blobs.save(getArchiveReferenceBlobKey(id, index), previousReference);
+            return;
+        }
+
+        await blobs.remove(getArchiveReferenceBlobKey(id, index));
+    }));
+
+    const layerIds = getTouchedLayerIds(Array.from(snapshot.layers.keys()), touchedLayerIds);
+    await Promise.all(layerIds.map(async (layerId) => {
+        const previousLayer = snapshot.layers.get(layerId);
+        if (previousLayer !== undefined) {
+            await blobs.save(getArchiveLayerBlobKey(id, layerId), previousLayer);
+            return;
+        }
+
+        await blobs.remove(getArchiveLayerBlobKey(id, layerId));
+    }));
+}

--- a/src/archive/ArchiveManifest.test.ts
+++ b/src/archive/ArchiveManifest.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import {
+    ARCHIVE_MANIFEST_VERSION,
+    LINEAGE_MANIFEST_VERSION,
+    createArchiveManifestLayerStack,
+    parseArchiveManifest,
+    parseLineageManifest,
+} from './ArchiveManifest';
+import type { ArchiveLayerStack } from '../db/types';
+
+describe('ArchiveManifest', () => {
+    it('accepts the existing archive manifest version and preserves stable layer ids', () => {
+        const manifest = parseArchiveManifest({
+            version: ARCHIVE_MANIFEST_VERSION,
+            images: [
+                {
+                    id: 'layered-image',
+                    prompt: 'layered',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-06-05T10:00:00.000Z',
+                    imageFileName: 'aura-layered-image.png',
+                    references: [],
+                    layerStack: createManifestLayerStack(),
+                },
+            ],
+        });
+
+        expect(manifest.version).toBe(1);
+        expect(manifest.images[0].layerStack?.layers.map((layer) => [layer.id, layer.assetFileName])).toEqual([
+            ['base', 'aura-layered-image-layer-base.png'],
+            ['upload', 'aura-layered-image-layer-upload.png'],
+        ]);
+    });
+
+    it('rejects malformed layer stack entries', () => {
+        expect(() => parseArchiveManifest({
+            version: ARCHIVE_MANIFEST_VERSION,
+            images: [
+                {
+                    id: 'layered-image',
+                    prompt: 'layered',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-06-05T10:00:00.000Z',
+                    imageFileName: 'aura-layered-image.png',
+                    references: [],
+                    layerStack: {
+                        canvasWidth: 1024,
+                        canvasHeight: 1024,
+                        layers: [
+                            {
+                                id: 'base',
+                                name: 'Base',
+                                kind: 'bitmap',
+                                assetFileName: 'aura-layered-image-layer-base.png',
+                                x: 0,
+                                y: 0,
+                                width: 1024,
+                                height: 1024,
+                                rotation: 0,
+                                opacity: 1,
+                                visible: true,
+                                locked: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+        })).toThrow('Invalid layer kind');
+    });
+
+    it('rejects invalid lineage step types through the shared parser', () => {
+        expect(() => parseLineageManifest({
+            version: LINEAGE_MANIFEST_VERSION,
+            steps: [
+                {
+                    id: 'step-1',
+                    archiveImageId: 'image-1',
+                    parentStepId: null,
+                    stepType: 'mystery-step',
+                    timestamp: '2026-06-05T10:00:00.000Z',
+                    metadata: {},
+                },
+            ],
+        })).toThrow('Invalid lineage step type');
+    });
+
+    it('validates exported layer stacks before they are written to a ZIP manifest', () => {
+        const layerStack: ArchiveLayerStack = {
+            canvasWidth: 1024,
+            canvasHeight: 1024,
+            layers: [
+                {
+                    id: 'base',
+                    name: 'Base',
+                    kind: 'base',
+                    assetUrl: 'data:image/png;base64,base',
+                    x: 0,
+                    y: 0,
+                    width: 1024,
+                    height: 1024,
+                    rotation: 0,
+                    opacity: 1,
+                    visible: true,
+                    locked: true,
+                },
+            ],
+        };
+
+        expect(createArchiveManifestLayerStack(
+            'layered-image',
+            layerStack,
+            (imageId, layerId) => `aura-${imageId}-layer-${layerId}.png`,
+        )).toEqual({
+            canvasWidth: 1024,
+            canvasHeight: 1024,
+            layers: [
+                {
+                    id: 'base',
+                    name: 'Base',
+                    kind: 'base',
+                    assetFileName: 'aura-layered-image-layer-base.png',
+                    x: 0,
+                    y: 0,
+                    width: 1024,
+                    height: 1024,
+                    rotation: 0,
+                    opacity: 1,
+                    visible: true,
+                    locked: true,
+                },
+            ],
+        });
+    });
+});
+
+function createManifestLayerStack() {
+    return {
+        canvasWidth: 1024,
+        canvasHeight: 1024,
+        layers: [
+            {
+                id: 'base',
+                name: 'Base',
+                kind: 'base',
+                assetFileName: 'aura-layered-image-layer-base.png',
+                x: 0,
+                y: 0,
+                width: 1024,
+                height: 1024,
+                rotation: 0,
+                opacity: 1,
+                visible: true,
+                locked: true,
+            },
+            {
+                id: 'upload',
+                name: 'Upload',
+                kind: 'uploaded',
+                assetFileName: 'aura-layered-image-layer-upload.png',
+                x: 120,
+                y: 160,
+                width: 400,
+                height: 300,
+                rotation: 0,
+                opacity: 0.8,
+                visible: true,
+                locked: false,
+            },
+        ],
+    };
+}

--- a/src/archive/ArchiveManifest.ts
+++ b/src/archive/ArchiveManifest.ts
@@ -1,0 +1,299 @@
+import type { ArchiveLayer, ArchiveLayerKind, ArchiveLayerStack } from '../db/types';
+import type { LineageStep } from '../lineage/types';
+
+export const ARCHIVE_MANIFEST_FILE = 'archive-manifest.json';
+export const LINEAGE_MANIFEST_FILE = 'lineage-manifest.json';
+export const ARCHIVE_MANIFEST_VERSION = 1;
+export const LINEAGE_MANIFEST_VERSION = 1;
+
+export interface ArchiveManifestReference {
+    fileName: string;
+}
+
+export interface ArchiveManifestImage {
+    id: string;
+    prompt: string;
+    quality: string;
+    aspectRatio: string;
+    background: string;
+    timestamp: string;
+    model?: string;
+    width?: number;
+    height?: number;
+    style?: string;
+    lighting?: string;
+    palette?: string;
+    imageFileName?: string;
+    references: ArchiveManifestReference[];
+    layerStack?: ArchiveManifestLayerStack;
+}
+
+export interface ArchiveManifestLayer extends Omit<ArchiveLayer, 'assetUrl'> {
+    assetFileName: string;
+}
+
+export interface ArchiveManifestLayerStack extends Omit<ArchiveLayerStack, 'layers'> {
+    layers: ArchiveManifestLayer[];
+}
+
+export interface ArchiveManifest {
+    version: typeof ARCHIVE_MANIFEST_VERSION;
+    images: ArchiveManifestImage[];
+}
+
+export interface LineageManifest {
+    version: typeof LINEAGE_MANIFEST_VERSION;
+    steps: LineageStep[];
+}
+
+export function createArchiveManifest(images: ArchiveManifestImage[]): ArchiveManifest {
+    return parseArchiveManifest({
+        version: ARCHIVE_MANIFEST_VERSION,
+        images,
+    });
+}
+
+export function createLineageManifest(steps: LineageStep[]): LineageManifest {
+    return parseLineageManifest({
+        version: LINEAGE_MANIFEST_VERSION,
+        steps,
+    });
+}
+
+export function createEmptyLineageManifest(): LineageManifest {
+    return {
+        version: LINEAGE_MANIFEST_VERSION,
+        steps: [],
+    };
+}
+
+export function parseArchiveManifest(value: unknown): ArchiveManifest {
+    if (!isRecord(value) || !Array.isArray(value.images)) {
+        throw new Error('Invalid archive manifest');
+    }
+    requireManifestVersion(value.version, ARCHIVE_MANIFEST_VERSION, 'archive manifest');
+
+    return {
+        version: ARCHIVE_MANIFEST_VERSION,
+        images: value.images.map(parseArchiveManifestImage),
+    };
+}
+
+export function parseLineageManifest(value: unknown): LineageManifest {
+    if (!isRecord(value) || !Array.isArray(value.steps)) {
+        throw new Error('Invalid lineage manifest');
+    }
+    requireManifestVersion(value.version, LINEAGE_MANIFEST_VERSION, 'lineage manifest');
+
+    return {
+        version: LINEAGE_MANIFEST_VERSION,
+        steps: value.steps.map(parseLineageStep),
+    };
+}
+
+export function createArchiveManifestLayerStack(
+    imageId: string,
+    layerStack: ArchiveLayerStack,
+    getLayerAssetFileName: (imageId: string, layerId: string) => string,
+): ArchiveManifestLayerStack {
+    return parseArchiveManifestLayerStack({
+        canvasWidth: layerStack.canvasWidth,
+        canvasHeight: layerStack.canvasHeight,
+        layers: layerStack.layers.map((layer) => ({
+            id: layer.id,
+            name: layer.name,
+            kind: layer.kind,
+            x: layer.x,
+            y: layer.y,
+            width: layer.width,
+            height: layer.height,
+            rotation: layer.rotation,
+            opacity: layer.opacity,
+            visible: layer.visible,
+            locked: layer.locked,
+            assetFileName: getLayerAssetFileName(imageId, layer.id),
+        })),
+    });
+}
+
+export function createLayerStackMetadata(layerStack: ArchiveManifestLayerStack): ArchiveLayerStack {
+    return {
+        canvasWidth: layerStack.canvasWidth,
+        canvasHeight: layerStack.canvasHeight,
+        layers: layerStack.layers.map((layer) => ({
+            id: layer.id,
+            name: layer.name,
+            kind: layer.kind,
+            x: layer.x,
+            y: layer.y,
+            width: layer.width,
+            height: layer.height,
+            rotation: layer.rotation,
+            opacity: layer.opacity,
+            visible: layer.visible,
+            locked: layer.locked,
+            assetUrl: '',
+        })),
+    };
+}
+
+function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
+    if (!isRecord(value)) {
+        throw new Error('Invalid archive image manifest entry');
+    }
+
+    return {
+        id: requireString(value.id, 'archive image id'),
+        prompt: requireString(value.prompt, 'archive image prompt'),
+        quality: requireString(value.quality, 'archive image quality'),
+        aspectRatio: requireString(value.aspectRatio, 'archive image aspectRatio'),
+        background: requireString(value.background, 'archive image background'),
+        timestamp: requireString(value.timestamp, 'archive image timestamp'),
+        model: optionalString(value.model),
+        width: optionalNumber(value.width),
+        height: optionalNumber(value.height),
+        style: optionalString(value.style),
+        lighting: optionalString(value.lighting),
+        palette: optionalString(value.palette),
+        imageFileName: optionalString(value.imageFileName),
+        references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
+        layerStack: parseOptionalLayerStack(value.layerStack),
+    };
+}
+
+function parseArchiveManifestReference(value: unknown): ArchiveManifestReference {
+    if (!isRecord(value)) {
+        throw new Error('Invalid archive reference manifest entry');
+    }
+
+    return {
+        fileName: requireString(value.fileName, 'archive reference fileName'),
+    };
+}
+
+function parseLineageStep(value: unknown): LineageStep {
+    if (!isRecord(value)) {
+        throw new Error('Invalid lineage step entry');
+    }
+
+    const metadata = value.metadata;
+    if (!isRecord(metadata)) {
+        throw new Error('Invalid lineage metadata');
+    }
+
+    return {
+        id: requireString(value.id, 'lineage step id'),
+        archiveImageId: requireString(value.archiveImageId, 'lineage archiveImageId'),
+        parentStepId: value.parentStepId === null ? null : optionalString(value.parentStepId) ?? null,
+        stepType: requireLineageStepType(value.stepType),
+        timestamp: requireString(value.timestamp, 'lineage timestamp'),
+        metadata,
+    };
+}
+
+function parseOptionalLayerStack(value: unknown): ArchiveManifestLayerStack | undefined {
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+
+    return parseArchiveManifestLayerStack(value);
+}
+
+function parseArchiveManifestLayerStack(value: unknown): ArchiveManifestLayerStack {
+    if (!isRecord(value) || !Array.isArray(value.layers)) {
+        throw new Error('Invalid archive layer stack');
+    }
+
+    return {
+        canvasWidth: requireNumber(value.canvasWidth, 'layer stack canvasWidth'),
+        canvasHeight: requireNumber(value.canvasHeight, 'layer stack canvasHeight'),
+        layers: value.layers.map(parseArchiveManifestLayer),
+    };
+}
+
+function parseArchiveManifestLayer(value: unknown): ArchiveManifestLayer {
+    if (!isRecord(value)) {
+        throw new Error('Invalid archive layer entry');
+    }
+
+    return {
+        id: requireString(value.id, 'layer id'),
+        name: requireString(value.name, 'layer name'),
+        kind: requireLayerKind(value.kind),
+        assetFileName: requireString(value.assetFileName, 'layer assetFileName'),
+        x: requireNumber(value.x, 'layer x'),
+        y: requireNumber(value.y, 'layer y'),
+        width: requireNumber(value.width, 'layer width'),
+        height: requireNumber(value.height, 'layer height'),
+        rotation: requireNumber(value.rotation, 'layer rotation'),
+        opacity: requireNumber(value.opacity, 'layer opacity'),
+        visible: requireBoolean(value.visible, 'layer visible'),
+        locked: requireBoolean(value.locked, 'layer locked'),
+    };
+}
+
+function requireManifestVersion(value: unknown, expectedVersion: number, label: string) {
+    if (value !== expectedVersion) {
+        throw new Error(`Unsupported ${label} version`);
+    }
+}
+
+function requireLineageStepType(value: unknown): LineageStep['stepType'] {
+    if (
+        value === 'generation'
+        || value === 'reference-generation'
+        || value === 'ai-edit'
+        || value === 'manual-edit'
+        || value === 'overwrite'
+        || value === 'save-as-copy'
+        || value === 'autopilot-iteration'
+    ) {
+        return value;
+    }
+
+    throw new Error('Invalid lineage step type');
+}
+
+function requireLayerKind(value: unknown): ArchiveLayerKind {
+    if (value === 'base' || value === 'uploaded' || value === 'ai-result') {
+        return value;
+    }
+
+    throw new Error('Invalid layer kind');
+}
+
+function requireString(value: unknown, label: string) {
+    if (typeof value !== 'string') {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return value;
+}
+
+function requireNumber(value: unknown, label: string) {
+    if (typeof value !== 'number') {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return value;
+}
+
+function requireBoolean(value: unknown, label: string) {
+    if (typeof value !== 'boolean') {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return value;
+}
+
+function optionalString(value: unknown) {
+    return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNumber(value: unknown) {
+    return typeof value === 'number' ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/archive/ArchiveStore.test.ts
+++ b/src/archive/ArchiveStore.test.ts
@@ -20,13 +20,7 @@ class InMemoryArchiveMetadataPort {
     }
 
     async save(record: ArchiveMetadataRecord) {
-        this.records.set(record.id, {
-            ...record,
-            layerStack: record.layerStack ? {
-                ...record.layerStack,
-                layers: record.layerStack.layers.map((layer) => ({ ...layer, assetUrl: '' })),
-            } : undefined,
-        });
+        this.records.set(record.id, record);
     }
 
     async remove(id: string) {
@@ -66,13 +60,17 @@ class InMemoryBlobPort {
 
 describe('ArchiveStore layer asset ownership', () => {
     it('hydrates durable layer metadata with layer bitmap assets', async () => {
-        const { store } = createStore();
+        const { store, metadata } = createStore();
 
         await store.save(createImageInput({
             id: 'image-1',
             layerStack: createLayerStack('image-1', ['base', 'upload']),
         }));
 
+        expect(metadata.records.get('image-1')?.layerStack?.layers.map((layer) => [layer.id, layer.assetUrl])).toEqual([
+            ['base', ''],
+            ['upload', ''],
+        ]);
         await expect(store.list()).resolves.toEqual([
             expect.objectContaining({
                 id: 'image-1',

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -1,6 +1,22 @@
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
 import { storage, type StorageProvider } from '../services/StorageService';
 import { archiveMetadataPort } from '../db/AuraPersistence';
+import {
+    captureArchiveAssetSnapshot,
+    createDurableLayerStackMetadata,
+    getArchiveImageBlobKey,
+    getArchiveImageIdFromBlobKey,
+    getArchiveLayerBlobKey,
+    getArchiveReferenceBlobKey,
+    getLayerIds,
+    getTouchedLayerIds,
+    getTouchedReferenceIds,
+    hydrateLayerStackAssets,
+    restoreArchiveAssetSnapshot,
+    syncLayerAssets,
+    syncReferenceAssets,
+    type ArchiveBlobPort,
+} from './ArchiveAssets';
 
 export type SaveArchiveImageInput = Omit<ArchiveImage, 'id' | 'timestamp'> & {
     id?: string;
@@ -24,13 +40,6 @@ interface ArchiveMetadataPort {
     get(id: string): Promise<ArchiveMetadataRecord | null>;
     save(record: ArchiveMetadataRecord): Promise<void>;
     remove(id: string): Promise<void>;
-}
-
-interface ArchiveBlobPort {
-    save(key: string, data: string): Promise<void>;
-    load(key: string): Promise<string | null>;
-    remove(key: string): Promise<void>;
-    listKeys(): Promise<string[]>;
 }
 
 interface CreateArchiveStoreDeps {
@@ -97,15 +106,17 @@ class LocalArchiveStore implements ArchiveStore {
         const existing = await this.metadata.get(id);
         const timestamp = input.timestamp ?? existing?.timestamp ?? this.clock();
         const referenceIds = input.references?.map((_, index) => index) ?? [];
-        const layerIds = input.layerStack?.layers.map((layer) => layer.id) ?? [];
-        const snapshot = await this.captureSnapshot(id, existing?.referenceIds ?? [], existing?.layerStack?.layers.map((layer) => layer.id) ?? []);
+        const layerIds = getLayerIds(input.layerStack);
+        const previousLayerIds = getLayerIds(existing?.layerStack);
+        const snapshot = await captureArchiveAssetSnapshot(this.blobs, id, existing?.referenceIds ?? [], previousLayerIds);
         const touchedReferenceIds = getTouchedReferenceIds(existing?.referenceIds ?? [], referenceIds);
-        const touchedLayerIds = getTouchedLayerIds(existing?.layerStack?.layers.map((layer) => layer.id) ?? [], layerIds);
+        const touchedLayerIds = getTouchedLayerIds(previousLayerIds, layerIds);
+        const durableLayerStack = createDurableLayerStackMetadata(input.layerStack);
 
         try {
-            await this.blobs.save(getImageBlobKey(id), input.url);
-            await this.syncReferences(id, existing?.referenceIds ?? [], input.references ?? []);
-            await this.syncLayers(id, existing?.layerStack?.layers.map((layer) => layer.id) ?? [], input.layerStack);
+            await this.blobs.save(getArchiveImageBlobKey(id), input.url);
+            await syncReferenceAssets(this.blobs, id, existing?.referenceIds ?? [], input.references ?? []);
+            await syncLayerAssets(this.blobs, id, previousLayerIds, input.layerStack);
 
             await this.metadata.save({
                 id,
@@ -122,11 +133,11 @@ class LocalArchiveStore implements ArchiveStore {
                 lighting: input.lighting,
                 palette: input.palette,
                 referenceIds,
-                layerStack: input.layerStack,
+                layerStack: durableLayerStack,
             });
         } catch (error) {
             await this.restoreMetadata(id, existing);
-            await this.restoreSnapshot(id, snapshot, touchedReferenceIds, touchedLayerIds);
+            await restoreArchiveAssetSnapshot(this.blobs, id, snapshot, touchedReferenceIds, touchedLayerIds);
             throw error;
         }
 
@@ -151,31 +162,33 @@ class LocalArchiveStore implements ArchiveStore {
 
     async remove(id: string): Promise<void> {
         const existing = await this.metadata.get(id);
-        const snapshot = await this.captureSnapshot(
+        const previousLayerIds = getLayerIds(existing?.layerStack);
+        const snapshot = await captureArchiveAssetSnapshot(
+            this.blobs,
             id,
             existing?.referenceIds ?? [],
-            existing?.layerStack?.layers.map((layer) => layer.id) ?? [],
+            previousLayerIds,
         );
         const touchedReferenceIds = existing?.referenceIds ?? [];
-        const touchedLayerIds = existing?.layerStack?.layers.map((layer) => layer.id) ?? [];
+        const touchedLayerIds = previousLayerIds;
 
         try {
-            await this.blobs.remove(getImageBlobKey(id));
-            await Promise.all(touchedReferenceIds.map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
-            await Promise.all(touchedLayerIds.map((layerId) => this.blobs.remove(getLayerBlobKey(id, layerId))));
+            await this.blobs.remove(getArchiveImageBlobKey(id));
+            await Promise.all(touchedReferenceIds.map((index) => this.blobs.remove(getArchiveReferenceBlobKey(id, index))));
+            await Promise.all(touchedLayerIds.map((layerId) => this.blobs.remove(getArchiveLayerBlobKey(id, layerId))));
             await this.metadata.remove(id);
         } catch (error) {
             await this.restoreMetadata(id, existing);
-            await this.restoreSnapshot(id, snapshot, touchedReferenceIds, touchedLayerIds);
+            await restoreArchiveAssetSnapshot(this.blobs, id, snapshot, touchedReferenceIds, touchedLayerIds);
             throw error;
         }
     }
 
     private async hydrate(record: ArchiveMetadataRecord): Promise<ArchiveImage | null> {
         const [imageUrl, references, layerStack] = await Promise.all([
-            this.blobs.load(getImageBlobKey(record.id)),
-            Promise.all(record.referenceIds.map((index) => this.blobs.load(getReferenceBlobKey(record.id, index)))),
-            this.hydrateLayerStack(record.id, record.layerStack),
+            this.blobs.load(getArchiveImageBlobKey(record.id)),
+            Promise.all(record.referenceIds.map((index) => this.blobs.load(getArchiveReferenceBlobKey(record.id, index)))),
+            hydrateLayerStackAssets(this.blobs, record.id, record.layerStack),
         ]);
 
         const resolvedImageUrl = imageUrl ?? (record.storedUrl.startsWith('data:') ? record.storedUrl : null);
@@ -202,55 +215,6 @@ class LocalArchiveStore implements ArchiveStore {
         };
     }
 
-    private async captureSnapshot(id: string, referenceIds: number[], layerIds: string[]) {
-        const [image, references, layers] = await Promise.all([
-            this.blobs.load(getImageBlobKey(id)),
-            Promise.all(referenceIds.map(async (index) => [index, await this.blobs.load(getReferenceBlobKey(id, index))] as const)),
-            Promise.all(layerIds.map(async (layerId) => [layerId, await this.blobs.load(getLayerBlobKey(id, layerId))] as const)),
-        ]);
-
-        return {
-            image,
-            references: new Map(references.filter((entry): entry is readonly [number, string] => entry[1] !== null)),
-            layers: new Map(layers.filter((entry): entry is readonly [string, string] => entry[1] !== null)),
-        };
-    }
-
-    private async restoreSnapshot(
-        id: string,
-        snapshot: { image: string | null; references: Map<number, string>; layers: Map<string, string> },
-        touchedReferenceIds: number[],
-        touchedLayerIds: string[],
-    ) {
-        if (snapshot.image !== null) {
-            await this.blobs.save(getImageBlobKey(id), snapshot.image);
-        } else {
-            await this.blobs.remove(getImageBlobKey(id));
-        }
-
-        const referenceIds = getTouchedReferenceIds(Array.from(snapshot.references.keys()), touchedReferenceIds);
-        await Promise.all(referenceIds.map(async (index) => {
-            const previousReference = snapshot.references.get(index);
-            if (previousReference !== undefined) {
-                await this.blobs.save(getReferenceBlobKey(id, index), previousReference);
-                return;
-            }
-
-            await this.blobs.remove(getReferenceBlobKey(id, index));
-        }));
-
-        const layerIds = getTouchedLayerIds(Array.from(snapshot.layers.keys()), touchedLayerIds);
-        await Promise.all(layerIds.map(async (layerId) => {
-            const previousLayer = snapshot.layers.get(layerId);
-            if (previousLayer !== undefined) {
-                await this.blobs.save(getLayerBlobKey(id, layerId), previousLayer);
-                return;
-            }
-
-            await this.blobs.remove(getLayerBlobKey(id, layerId));
-        }));
-    }
-
     private async restoreMetadata(id: string, record: ArchiveMetadataRecord | null) {
         if (record) {
             await this.metadata.save(record);
@@ -260,41 +224,10 @@ class LocalArchiveStore implements ArchiveStore {
         await this.metadata.remove(id);
     }
 
-    private async syncReferences(id: string, previousReferenceIds: number[], nextReferences: string[]): Promise<void> {
-        await Promise.all(nextReferences.map((reference, index) => this.blobs.save(getReferenceBlobKey(id, index), reference)));
-
-        const nextReferenceIds = new Set(nextReferences.map((_, index) => index));
-        const staleReferenceIds = previousReferenceIds.filter((index) => !nextReferenceIds.has(index));
-
-        await Promise.all(staleReferenceIds.map((index) => this.blobs.remove(getReferenceBlobKey(id, index))));
-    }
-
-    private async syncLayers(id: string, previousLayerIds: string[], nextLayerStack?: ArchiveLayerStack): Promise<void> {
-        await Promise.all((nextLayerStack?.layers ?? []).map((layer) => this.blobs.save(getLayerBlobKey(id, layer.id), layer.assetUrl)));
-
-        const nextLayerIds = new Set((nextLayerStack?.layers ?? []).map((layer) => layer.id));
-        const staleLayerIds = previousLayerIds.filter((layerId) => !nextLayerIds.has(layerId));
-
-        await Promise.all(staleLayerIds.map((layerId) => this.blobs.remove(getLayerBlobKey(id, layerId))));
-    }
-
-    private async hydrateLayerStack(id: string, layerStack?: ArchiveLayerStack): Promise<ArchiveLayerStack | undefined> {
-        if (!layerStack) {
-            return undefined;
-        }
-
-        const layers = await Promise.all(layerStack.layers.map(async (layer) => ({
-            ...layer,
-            assetUrl: await this.blobs.load(getLayerBlobKey(id, layer.id)) ?? layer.assetUrl,
-        })));
-
-        return { ...layerStack, layers };
-    }
-
     private async recoverOrphanedImageBlobs(records: ArchiveMetadataRecord[]): Promise<ArchiveImage[]> {
         const knownImageIds = new Set(records.map((record) => record.id));
         const imageIds = (await this.blobs.listKeys())
-            .map(getImageIdFromBlobKey)
+            .map(getArchiveImageIdFromBlobKey)
             .filter((id): id is string => id !== null && !knownImageIds.has(id))
             .sort();
 
@@ -303,7 +236,7 @@ class LocalArchiveStore implements ArchiveStore {
     }
 
     private async recoverOrphanedImageBlob(id: string): Promise<ArchiveImage | null> {
-        const url = await this.blobs.load(getImageBlobKey(id));
+        const url = await this.blobs.load(getArchiveImageBlobKey(id));
         if (!url) {
             return null;
         }
@@ -337,28 +270,6 @@ class LocalArchiveStore implements ArchiveStore {
         return recoveredImage;
     }
 }
-
-const getImageBlobKey = (id: string) => `img_${id}`;
-
-const getImageIdFromBlobKey = (key: string) => {
-    if (!key.startsWith('img_') || key.length === 'img_'.length) {
-        return null;
-    }
-
-    return key.slice('img_'.length);
-};
-
-const getReferenceBlobKey = (id: string, index: number) => `ref_${id}_${index}`;
-
-const getLayerBlobKey = (id: string, layerId: string) => `layer_${id}_${layerId}`;
-
-const getTouchedReferenceIds = (left: number[], right: number[]) => {
-    return Array.from(new Set([...left, ...right]));
-};
-
-const getTouchedLayerIds = (left: string[], right: string[]) => {
-    return Array.from(new Set([...left, ...right]));
-};
 
 export function createArchiveStore(deps: CreateArchiveStoreDeps = {}): ArchiveStore {
     return new LocalArchiveStore(

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -72,7 +72,7 @@ describe('ArchiveTransfer', () => {
 
     it('round-trips archive images and lineage relationships through ZIP import', async () => {
         const sourceLineage = createStore();
-        const sourceImages = createImages();
+        const sourceImages = [...createImages(), createLayeredImage()];
         await seedLineage(sourceLineage);
 
         const zipBytes = await buildArchiveZip(sourceImages, { lineageStore: sourceLineage });
@@ -86,9 +86,10 @@ describe('ArchiveTransfer', () => {
 
         expect(summary.brokenParentReferences).toEqual([]);
         expect(summary.missingAssetFiles).toEqual([]);
-        expect(summary.importedImageIds).toEqual(['image-1', 'image-2', 'image-3']);
+        expect(summary.importedImageIds).toEqual(['image-1', 'image-2', 'image-3', 'layered-image']);
         expect(summary.importedStepIds).toEqual(['step-1', 'step-2', 'step-3', 'step-4']);
-        expect(Array.from(archiveStore.images.keys())).toEqual(['image-1', 'image-2', 'image-3']);
+        expect(Array.from(archiveStore.images.keys())).toEqual(['image-1', 'image-2', 'image-3', 'layered-image']);
+        expect(archiveStore.images.get('layered-image')?.layerStack?.layers.map((layer) => layer.id)).toEqual(['base', 'upload']);
 
         await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
             expect.objectContaining({ id: 'step-1', stepType: 'generation', parentStepId: null }),
@@ -177,6 +178,50 @@ describe('ArchiveTransfer', () => {
             { stepId: 'step-1', parentStepId: 'missing-parent' },
         ]);
         expect(summary.importedStepIds).toEqual(['step-1']);
+    });
+
+    it('rejects malformed layer stack entries through the shared manifest parser', async () => {
+        const zip = new JSZip();
+        zip.file('aura-layered-image.png', Uint8Array.from([105, 109, 103]));
+        zip.file('archive-manifest.json', JSON.stringify({
+            version: 1,
+            images: [
+                {
+                    id: 'layered-image',
+                    prompt: 'broken layered import',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-04-04T12:00:00.000Z',
+                    imageFileName: 'aura-layered-image.png',
+                    references: [],
+                    layerStack: {
+                        canvasWidth: 1024,
+                        canvasHeight: 1024,
+                        layers: [
+                            {
+                                id: 'base',
+                                name: 'Base',
+                                kind: 'base',
+                                assetFileName: 'aura-layered-image-layer-base.png',
+                                x: 0,
+                                y: 0,
+                                height: 1024,
+                                rotation: 0,
+                                opacity: 1,
+                                visible: true,
+                                locked: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+        }));
+
+        await expect(importArchiveZip(await zip.generateAsync({ type: 'uint8array' }), {
+            archiveStore: new InMemoryArchiveStore(),
+            lineageStore: createStore(),
+        })).rejects.toThrow('Invalid layer width');
     });
 });
 

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -3,51 +3,25 @@ import type { ArchiveStore } from './ArchiveStore';
 import type { ArchiveImage, ArchiveLayer, ArchiveLayerStack } from '../db/types';
 import type { LineageStep } from '../lineage/types';
 import type { LineageStore } from '../lineage/LineageStore';
+import {
+    ARCHIVE_MANIFEST_FILE,
+    LINEAGE_MANIFEST_FILE,
+    createArchiveManifest,
+    createArchiveManifestLayerStack,
+    createEmptyLineageManifest,
+    createLineageManifest,
+    parseArchiveManifest,
+    parseLineageManifest,
+    type ArchiveManifestImage,
+    type ArchiveManifestLayerStack,
+} from './ArchiveManifest';
 
-export const ARCHIVE_MANIFEST_FILE = 'archive-manifest.json';
-export const LINEAGE_MANIFEST_FILE = 'lineage-manifest.json';
-export const ARCHIVE_MANIFEST_VERSION = 1;
-export const LINEAGE_MANIFEST_VERSION = 1;
-
-interface ArchiveManifestReference {
-    fileName: string;
-}
-
-interface ArchiveManifestImage {
-    id: string;
-    prompt: string;
-    quality: string;
-    aspectRatio: string;
-    background: string;
-    timestamp: string;
-    model?: string;
-    width?: number;
-    height?: number;
-    style?: string;
-    lighting?: string;
-    palette?: string;
-    imageFileName: string;
-    references: ArchiveManifestReference[];
-    layerStack?: ArchiveManifestLayerStack;
-}
-
-interface ArchiveManifestLayer extends Omit<ArchiveLayer, 'assetUrl'> {
-    assetFileName: string;
-}
-
-interface ArchiveManifestLayerStack extends Omit<ArchiveLayerStack, 'layers'> {
-    layers: ArchiveManifestLayer[];
-}
-
-interface ArchiveManifest {
-    version: number;
-    images: ArchiveManifestImage[];
-}
-
-interface LineageManifest {
-    version: number;
-    steps: LineageStep[];
-}
+export {
+    ARCHIVE_MANIFEST_FILE,
+    ARCHIVE_MANIFEST_VERSION,
+    LINEAGE_MANIFEST_FILE,
+    LINEAGE_MANIFEST_VERSION,
+} from './ArchiveManifest';
 
 interface BuildArchiveZipDeps {
     lineageStore: Pick<LineageStore, 'getByArchiveImageId'>;
@@ -102,15 +76,9 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
         });
     }
 
-    zip.file(ARCHIVE_MANIFEST_FILE, JSON.stringify({
-        version: ARCHIVE_MANIFEST_VERSION,
-        images: archiveManifestImages,
-    }, null, 2));
+    zip.file(ARCHIVE_MANIFEST_FILE, JSON.stringify(createArchiveManifest(archiveManifestImages), null, 2));
 
-    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify({
-        version: LINEAGE_MANIFEST_VERSION,
-        steps: dedupeLineageSteps(lineageCollections),
-    }, null, 2));
+    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify(createLineageManifest(dedupeLineageSteps(lineageCollections)), null, 2));
 
     return zip.generateAsync({ type: 'uint8array' });
 }
@@ -124,9 +92,10 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
     const importedImageIds: string[] = [];
 
     for (const image of archiveManifest.images) {
-        const imageFile = zip.file(image.imageFileName);
+        const imageFileName = image.imageFileName ?? getImageFileName(image.id);
+        const imageFile = zip.file(imageFileName);
         if (!imageFile) {
-            missingAssetFiles.push(image.imageFileName);
+            missingAssetFiles.push(imageFileName);
             continue;
         }
 
@@ -211,122 +180,10 @@ async function readJsonFile(zip: JSZip, fileName: string): Promise<unknown> {
 async function readOptionalJsonFile(zip: JSZip, fileName: string): Promise<unknown> {
     const file = zip.file(fileName);
     if (!file) {
-        return { version: LINEAGE_MANIFEST_VERSION, steps: [] };
+        return createEmptyLineageManifest();
     }
 
     return JSON.parse(await file.async('text')) as unknown;
-}
-
-function parseArchiveManifest(value: unknown): ArchiveManifest {
-    if (!isRecord(value) || !Array.isArray(value.images) || typeof value.version !== 'number') {
-        throw new Error('Invalid archive manifest');
-    }
-
-    return {
-        version: value.version,
-        images: value.images.map(parseArchiveManifestImage),
-    };
-}
-
-function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
-    if (!isRecord(value)) {
-        throw new Error('Invalid archive image manifest entry');
-    }
-
-    return {
-        id: requireString(value.id, 'archive image id'),
-        prompt: requireString(value.prompt, 'archive image prompt'),
-        quality: requireString(value.quality, 'archive image quality'),
-        aspectRatio: requireString(value.aspectRatio, 'archive image aspectRatio'),
-        background: requireString(value.background, 'archive image background'),
-        timestamp: requireString(value.timestamp, 'archive image timestamp'),
-        model: optionalString(value.model),
-        width: optionalNumber(value.width),
-        height: optionalNumber(value.height),
-        style: optionalString(value.style),
-        lighting: optionalString(value.lighting),
-        palette: optionalString(value.palette),
-        imageFileName: requireString(value.imageFileName, 'archive image fileName'),
-        references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
-        layerStack: parseOptionalLayerStack(value.layerStack),
-    };
-}
-
-function parseArchiveManifestReference(value: unknown): ArchiveManifestReference {
-    if (!isRecord(value)) {
-        throw new Error('Invalid archive reference manifest entry');
-    }
-
-    return {
-        fileName: requireString(value.fileName, 'archive reference fileName'),
-    };
-}
-
-function parseLineageManifest(value: unknown): LineageManifest {
-    if (!isRecord(value) || !Array.isArray(value.steps) || typeof value.version !== 'number') {
-        throw new Error('Invalid lineage manifest');
-    }
-
-    return {
-        version: value.version,
-        steps: value.steps.map(parseLineageStep),
-    };
-}
-
-function parseLineageStep(value: unknown): LineageStep {
-    if (!isRecord(value)) {
-        throw new Error('Invalid lineage step entry');
-    }
-
-    const metadata = value.metadata;
-    if (!isRecord(metadata)) {
-        throw new Error('Invalid lineage metadata');
-    }
-
-    return {
-        id: requireString(value.id, 'lineage step id'),
-        archiveImageId: requireString(value.archiveImageId, 'lineage archiveImageId'),
-        parentStepId: value.parentStepId === null ? null : optionalString(value.parentStepId) ?? null,
-        stepType: requireLineageStepType(value.stepType),
-        timestamp: requireString(value.timestamp, 'lineage timestamp'),
-        metadata,
-    };
-}
-
-function requireLineageStepType(value: unknown): LineageStep['stepType'] {
-    if (
-        value === 'generation'
-        || value === 'reference-generation'
-        || value === 'ai-edit'
-        || value === 'manual-edit'
-        || value === 'overwrite'
-        || value === 'save-as-copy'
-        || value === 'autopilot-iteration'
-    ) {
-        return value;
-    }
-
-    throw new Error('Invalid lineage step type');
-}
-
-function requireString(value: unknown, label: string) {
-    if (typeof value !== 'string') {
-        throw new Error(`Invalid ${label}`);
-    }
-
-    return value;
-}
-
-function optionalString(value: unknown) {
-    return typeof value === 'string' ? value : undefined;
-}
-
-function optionalNumber(value: unknown) {
-    return typeof value === 'number' ? value : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
 }
 
 function getImageFileName(id: string) {
@@ -342,30 +199,11 @@ function getLayerFileName(imageId: string, layerId: string) {
 }
 
 async function addLayerStackToZip(zip: JSZip, imageId: string, layerStack: ArchiveLayerStack): Promise<ArchiveManifestLayerStack> {
-    const layers = await Promise.all(layerStack.layers.map(async (layer) => {
-        const assetFileName = getLayerFileName(imageId, layer.id);
-        zip.file(assetFileName, await imageUrlToBytes(layer.assetUrl));
-        return {
-            id: layer.id,
-            name: layer.name,
-            kind: layer.kind,
-            x: layer.x,
-            y: layer.y,
-            width: layer.width,
-            height: layer.height,
-            rotation: layer.rotation,
-            opacity: layer.opacity,
-            visible: layer.visible,
-            locked: layer.locked,
-            assetFileName,
-        };
+    await Promise.all(layerStack.layers.map(async (layer) => {
+        zip.file(getLayerFileName(imageId, layer.id), await imageUrlToBytes(layer.assetUrl));
     }));
 
-    return {
-        canvasWidth: layerStack.canvasWidth,
-        canvasHeight: layerStack.canvasHeight,
-        layers,
-    };
+    return createArchiveManifestLayerStack(imageId, layerStack, getLayerFileName);
 }
 
 async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStack | undefined, missingAssetFiles: string[]): Promise<ArchiveLayerStack | undefined> {
@@ -375,14 +213,15 @@ async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStac
 
     const layers: ArchiveLayer[] = [];
     for (const layer of layerStack.layers) {
-        const file = zip.file(layer.assetFileName);
+        const { assetFileName, ...layerMetadata } = layer;
+        const file = zip.file(assetFileName);
         if (!file) {
-            missingAssetFiles.push(layer.assetFileName);
+            missingAssetFiles.push(assetFileName);
             continue;
         }
 
         layers.push({
-            ...layer,
+            ...layerMetadata,
             assetUrl: await blobToDataUrl(await file.async('blob')),
         });
     }
@@ -392,66 +231,6 @@ async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStac
         canvasHeight: layerStack.canvasHeight,
         layers,
     };
-}
-
-function parseOptionalLayerStack(value: unknown): ArchiveManifestLayerStack | undefined {
-    if (value === undefined || value === null) {
-        return undefined;
-    }
-    if (!isRecord(value) || !Array.isArray(value.layers)) {
-        throw new Error('Invalid archive layer stack');
-    }
-
-    return {
-        canvasWidth: requireNumber(value.canvasWidth, 'layer stack canvasWidth'),
-        canvasHeight: requireNumber(value.canvasHeight, 'layer stack canvasHeight'),
-        layers: value.layers.map(parseLayer),
-    };
-}
-
-function parseLayer(value: unknown): ArchiveManifestLayer {
-    if (!isRecord(value)) {
-        throw new Error('Invalid archive layer entry');
-    }
-
-    return {
-        id: requireString(value.id, 'layer id'),
-        name: requireString(value.name, 'layer name'),
-        kind: requireLayerKind(value.kind),
-        assetFileName: requireString(value.assetFileName, 'layer assetFileName'),
-        x: requireNumber(value.x, 'layer x'),
-        y: requireNumber(value.y, 'layer y'),
-        width: requireNumber(value.width, 'layer width'),
-        height: requireNumber(value.height, 'layer height'),
-        rotation: requireNumber(value.rotation, 'layer rotation'),
-        opacity: requireNumber(value.opacity, 'layer opacity'),
-        visible: requireBoolean(value.visible, 'layer visible'),
-        locked: requireBoolean(value.locked, 'layer locked'),
-    };
-}
-
-function requireLayerKind(value: unknown): ArchiveLayer['kind'] {
-    if (value === 'base' || value === 'uploaded' || value === 'ai-result') {
-        return value;
-    }
-
-    throw new Error('Invalid layer kind');
-}
-
-function requireNumber(value: unknown, label: string) {
-    if (typeof value !== 'number') {
-        throw new Error(`Invalid ${label}`);
-    }
-
-    return value;
-}
-
-function requireBoolean(value: unknown, label: string) {
-    if (typeof value !== 'boolean') {
-        throw new Error(`Invalid ${label}`);
-    }
-
-    return value;
 }
 
 async function blobToDataUrl(blob: Blob) {

--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -1,6 +1,7 @@
 import { SQLocal } from 'sqlocal';
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import { createDurableLayerStackMetadata } from './ArchiveAssets';
 
 type ArchiveImageRow = ArchiveImage & { ref_ids?: string; layer_stack?: string };
 
@@ -67,7 +68,7 @@ export class SQLiteArchiveMetadataPort {
                 ${record.style || null},
                 ${record.lighting || null},
                 ${record.palette || null},
-                ${record.layerStack ? JSON.stringify(stripLayerAssets(record.layerStack)) : null}
+                ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null}
             )
         `;
     }
@@ -162,11 +163,3 @@ const parseLayerStack = (value?: string): ArchiveLayerStack | undefined => {
         return undefined;
     }
 };
-
-const stripLayerAssets = (layerStack: ArchiveLayerStack): ArchiveLayerStack => ({
-    ...layerStack,
-    layers: layerStack.layers.map((layer) => ({
-        ...layer,
-        assetUrl: '',
-    })),
-});

--- a/src/archive/recoverArchiveMetadata.test.ts
+++ b/src/archive/recoverArchiveMetadata.test.ts
@@ -29,6 +29,40 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     palette: 'none',
                     imageFileName: 'aura-image-1.png',
                     references: [{ fileName: 'aura-image-1-reference-0.png' }],
+                    layerStack: {
+                        canvasWidth: 1536,
+                        canvasHeight: 1024,
+                        layers: [
+                            {
+                                id: 'base',
+                                name: 'Base',
+                                kind: 'base',
+                                assetFileName: 'aura-image-1-layer-base.png',
+                                x: 0,
+                                y: 0,
+                                width: 1536,
+                                height: 1024,
+                                rotation: 0,
+                                opacity: 1,
+                                visible: true,
+                                locked: true,
+                            },
+                            {
+                                id: 'upload',
+                                name: 'Upload',
+                                kind: 'uploaded',
+                                assetFileName: 'aura-image-1-layer-upload.png',
+                                x: 120,
+                                y: 80,
+                                width: 400,
+                                height: 300,
+                                rotation: 0,
+                                opacity: 0.85,
+                                visible: true,
+                                locked: false,
+                            },
+                        ],
+                    },
                 },
                 {
                     id: 'missing-image',
@@ -37,6 +71,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     aspectRatio: '1024x1024',
                     background: 'auto',
                     timestamp: '2026-05-30T16:12:00.000Z',
+                    imageFileName: 'aura-missing-image.png',
                     references: [],
                 },
             ],
@@ -67,10 +102,88 @@ describe('recoverArchiveMetadataFromManifests', () => {
             aspectRatio: '1536x1024',
             referenceIds: [0],
             model: 'gpt-image-2',
+            layerStack: expect.objectContaining({
+                layers: [
+                    expect.objectContaining({ id: 'base', assetUrl: '' }),
+                    expect.objectContaining({ id: 'upload', assetUrl: '' }),
+                ],
+            }),
         }));
         expect(lineage.steps.get('step-1')).toEqual(expect.objectContaining({
             archiveImageId: 'image-1',
             stepType: 'generation',
+        }));
+    });
+
+    it('rejects malformed layer stack entries through the shared manifest parser', async () => {
+        await expect(recoverArchiveMetadataFromManifests({
+            version: 1,
+            images: [
+                {
+                    id: 'image-1',
+                    prompt: 'broken',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-05-30T16:10:56.590Z',
+                    imageFileName: 'aura-image-1.png',
+                    references: [],
+                    layerStack: {
+                        canvasWidth: 1024,
+                        canvasHeight: 1024,
+                        layers: [
+                            {
+                                id: 'base',
+                                name: 'Base',
+                                kind: 'base',
+                                assetFileName: 'aura-image-1-layer-base.png',
+                                x: 0,
+                                y: 0,
+                                height: 1024,
+                                rotation: 0,
+                                opacity: 1,
+                                visible: true,
+                                locked: true,
+                            },
+                        ],
+                    },
+                },
+            ],
+        }, undefined, {
+            metadata: new InMemoryMetadata(),
+            blobs: new InMemoryBlobs([['img_image-1', 'data:image/png;base64,image']]),
+            lineage: new InMemoryLineage(),
+        })).rejects.toThrow('Invalid layer width');
+    });
+
+    it('recovers non-layered archive manifest entries without layer stack data', async () => {
+        const metadata = new InMemoryMetadata();
+
+        const summary = await recoverArchiveMetadataFromManifests({
+            version: 1,
+            images: [
+                {
+                    id: 'flat-image',
+                    prompt: 'flat',
+                    quality: 'high',
+                    aspectRatio: '1024x1024',
+                    background: 'transparent',
+                    timestamp: '2026-05-30T16:10:56.590Z',
+                    imageFileName: 'aura-flat-image.png',
+                    references: [],
+                },
+            ],
+        }, undefined, {
+            metadata,
+            blobs: new InMemoryBlobs([['img_flat-image', 'data:image/png;base64,flat']]),
+            lineage: new InMemoryLineage(),
+        });
+
+        expect(summary.restoredImages).toBe(1);
+        expect(metadata.records.get('flat-image')).toEqual(expect.objectContaining({
+            id: 'flat-image',
+            referenceIds: [],
+            layerStack: undefined,
         }));
     });
 });

--- a/src/archive/recoverArchiveMetadata.ts
+++ b/src/archive/recoverArchiveMetadata.ts
@@ -1,8 +1,14 @@
 import { archiveMetadataPort } from '../db/AuraPersistence';
 import type { ArchiveLayerStack } from '../db/types';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
-import type { LineageStep } from '../lineage/types';
 import { storage, type StorageProvider } from '../services/StorageService';
+import { getArchiveImageBlobKey } from './ArchiveAssets';
+import {
+    createEmptyLineageManifest,
+    createLayerStackMetadata,
+    parseArchiveManifest,
+    parseLineageManifest,
+} from './ArchiveManifest';
 
 interface ArchiveMetadataRecord {
     id: string;
@@ -26,27 +32,6 @@ interface ArchiveMetadataPort {
     save(record: ArchiveMetadataRecord): Promise<void>;
 }
 
-interface ArchiveManifestImage {
-    id: string;
-    prompt: string;
-    quality: string;
-    aspectRatio: string;
-    background: string;
-    timestamp: string;
-    model?: string;
-    width?: number;
-    height?: number;
-    style?: string;
-    lighting?: string;
-    palette?: string;
-    references: unknown[];
-    layerStack?: ArchiveManifestLayerStack;
-}
-
-interface ArchiveManifestLayerStack extends Omit<ArchiveLayerStack, 'layers'> {
-    layers: Array<Omit<ArchiveLayerStack['layers'][number], 'assetUrl'> & { assetFileName?: string }>;
-}
-
 interface RecoveryDeps {
     metadata?: ArchiveMetadataPort;
     blobs?: Pick<StorageProvider, 'load'>;
@@ -68,12 +53,12 @@ export async function recoverArchiveMetadataFromManifests(
     const blobs = deps.blobs ?? storage;
     const lineage = deps.lineage ?? lineageStore;
     const archiveManifest = parseArchiveManifest(archiveManifestValue);
-    const lineageSteps = lineageManifestValue ? parseLineageManifest(lineageManifestValue) : [];
+    const lineageManifest = lineageManifestValue ? parseLineageManifest(lineageManifestValue) : createEmptyLineageManifest();
     const skippedMissingImageBlobs: string[] = [];
     let restoredImages = 0;
 
     for (const image of archiveManifest.images) {
-        const imageUrl = await blobs.load(getImageBlobKey(image.id));
+        const imageUrl = await blobs.load(getArchiveImageBlobKey(image.id));
         if (!imageUrl) {
             skippedMissingImageBlobs.push(image.id);
             continue;
@@ -94,130 +79,18 @@ export async function recoverArchiveMetadataFromManifests(
             lighting: image.lighting,
             palette: image.palette,
             referenceIds: image.references.map((_, index) => index),
-            layerStack: image.layerStack ? restoreLayerStackMetadata(image.layerStack) : undefined,
+            layerStack: image.layerStack ? createLayerStackMetadata(image.layerStack) : undefined,
         });
         restoredImages += 1;
     }
 
-    for (const step of lineageSteps) {
+    for (const step of lineageManifest.steps) {
         await lineage.save(step);
     }
 
     return {
         restoredImages,
         skippedMissingImageBlobs,
-        restoredLineageSteps: lineageSteps.length,
+        restoredLineageSteps: lineageManifest.steps.length,
     };
-}
-
-const getImageBlobKey = (id: string) => `img_${id}`;
-
-function parseArchiveManifest(value: unknown): { images: ArchiveManifestImage[] } {
-    if (!isRecord(value) || !Array.isArray(value.images)) {
-        throw new Error('Invalid archive manifest');
-    }
-
-    return {
-        images: value.images.map(parseArchiveManifestImage),
-    };
-}
-
-function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
-    if (!isRecord(value)) {
-        throw new Error('Invalid archive image manifest entry');
-    }
-
-    return {
-        id: requireString(value.id, 'archive image id'),
-        prompt: requireString(value.prompt, 'archive image prompt'),
-        quality: requireString(value.quality, 'archive image quality'),
-        aspectRatio: requireString(value.aspectRatio, 'archive image aspectRatio'),
-        background: requireString(value.background, 'archive image background'),
-        timestamp: requireString(value.timestamp, 'archive image timestamp'),
-        model: optionalString(value.model),
-        width: optionalNumber(value.width),
-        height: optionalNumber(value.height),
-        style: optionalString(value.style),
-        lighting: optionalString(value.lighting),
-        palette: optionalString(value.palette),
-        references: Array.isArray(value.references) ? value.references : [],
-        layerStack: parseLayerStack(value.layerStack),
-    };
-}
-
-function parseLineageManifest(value: unknown): LineageStep[] {
-    if (!isRecord(value) || !Array.isArray(value.steps)) {
-        throw new Error('Invalid lineage manifest');
-    }
-
-    return value.steps.map(parseLineageStep);
-}
-
-function parseLineageStep(value: unknown): LineageStep {
-    if (!isRecord(value) || !isRecord(value.metadata)) {
-        throw new Error('Invalid lineage step entry');
-    }
-
-    return {
-        id: requireString(value.id, 'lineage step id'),
-        archiveImageId: requireString(value.archiveImageId, 'lineage archiveImageId'),
-        parentStepId: value.parentStepId === null ? null : optionalString(value.parentStepId) ?? null,
-        stepType: requireLineageStepType(value.stepType),
-        timestamp: requireString(value.timestamp, 'lineage timestamp'),
-        metadata: value.metadata,
-    };
-}
-
-function requireLineageStepType(value: unknown): LineageStep['stepType'] {
-    if (
-        value === 'generation'
-        || value === 'reference-generation'
-        || value === 'ai-edit'
-        || value === 'manual-edit'
-        || value === 'overwrite'
-        || value === 'save-as-copy'
-        || value === 'autopilot-iteration'
-    ) {
-        return value;
-    }
-
-    throw new Error('Invalid lineage step type');
-}
-
-function parseLayerStack(value: unknown): ArchiveManifestLayerStack | undefined {
-    if (!isRecord(value) || !Array.isArray(value.layers)) {
-        return undefined;
-    }
-
-    return value as unknown as ArchiveManifestLayerStack;
-}
-
-function restoreLayerStackMetadata(layerStack: ArchiveManifestLayerStack): ArchiveLayerStack {
-    return {
-        ...layerStack,
-        layers: layerStack.layers.map((layer) => ({
-            ...layer,
-            assetUrl: '',
-        })),
-    };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function requireString(value: unknown, label: string) {
-    if (typeof value !== 'string') {
-        throw new Error(`Invalid ${label}`);
-    }
-
-    return value;
-}
-
-function optionalString(value: unknown) {
-    return typeof value === 'string' ? value : undefined;
-}
-
-function optionalNumber(value: unknown) {
-    return typeof value === 'number' ? value : undefined;
 }

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -1,23 +1,29 @@
 import { useEffect, useState } from 'react';
 import type { ArchiveImage } from '../db/types';
+import {
+    buildActiveImageModelControls,
+    buildImageModelArchiveFields,
+    getDefaultImageModelControls,
+    getImageModelDraftKey as resolveImageModelDraftKey,
+    sanitizeArchiveImageModelControls,
+    sanitizeImageModelControls,
+    type GptImage2Controls,
+    type ImageModelArchiveFields,
+    type NanoBananaProControls,
+} from '../image-models/ImageModelControls';
 import { storage, type StorageProvider } from '../services/StorageService';
-import type { ImageBackground, ImageQuality } from '../utils/openai';
 import {
     DEFAULT_IMAGE_MODEL,
     NANO_BANANA_PRO_IMAGE_MODEL,
+    OPENAI_IMAGE_MODEL,
     isImageModelSlug,
     type ImageModelSlug,
-    type NanoBananaAspectRatio,
-    type NanoBananaImageSize,
 } from '../utils/openaiModels';
 
 const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
 const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
-const VALID_OPENAI_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
-const VALID_NANO_ASPECT_RATIOS = new Set(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9']);
-const VALID_NANO_IMAGE_SIZES = new Set(['1K', '2K', '4K']);
 
 const LEGACY_KEYS = {
     prompt: 'aura_generate_prompt',
@@ -41,16 +47,9 @@ export interface GenerateDraft {
     isSaved: boolean;
 }
 
-export interface GptImage2DraftControls {
-    quality: ImageQuality;
-    size: string;
-    background: ImageBackground;
-}
+export type GptImage2DraftControls = GptImage2Controls;
 
-export interface NanoBananaProDraftControls {
-    aspectRatio: NanoBananaAspectRatio;
-    imageSize: NanoBananaImageSize;
-}
+export type NanoBananaProDraftControls = NanoBananaProControls;
 
 export interface GenerateLineageSource {
     archiveImageId: string;
@@ -81,15 +80,8 @@ export const DEFAULT_GENERATE_DRAFT: GenerateDraft = {
     style: 'none',
     lighting: 'none',
     palette: 'none',
-    gptImage2: {
-        quality: 'medium',
-        size: '1024x1024',
-        background: 'auto',
-    },
-    nanoBananaPro: {
-        aspectRatio: '1:1',
-        imageSize: '1K',
-    },
+    gptImage2: getDefaultImageModelControls(OPENAI_IMAGE_MODEL),
+    nanoBananaPro: getDefaultImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL),
     isSaved: false,
 };
 
@@ -127,24 +119,17 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
     }
 
     async transferFromArchive(image: ArchiveImage, lineageSource: GenerateLineageSource | null = { archiveImageId: image.id }, draftOverrides: Partial<GenerateDraft> = {}): Promise<void> {
+        const model = isImageModelSlug(image.model) ? image.model : DEFAULT_IMAGE_MODEL;
+
         this.writeDraft(sanitizeGenerateDraft({
             ...DEFAULT_GENERATE_DRAFT,
             prompt: image.prompt,
-            model: isImageModelSlug(image.model) ? image.model : DEFAULT_IMAGE_MODEL,
+            model,
             style: image.style || 'none',
             lighting: image.lighting || 'none',
             palette: image.palette || 'none',
-            gptImage2: {
-                ...DEFAULT_GENERATE_DRAFT.gptImage2,
-                quality: coerceQuality(image.quality),
-                size: coerceOpenAiSize(image.aspectRatio),
-                background: coerceBackground(image.background),
-            },
-            nanoBananaPro: {
-                ...DEFAULT_GENERATE_DRAFT.nanoBananaPro,
-                aspectRatio: coerceNanoAspectRatio(image.aspectRatio),
-                imageSize: coerceNanoImageSize(image.quality),
-            },
+            gptImage2: sanitizeArchiveImageModelControls(OPENAI_IMAGE_MODEL, image),
+            nanoBananaPro: sanitizeArchiveImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, image),
             isSaved: false,
             ...draftOverrides,
         }));
@@ -287,9 +272,15 @@ type DraftLike = Partial<GenerateDraft> & {
 };
 
 export const sanitizeGenerateDraft = (draft: DraftLike): GenerateDraft => {
-    const legacyQuality = coerceQuality(draft.quality);
-    const legacySize = coerceOpenAiSize(draft.aspectRatio);
-    const legacyBackground = coerceBackground(draft.background);
+    const legacyGptImage2Controls = sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+        quality: draft.quality,
+        size: draft.aspectRatio,
+        background: draft.background,
+    });
+    const legacyNanoBananaProControls = sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
+        aspectRatio: draft.aspectRatio,
+        imageSize: draft.quality,
+    });
 
     return {
         model: isImageModelSlug(draft.model) ? draft.model : DEFAULT_GENERATE_DRAFT.model,
@@ -297,108 +288,26 @@ export const sanitizeGenerateDraft = (draft: DraftLike): GenerateDraft => {
         style: typeof draft.style === 'string' ? draft.style : DEFAULT_GENERATE_DRAFT.style,
         lighting: typeof draft.lighting === 'string' ? draft.lighting : DEFAULT_GENERATE_DRAFT.lighting,
         palette: typeof draft.palette === 'string' ? draft.palette : DEFAULT_GENERATE_DRAFT.palette,
-        gptImage2: sanitizeGptImage2Controls(draft.gptImage2, {
-            quality: legacyQuality,
-            size: legacySize,
-            background: legacyBackground,
-        }),
-        nanoBananaPro: sanitizeNanoBananaProControls(draft.nanoBananaPro, {
-            aspectRatio: coerceNanoAspectRatio(draft.aspectRatio),
-            imageSize: DEFAULT_GENERATE_DRAFT.nanoBananaPro.imageSize,
-        }),
+        gptImage2: sanitizeImageModelControls(OPENAI_IMAGE_MODEL, draft.gptImage2, legacyGptImage2Controls),
+        nanoBananaPro: sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, draft.nanoBananaPro, legacyNanoBananaProControls),
         isSaved: typeof draft.isSaved === 'boolean' ? draft.isSaved : DEFAULT_GENERATE_DRAFT.isSaved,
     };
 };
 
 export function getActiveGenerateControls(draft: GenerateDraft) {
     if (draft.model === NANO_BANANA_PRO_IMAGE_MODEL) {
-        return {
-            aspectRatio: draft.nanoBananaPro.aspectRatio,
-            imageSize: draft.nanoBananaPro.imageSize,
-            quality: DEFAULT_GENERATE_DRAFT.gptImage2.quality,
-            background: DEFAULT_GENERATE_DRAFT.gptImage2.background,
-        };
+        return buildActiveImageModelControls(draft.model, draft.nanoBananaPro);
     }
 
-    return {
-        aspectRatio: draft.gptImage2.size,
-        imageSize: undefined,
-        quality: draft.gptImage2.quality,
-        background: draft.gptImage2.background,
-    };
+    return buildActiveImageModelControls(draft.model, draft.gptImage2);
 }
 
-export function getImageModelDraftKey(model: ImageModelSlug) {
-    return model === NANO_BANANA_PRO_IMAGE_MODEL ? 'nanoBananaPro' : 'gptImage2';
+export function getActiveGenerateArchiveFields(draft: GenerateDraft): ImageModelArchiveFields {
+    if (draft.model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return buildImageModelArchiveFields(draft.model, draft.nanoBananaPro);
+    }
+
+    return buildImageModelArchiveFields(draft.model, draft.gptImage2);
 }
 
-function sanitizeGptImage2Controls(value: unknown, fallback: GptImage2DraftControls): GptImage2DraftControls {
-    const record = value && typeof value === 'object' ? value as Partial<GptImage2DraftControls> : {};
-    return {
-        quality: isQuality(record.quality) ? record.quality : fallback.quality,
-        size: isOpenAiSize(record.size) ? record.size : fallback.size,
-        background: isBackground(record.background) ? record.background : fallback.background,
-    };
-}
-
-function sanitizeNanoBananaProControls(value: unknown, fallback: NanoBananaProDraftControls): NanoBananaProDraftControls {
-    const record = value && typeof value === 'object' ? value as Partial<NanoBananaProDraftControls> : {};
-    return {
-        aspectRatio: isNanoAspectRatio(record.aspectRatio) ? record.aspectRatio : fallback.aspectRatio,
-        imageSize: isNanoImageSize(record.imageSize) ? record.imageSize : fallback.imageSize,
-    };
-}
-
-const coerceQuality = (quality: unknown): ImageQuality => {
-    return isQuality(quality)
-        ? quality
-        : DEFAULT_GENERATE_DRAFT.gptImage2.quality;
-};
-
-const coerceBackground = (background: unknown): ImageBackground => {
-    return isBackground(background)
-        ? background
-        : DEFAULT_GENERATE_DRAFT.gptImage2.background;
-};
-
-const coerceOpenAiSize = (size: unknown): string => {
-    return isOpenAiSize(size)
-        ? size
-        : DEFAULT_GENERATE_DRAFT.gptImage2.size;
-};
-
-const coerceNanoAspectRatio = (aspectRatio: unknown): NanoBananaAspectRatio => {
-    if (aspectRatio === '1024x1024' || aspectRatio === 'auto') return '1:1';
-    if (aspectRatio === '1536x1024') return '3:2';
-    if (aspectRatio === '1024x1536') return '2:3';
-
-    return isNanoAspectRatio(aspectRatio)
-        ? aspectRatio
-        : DEFAULT_GENERATE_DRAFT.nanoBananaPro.aspectRatio;
-};
-
-const coerceNanoImageSize = (imageSize: unknown): NanoBananaImageSize => {
-    return isNanoImageSize(imageSize)
-        ? imageSize
-        : DEFAULT_GENERATE_DRAFT.nanoBananaPro.imageSize;
-};
-
-function isQuality(value: unknown): value is ImageQuality {
-    return value === 'low' || value === 'medium' || value === 'high';
-}
-
-function isBackground(value: unknown): value is ImageBackground {
-    return value === 'auto' || value === 'opaque' || value === 'transparent';
-}
-
-function isOpenAiSize(value: unknown): value is string {
-    return typeof value === 'string' && VALID_OPENAI_SIZES.has(value);
-}
-
-function isNanoAspectRatio(value: unknown): value is NanoBananaAspectRatio {
-    return typeof value === 'string' && VALID_NANO_ASPECT_RATIOS.has(value);
-}
-
-function isNanoImageSize(value: unknown): value is NanoBananaImageSize {
-    return typeof value === 'string' && VALID_NANO_IMAGE_SIZES.has(value);
-}
+export const getImageModelDraftKey = resolveImageModelDraftKey;

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -3,7 +3,7 @@ import { createLineageStore, type LineageMetadataPort, type LineageStep } from '
 import { saveGeneratedImage } from './saveGeneratedImage';
 import type { ArchiveImage } from '../db/types';
 import type { GenerateLineageSource } from './GenerateSession';
-import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -59,8 +59,13 @@ describe('saveGeneratedImage', () => {
                 timestamp: savedImage.timestamp,
                 metadata: expect.objectContaining({
                     prompt: savedImage.prompt,
+                    model: OPENAI_IMAGE_MODEL,
                     quality: savedImage.quality,
                     aspectRatio: savedImage.aspectRatio,
+                    background: savedImage.background,
+                    width: 1024,
+                    height: 1024,
+                    imageSize: null,
                     sourceArchiveImageId: null,
                     referenceIds: [],
                 }),
@@ -92,6 +97,41 @@ describe('saveGeneratedImage', () => {
                         'generated-2:reference:0',
                         'generated-2:reference:1',
                     ],
+                }),
+            }),
+        ]);
+    });
+
+    it('records nano-banana-pro archive metadata dimensions through shared Image model controls', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const image = createArchiveImage({
+            id: 'generated-nano',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            quality: '2K',
+            aspectRatio: '16:9',
+            background: 'auto',
+            width: 2048,
+            height: 1152,
+        });
+
+        await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        await expect(lineage.getByArchiveImageId('generated-nano')).resolves.toEqual([
+            expect.objectContaining({
+                stepType: 'generation',
+                metadata: expect.objectContaining({
+                    model: NANO_BANANA_PRO_IMAGE_MODEL,
+                    quality: '2K',
+                    aspectRatio: '16:9',
+                    background: 'auto',
+                    width: 2048,
+                    height: 1152,
+                    imageSize: '2K',
                 }),
             }),
         ]);

--- a/src/generate-session/saveGeneratedImage.ts
+++ b/src/generate-session/saveGeneratedImage.ts
@@ -1,5 +1,10 @@
 import type { ArchiveImage } from '../db/types';
+import {
+    buildImageModelArchiveFields,
+    sanitizeArchiveImageModelControls,
+} from '../image-models/ImageModelControls';
 import type { LineageStore } from '../lineage/LineageStore';
+import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, isImageModelSlug } from '../utils/openaiModels';
 import type { GenerateLineageSource, GenerateSessionStore } from './GenerateSession';
 
 export interface SaveGeneratedImageDeps {
@@ -42,12 +47,19 @@ async function resolveParentStepId(
 }
 
 function buildGenerationMetadata(image: ArchiveImage, lineageSource: GenerateLineageSource | null) {
+    const model = isImageModelSlug(image.model) ? image.model : DEFAULT_IMAGE_MODEL;
+    const imageModelControls = sanitizeArchiveImageModelControls(model, image);
+    const imageModelArchiveFields = buildImageModelArchiveFields(model, imageModelControls);
+
     return {
         prompt: image.prompt,
         model: image.model ?? null,
         quality: image.quality,
         aspectRatio: image.aspectRatio,
         background: image.background,
+        width: image.width ?? imageModelArchiveFields.width,
+        height: image.height ?? imageModelArchiveFields.height,
+        imageSize: model === NANO_BANANA_PRO_IMAGE_MODEL ? imageModelArchiveFields.quality : null,
         style: image.style ?? 'none',
         lighting: image.lighting ?? 'none',
         palette: image.palette ?? 'none',

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
+import { buildGeneratedArchiveImage } from './useGenerateController';
+
+describe('Generate controller Image model archive metadata', () => {
+    it('builds gpt-image-2 archive metadata from shared Image model controls', () => {
+        const draft = createDraft({
+            model: OPENAI_IMAGE_MODEL,
+            gptImage2: {
+                quality: 'high',
+                size: '1536x1024',
+                background: 'transparent',
+            },
+        });
+
+        expect(buildGeneratedArchiveImage({
+            id: 'generated-openai',
+            url: 'data:image/png;base64,gpt',
+            timestamp: '2026-06-05T12:00:00.000Z',
+            draft,
+            references: ['data:image/png;base64,ref'],
+        })).toMatchObject({
+            id: 'generated-openai',
+            model: OPENAI_IMAGE_MODEL,
+            quality: 'high',
+            aspectRatio: '1536x1024',
+            background: 'transparent',
+            width: 1536,
+            height: 1024,
+            references: ['data:image/png;base64,ref'],
+        });
+    });
+
+    it('builds nano-banana-pro archive metadata from shared Image model controls', () => {
+        const draft = createDraft({
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            nanoBananaPro: {
+                aspectRatio: '16:9',
+                imageSize: '4K',
+            },
+        });
+
+        expect(buildGeneratedArchiveImage({
+            id: 'generated-nano',
+            url: 'data:image/png;base64,nano',
+            timestamp: '2026-06-05T12:00:00.000Z',
+            draft,
+            references: [],
+        })).toMatchObject({
+            id: 'generated-nano',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            quality: '4K',
+            aspectRatio: '16:9',
+            background: 'auto',
+            width: 4096,
+            height: 2304,
+            references: [],
+        });
+    });
+});
+
+function createDraft(overrides: Partial<GenerateDraft>): GenerateDraft {
+    return {
+        ...DEFAULT_GENERATE_DRAFT,
+        prompt: 'studio prompt',
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        ...overrides,
+        gptImage2: {
+            ...DEFAULT_GENERATE_DRAFT.gptImage2,
+            ...overrides.gptImage2,
+        },
+        nanoBananaPro: {
+            ...DEFAULT_GENERATE_DRAFT.nanoBananaPro,
+            ...overrides.nanoBananaPro,
+        },
+    };
+}

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, getActiveGenerateControls, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
+import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
 import { imageWorkflow, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
@@ -42,6 +42,41 @@ interface UseGenerateControllerOptions {
     createAutopilot?: typeof createAutopilotSession;
     evaluate?: typeof satisfactionEvaluator.evaluate;
     refine?: typeof promptRefiner.refine;
+}
+
+interface BuildGeneratedArchiveImageInput {
+    id: string;
+    url: string;
+    timestamp: string;
+    draft: GenerateDraft;
+    references: string[];
+}
+
+export function buildGeneratedArchiveImage({
+    id,
+    url,
+    timestamp,
+    draft,
+    references,
+}: BuildGeneratedArchiveImageInput): ArchiveImage {
+    const archiveFields = getActiveGenerateArchiveFields(draft);
+
+    return {
+        id,
+        url,
+        prompt: draft.prompt,
+        model: draft.model,
+        timestamp,
+        width: archiveFields.width,
+        height: archiveFields.height,
+        quality: archiveFields.quality,
+        aspectRatio: archiveFields.aspectRatio,
+        background: archiveFields.background,
+        style: draft.style,
+        lighting: draft.lighting,
+        palette: draft.palette,
+        references,
+    };
 }
 
 export function useGenerateController({
@@ -232,24 +267,13 @@ export function useGenerateController({
 
         try {
             const references = await serializeReferences();
-            const controls = getActiveGenerateControls(draft);
-            const { width, height } = getImageDimensions(controls.aspectRatio, controls.imageSize);
-            await saveGeneratedImage({
+            await saveGeneratedImage(buildGeneratedArchiveImage({
                 id: crypto.randomUUID(),
                 url: currentResult,
-                prompt: draft.prompt,
-                model: draft.model,
                 timestamp: new Date().toISOString(),
-                width,
-                height,
-                quality: controls.imageSize ?? controls.quality,
-                aspectRatio: controls.aspectRatio,
-                background: controls.background,
-                style: draft.style,
-                lighting: draft.lighting,
-                palette: draft.palette,
+                draft,
                 references,
-            }, {
+            }), {
                 saveImage: async (image) => Promise.resolve(onSaveImage(image)),
                 lineageStore: lineage,
                 sessionStore: session,
@@ -286,36 +310,4 @@ export function useGenerateController({
         download,
         clear,
     };
-}
-
-function getImageDimensions(aspectRatio: string, imageSize?: string) {
-    if (imageSize) {
-        const longEdge = imageSize === '4K' ? 4096 : imageSize === '2K' ? 2048 : 1024;
-        const [widthRatio, heightRatio] = aspectRatio.split(':').map(Number);
-        if (widthRatio && heightRatio) {
-            if (widthRatio >= heightRatio) {
-                return {
-                    width: longEdge,
-                    height: Math.round(longEdge * (heightRatio / widthRatio)),
-                };
-            }
-
-            return {
-                width: Math.round(longEdge * (widthRatio / heightRatio)),
-                height: longEdge,
-            };
-        }
-    }
-
-    if (aspectRatio === 'auto') {
-        return { width: 1024, height: 1024 };
-    }
-
-    const [width, height] = aspectRatio.split('x').map(Number);
-
-    if (!width || !height) {
-        return { width: 1024, height: 1024 };
-    }
-
-    return { width, height };
 }

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+    IMAGE_MODEL_CONTROL_FACTS,
+    buildImageModelArchiveFields,
+    coerceImageModelControlValue,
+    getDefaultImageModelControls,
+    getImageModelGenerateControls,
+    getImageModelReferenceLimitMessage,
+    getImageModelUiChoices,
+    limitReferenceImagesForImageModel,
+    mapImageModelEditProviderRequest,
+    mapImageModelGenerateProviderRequest,
+    sanitizeImageModelControls,
+} from './ImageModelControls';
+import { IMAGE_MODEL_REGISTRY, NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+
+describe('Image model controls', () => {
+    it('covers every registered Image model with defaults and Generate UI facts', () => {
+        const registrySlugs = Object.keys(IMAGE_MODEL_REGISTRY).sort();
+
+        expect(Object.keys(IMAGE_MODEL_CONTROL_FACTS).sort()).toEqual(registrySlugs);
+        expect(getImageModelUiChoices().map((choice) => choice.slug).sort()).toEqual(registrySlugs);
+        expect(getImageModelGenerateControls(OPENAI_IMAGE_MODEL)).toEqual([
+            {
+                id: 'quality',
+                label: 'QUALITY',
+                kind: 'toggle',
+                options: [
+                    { value: 'low', label: 'Low' },
+                    { value: 'medium', label: 'Medium' },
+                    { value: 'high', label: 'High' },
+                ],
+            },
+            {
+                id: 'size',
+                label: 'SIZE',
+                kind: 'select',
+                options: [
+                    { value: 'auto', label: 'Auto' },
+                    { value: '1024x1024', label: 'Square (1:1)' },
+                    { value: '1536x1024', label: 'Wide (3:2)' },
+                    { value: '1024x1536', label: 'Tall (2:3)' },
+                ],
+            },
+            {
+                id: 'background',
+                label: 'BACKGROUND',
+                kind: 'toggle',
+                options: [
+                    { value: 'auto', label: 'Auto' },
+                    { value: 'opaque', label: 'Opaque' },
+                    { value: 'transparent', label: 'Transparent' },
+                ],
+            },
+        ]);
+        expect(getImageModelGenerateControls(NANO_BANANA_PRO_IMAGE_MODEL).map((control) => control.id)).toEqual([
+            'aspectRatio',
+            'imageSize',
+        ]);
+    });
+
+    it('validates defaults and coercion for both Image models', () => {
+        expect(getDefaultImageModelControls(OPENAI_IMAGE_MODEL)).toEqual({
+            quality: 'medium',
+            size: '1024x1024',
+            background: 'auto',
+        });
+        expect(getDefaultImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL)).toEqual({
+            aspectRatio: '1:1',
+            imageSize: '1K',
+        });
+        expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+            quality: 'high',
+            size: '1536x1024',
+            background: 'transparent',
+        })).toEqual({
+            quality: 'high',
+            size: '1536x1024',
+            background: 'transparent',
+        });
+        expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+            quality: 'best',
+            size: '1600x900',
+            background: 'clear',
+        })).toEqual(getDefaultImageModelControls(OPENAI_IMAGE_MODEL));
+        expect(sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
+            aspectRatio: '1536x1024',
+            imageSize: '4K',
+        })).toEqual({
+            aspectRatio: '3:2',
+            imageSize: '4K',
+        });
+        expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'aspectRatio', '1024x1536')).toBe('2:3');
+        expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'quality', 'best')).toBe('medium');
+    });
+
+    it('builds archive metadata dimensions for Generate saves through shared Image model controls', () => {
+        expect(buildImageModelArchiveFields(OPENAI_IMAGE_MODEL, {
+            quality: 'high',
+            size: '1536x1024',
+            background: 'transparent',
+        })).toEqual({
+            quality: 'high',
+            aspectRatio: '1536x1024',
+            background: 'transparent',
+            width: 1536,
+            height: 1024,
+        });
+        expect(buildImageModelArchiveFields(NANO_BANANA_PRO_IMAGE_MODEL, {
+            aspectRatio: '16:9',
+            imageSize: '2K',
+        })).toEqual({
+            quality: '2K',
+            aspectRatio: '16:9',
+            background: 'auto',
+            width: 2048,
+            height: 1152,
+        });
+    });
+
+    it('maps Generate Provider requests for both Image models', () => {
+        const references = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+
+        expect(mapImageModelGenerateProviderRequest(OPENAI_IMAGE_MODEL, {
+            quality: 'high',
+            aspectRatio: ' 1536x1024 ',
+            background: 'transparent',
+            referenceImages: references,
+        })).toEqual({
+            quality: 'high',
+            size: '1536x1024',
+            background: 'transparent',
+            referenceImages: references,
+        });
+        expect(mapImageModelGenerateProviderRequest(NANO_BANANA_PRO_IMAGE_MODEL, {
+            quality: 'high',
+            aspectRatio: '1024x1536',
+            background: 'transparent',
+            imageSize: '4K',
+            referenceImages: references,
+        })).toEqual({
+            aspectRatio: '2:3',
+            imageSize: '4K',
+            referenceImages: references.slice(0, 14),
+        });
+    });
+
+    it('maps Editor Provider requests with source and Reference image limits for each Image model', () => {
+        const sourceImage = new File(['source'], 'source.png', { type: 'image/png' });
+        const references = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+
+        expect(mapImageModelEditProviderRequest(OPENAI_IMAGE_MODEL, {
+            sourceImage,
+            referenceImages: references.slice(0, 1),
+            quality: 'low',
+        })).toEqual({
+            quality: 'low',
+            size: '1024x1024',
+            background: 'auto',
+            referenceImages: [sourceImage, references[0]],
+        });
+
+        const nanoRequest = mapImageModelEditProviderRequest(NANO_BANANA_PRO_IMAGE_MODEL, {
+            sourceImage,
+            referenceImages: references,
+        });
+
+        expect(nanoRequest).toEqual({
+            aspectRatio: '1:1',
+            imageSize: '1K',
+            preserveSourceDimensions: true,
+            referenceImages: [sourceImage, ...references.slice(0, 13)],
+        });
+        expect(nanoRequest.referenceImages).toHaveLength(14);
+    });
+
+    it('exposes shared UI facts for Reference image limits used by Generate and Editor', () => {
+        const references = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+
+        expect(limitReferenceImagesForImageModel(OPENAI_IMAGE_MODEL, references)).toHaveLength(15);
+        expect(limitReferenceImagesForImageModel(NANO_BANANA_PRO_IMAGE_MODEL, references)).toHaveLength(14);
+        expect(getImageModelReferenceLimitMessage(OPENAI_IMAGE_MODEL, references.length, 'generation')).toBeNull();
+        expect(getImageModelReferenceLimitMessage(NANO_BANANA_PRO_IMAGE_MODEL, references.length, 'generation')).toBe(
+            'Nano Banana Pro uses the first 14 reference images for generation.',
+        );
+        expect(getImageModelReferenceLimitMessage(NANO_BANANA_PRO_IMAGE_MODEL, references.length, 'AI transforms')).toBe(
+            'Nano Banana Pro uses the first 14 reference images for AI transforms.',
+        );
+    });
+});

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -1,0 +1,481 @@
+import type { ImageBackground, ImageQuality } from '../utils/openai';
+import type { ArchiveImage } from '../db/types';
+import {
+    IMAGE_MODEL_REGISTRY,
+    NANO_BANANA_PRO_IMAGE_MODEL,
+    OPENAI_IMAGE_MODEL,
+    type ImageModelSlug,
+    type NanoBananaAspectRatio,
+    type NanoBananaImageSize,
+    type Provider,
+} from '../utils/openaiModels';
+
+export const NANO_REFERENCE_LIMIT = 14;
+
+export type GptImage2Controls = {
+    quality: ImageQuality;
+    size: string;
+    background: ImageBackground;
+};
+
+export type NanoBananaProControls = {
+    aspectRatio: NanoBananaAspectRatio;
+    imageSize: NanoBananaImageSize;
+};
+
+export type ImageModelControls = GptImage2Controls | NanoBananaProControls;
+
+export type ImageModelControlId = 'quality' | 'size' | 'background' | 'aspectRatio' | 'imageSize';
+
+export interface ActiveImageModelControls {
+    quality: ImageQuality;
+    aspectRatio: string;
+    background: ImageBackground;
+    imageSize?: NanoBananaImageSize;
+}
+
+export interface ImageModelArchiveFields {
+    quality: string;
+    aspectRatio: string;
+    background: string;
+    width: number;
+    height: number;
+}
+
+export interface ImageModelControlOption {
+    value: string;
+    label: string;
+}
+
+export interface ImageModelGenerateControl {
+    id: ImageModelControlId;
+    label: string;
+    kind: 'toggle' | 'select';
+    options: ImageModelControlOption[];
+}
+
+interface ImageModelControlFacts {
+    defaults: ImageModelControls;
+    generateControls: ImageModelGenerateControl[];
+    referenceLimit: number | null;
+}
+
+const GPT_IMAGE_2_SIZES = ['1024x1024', '1536x1024', '1024x1536', 'auto'] as const;
+const IMAGE_QUALITIES = ['low', 'medium', 'high'] as const;
+const IMAGE_BACKGROUNDS = ['auto', 'opaque', 'transparent'] as const;
+const NANO_ASPECT_RATIOS = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'] as const;
+const NANO_IMAGE_SIZES = ['1K', '2K', '4K'] as const;
+
+export const IMAGE_MODEL_CONTROL_FACTS = {
+    [OPENAI_IMAGE_MODEL]: {
+        defaults: {
+            quality: 'medium',
+            size: '1024x1024',
+            background: 'auto',
+        },
+        generateControls: [
+            {
+                id: 'quality',
+                label: 'QUALITY',
+                kind: 'toggle',
+                options: [
+                    { value: 'low', label: 'Low' },
+                    { value: 'medium', label: 'Medium' },
+                    { value: 'high', label: 'High' },
+                ],
+            },
+            {
+                id: 'size',
+                label: 'SIZE',
+                kind: 'select',
+                options: [
+                    { value: 'auto', label: 'Auto' },
+                    { value: '1024x1024', label: 'Square (1:1)' },
+                    { value: '1536x1024', label: 'Wide (3:2)' },
+                    { value: '1024x1536', label: 'Tall (2:3)' },
+                ],
+            },
+            {
+                id: 'background',
+                label: 'BACKGROUND',
+                kind: 'toggle',
+                options: [
+                    { value: 'auto', label: 'Auto' },
+                    { value: 'opaque', label: 'Opaque' },
+                    { value: 'transparent', label: 'Transparent' },
+                ],
+            },
+        ],
+        referenceLimit: null,
+    },
+    [NANO_BANANA_PRO_IMAGE_MODEL]: {
+        defaults: {
+            aspectRatio: '1:1',
+            imageSize: '1K',
+        },
+        generateControls: [
+            {
+                id: 'aspectRatio',
+                label: 'ASPECT RATIO',
+                kind: 'select',
+                options: [
+                    { value: '1:1', label: 'Square (1:1)' },
+                    { value: '2:3', label: 'Portrait (2:3)' },
+                    { value: '3:2', label: 'Landscape (3:2)' },
+                    { value: '3:4', label: 'Portrait (3:4)' },
+                    { value: '4:3', label: 'Landscape (4:3)' },
+                    { value: '4:5', label: 'Portrait (4:5)' },
+                    { value: '5:4', label: 'Landscape (5:4)' },
+                    { value: '9:16', label: 'Story (9:16)' },
+                    { value: '16:9', label: 'Widescreen (16:9)' },
+                    { value: '21:9', label: 'Cinema (21:9)' },
+                ],
+            },
+            {
+                id: 'imageSize',
+                label: 'RESOLUTION',
+                kind: 'toggle',
+                options: [
+                    { value: '1K', label: '1K' },
+                    { value: '2K', label: '2K' },
+                    { value: '4K', label: '4K' },
+                ],
+            },
+        ],
+        referenceLimit: NANO_REFERENCE_LIMIT,
+    },
+} as const satisfies Record<ImageModelSlug, ImageModelControlFacts>;
+
+export function getDefaultImageModelControls(model: typeof OPENAI_IMAGE_MODEL): GptImage2Controls;
+export function getDefaultImageModelControls(model: typeof NANO_BANANA_PRO_IMAGE_MODEL): NanoBananaProControls;
+export function getDefaultImageModelControls(model: ImageModelSlug): ImageModelControls;
+export function getDefaultImageModelControls(model: ImageModelSlug): ImageModelControls {
+    return { ...IMAGE_MODEL_CONTROL_FACTS[model].defaults };
+}
+
+export function getImageModelDraftKey(model: ImageModelSlug): 'gptImage2' | 'nanoBananaPro' {
+    return model === NANO_BANANA_PRO_IMAGE_MODEL ? 'nanoBananaPro' : 'gptImage2';
+}
+
+export function getImageModelGenerateControls(model: ImageModelSlug): ImageModelGenerateControl[] {
+    return IMAGE_MODEL_CONTROL_FACTS[model].generateControls.map((control) => ({
+        ...control,
+        options: control.options.map((option) => ({ ...option })),
+    }));
+}
+
+export function getImageModelUiChoices(): Array<{
+    slug: ImageModelSlug;
+    label: string;
+    provider: Provider;
+}> {
+    return (Object.keys(IMAGE_MODEL_REGISTRY) as ImageModelSlug[]).map((slug) => {
+        const config = IMAGE_MODEL_REGISTRY[slug];
+        return {
+            slug,
+            label: config.label,
+            provider: config.provider,
+        };
+    });
+}
+
+export function sanitizeImageModelControls(
+    model: typeof OPENAI_IMAGE_MODEL,
+    value: unknown,
+    fallback?: GptImage2Controls,
+): GptImage2Controls;
+export function sanitizeImageModelControls(
+    model: typeof NANO_BANANA_PRO_IMAGE_MODEL,
+    value: unknown,
+    fallback?: NanoBananaProControls,
+): NanoBananaProControls;
+export function sanitizeImageModelControls(
+    model: ImageModelSlug,
+    value: unknown,
+    fallback?: ImageModelControls,
+): ImageModelControls;
+export function sanitizeImageModelControls(
+    model: ImageModelSlug,
+    value: unknown,
+    fallback: ImageModelControls = getDefaultImageModelControls(model),
+): ImageModelControls {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const record = asRecord(value);
+        const fallbackControls = asNanoControls(fallback);
+        return {
+            aspectRatio: coerceNanoAspectRatio(record?.aspectRatio, fallbackControls.aspectRatio),
+            imageSize: coerceNanoImageSize(record?.imageSize, fallbackControls.imageSize),
+        };
+    }
+
+    const record = asRecord(value);
+    const fallbackControls = asGptControls(fallback);
+    return {
+        quality: coerceImageQuality(record?.quality, fallbackControls.quality),
+        size: coerceGptImageSize(record?.size, fallbackControls.size),
+        background: coerceImageBackground(record?.background, fallbackControls.background),
+    };
+}
+
+export function sanitizeArchiveImageModelControls(model: typeof OPENAI_IMAGE_MODEL, image: Pick<ArchiveImage, 'quality' | 'aspectRatio' | 'background'>): GptImage2Controls;
+export function sanitizeArchiveImageModelControls(model: typeof NANO_BANANA_PRO_IMAGE_MODEL, image: Pick<ArchiveImage, 'quality' | 'aspectRatio' | 'background'>): NanoBananaProControls;
+export function sanitizeArchiveImageModelControls(model: ImageModelSlug, image: Pick<ArchiveImage, 'quality' | 'aspectRatio' | 'background'>): ImageModelControls;
+export function sanitizeArchiveImageModelControls(model: ImageModelSlug, image: Pick<ArchiveImage, 'quality' | 'aspectRatio' | 'background'>): ImageModelControls {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return sanitizeImageModelControls(model, {
+            aspectRatio: image.aspectRatio,
+            imageSize: image.quality,
+        });
+    }
+
+    return sanitizeImageModelControls(model, {
+        quality: image.quality,
+        size: image.aspectRatio,
+        background: image.background,
+    });
+}
+
+export function coerceImageModelControlValue(model: ImageModelSlug, controlId: string, value: unknown): string {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const defaults = getDefaultImageModelControls(model) as NanoBananaProControls;
+        if (controlId === 'aspectRatio') {
+            return coerceNanoAspectRatio(value, defaults.aspectRatio);
+        }
+        if (controlId === 'imageSize') {
+            return coerceNanoImageSize(value, defaults.imageSize);
+        }
+        return '';
+    }
+
+    const defaults = getDefaultImageModelControls(model) as GptImage2Controls;
+    if (controlId === 'quality') {
+        return coerceImageQuality(value, defaults.quality);
+    }
+    if (controlId === 'size') {
+        return coerceGptImageSize(value, defaults.size);
+    }
+    if (controlId === 'background') {
+        return coerceImageBackground(value, defaults.background);
+    }
+    return '';
+}
+
+export function getActiveImageModelGenerateControls(model: ImageModelSlug, controls: ImageModelControls): ActiveImageModelControls {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const sanitized = sanitizeImageModelControls(model, controls) as NanoBananaProControls;
+        const gptDefaults = getDefaultImageModelControls(OPENAI_IMAGE_MODEL) as GptImage2Controls;
+        return {
+            aspectRatio: sanitized.aspectRatio,
+            imageSize: sanitized.imageSize,
+            quality: gptDefaults.quality,
+            background: gptDefaults.background,
+        };
+    }
+
+    const sanitized = sanitizeImageModelControls(model, controls) as GptImage2Controls;
+    return {
+        aspectRatio: sanitized.size,
+        imageSize: undefined,
+        quality: sanitized.quality,
+        background: sanitized.background,
+    };
+}
+
+export const buildActiveImageModelControls = getActiveImageModelGenerateControls;
+
+export function buildImageModelArchiveFields(model: ImageModelSlug, controls: unknown): ImageModelArchiveFields {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const sanitized = sanitizeImageModelControls(model, controls) as NanoBananaProControls;
+        const { width, height } = getRatioDimensions(sanitized.aspectRatio, getNanoLongEdge(sanitized.imageSize));
+        return {
+            quality: sanitized.imageSize,
+            aspectRatio: sanitized.aspectRatio,
+            background: 'auto',
+            width,
+            height,
+        };
+    }
+
+    const sanitized = sanitizeImageModelControls(model, controls) as GptImage2Controls;
+    const { width, height } = getExactDimensions(sanitized.size);
+    return {
+        quality: sanitized.quality,
+        aspectRatio: sanitized.size,
+        background: sanitized.background,
+        width,
+        height,
+    };
+}
+
+export function mapImageModelGenerateProviderRequest(
+    model: ImageModelSlug,
+    input: {
+        quality: ImageQuality;
+        aspectRatio: string;
+        background: ImageBackground;
+        imageSize?: NanoBananaImageSize;
+        referenceImages: File[];
+    },
+) {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const controls = sanitizeImageModelControls(model, {
+            aspectRatio: input.aspectRatio,
+            imageSize: input.imageSize,
+        }) as NanoBananaProControls;
+        return {
+            aspectRatio: controls.aspectRatio,
+            imageSize: controls.imageSize,
+            referenceImages: limitReferenceImagesForImageModel(model, input.referenceImages),
+        };
+    }
+
+    return {
+        quality: coerceImageQuality(input.quality, 'medium'),
+        size: coerceGptImageSize(input.aspectRatio, '1024x1024'),
+        background: coerceImageBackground(input.background, 'auto'),
+        referenceImages: input.referenceImages,
+    };
+}
+
+export function mapImageModelEditProviderRequest(
+    model: ImageModelSlug,
+    input: {
+        sourceImage: File;
+        referenceImages: File[];
+        quality?: ImageQuality;
+        aspectRatio?: NanoBananaAspectRatio;
+        imageSize?: NanoBananaImageSize;
+    },
+) {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        const controls = sanitizeImageModelControls(model, {
+            aspectRatio: input.aspectRatio,
+            imageSize: input.imageSize,
+        }) as NanoBananaProControls;
+        return {
+            aspectRatio: controls.aspectRatio,
+            imageSize: controls.imageSize,
+            preserveSourceDimensions: true,
+            referenceImages: [input.sourceImage, ...input.referenceImages.slice(0, NANO_REFERENCE_LIMIT - 1)],
+        };
+    }
+
+    return {
+        quality: coerceImageQuality(input.quality, 'medium'),
+        size: '1024x1024',
+        background: 'auto' as ImageBackground,
+        referenceImages: [input.sourceImage, ...input.referenceImages],
+    };
+}
+
+export function limitReferenceImagesForImageModel<T>(model: ImageModelSlug, referenceImages: T[]): T[] {
+    const limit = IMAGE_MODEL_CONTROL_FACTS[model].referenceLimit;
+    return limit === null ? referenceImages : referenceImages.slice(0, limit);
+}
+
+export function getImageModelReferenceLimitMessage(
+    model: ImageModelSlug,
+    referenceCount: number,
+    context: string,
+): string | null {
+    const limit = IMAGE_MODEL_CONTROL_FACTS[model].referenceLimit;
+    if (limit === null || referenceCount <= limit) {
+        return null;
+    }
+
+    return `${IMAGE_MODEL_REGISTRY[model].label} uses the first ${limit} reference images for ${context}.`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function asGptControls(value: ImageModelControls): GptImage2Controls {
+    return 'quality' in value ? value : IMAGE_MODEL_CONTROL_FACTS[OPENAI_IMAGE_MODEL].defaults;
+}
+
+function asNanoControls(value: ImageModelControls): NanoBananaProControls {
+    return 'aspectRatio' in value ? value : IMAGE_MODEL_CONTROL_FACTS[NANO_BANANA_PRO_IMAGE_MODEL].defaults;
+}
+
+function coerceImageQuality(value: unknown, fallback: ImageQuality): ImageQuality {
+    return typeof value === 'string' && (IMAGE_QUALITIES as readonly string[]).includes(value)
+        ? value as ImageQuality
+        : fallback;
+}
+
+function coerceImageBackground(value: unknown, fallback: ImageBackground): ImageBackground {
+    return typeof value === 'string' && (IMAGE_BACKGROUNDS as readonly string[]).includes(value)
+        ? value as ImageBackground
+        : fallback;
+}
+
+function coerceGptImageSize(value: unknown, fallback: string): string {
+    if (typeof value !== 'string') {
+        return fallback;
+    }
+
+    const normalized = value.trim();
+    return (GPT_IMAGE_2_SIZES as readonly string[]).includes(normalized) ? normalized : fallback;
+}
+
+function coerceNanoAspectRatio(value: unknown, fallback: NanoBananaAspectRatio): NanoBananaAspectRatio {
+    if (value === '1024x1024' || value === 'auto') return '1:1';
+    if (value === '1536x1024') return '3:2';
+    if (value === '1024x1536') return '2:3';
+
+    if (typeof value !== 'string') {
+        return fallback;
+    }
+
+    const normalized = value.trim();
+    if (normalized === '1024x1024' || normalized === 'auto') return '1:1';
+    if (normalized === '1536x1024') return '3:2';
+    if (normalized === '1024x1536') return '2:3';
+
+    return (NANO_ASPECT_RATIOS as readonly string[]).includes(normalized)
+        ? normalized as NanoBananaAspectRatio
+        : fallback;
+}
+
+function coerceNanoImageSize(value: unknown, fallback: NanoBananaImageSize): NanoBananaImageSize {
+    return typeof value === 'string' && (NANO_IMAGE_SIZES as readonly string[]).includes(value)
+        ? value as NanoBananaImageSize
+        : fallback;
+}
+
+function getExactDimensions(size: string) {
+    if (size === 'auto') {
+        return { width: 1024, height: 1024 };
+    }
+
+    const [width, height] = size.split('x').map(Number);
+    return width && height ? { width, height } : { width: 1024, height: 1024 };
+}
+
+function getRatioDimensions(aspectRatio: string, longEdge: number) {
+    const [widthRatio, heightRatio] = aspectRatio.split(':').map(Number);
+    if (!widthRatio || !heightRatio) {
+        return { width: longEdge, height: longEdge };
+    }
+
+    if (widthRatio >= heightRatio) {
+        return {
+            width: longEdge,
+            height: Math.round(longEdge * (heightRatio / widthRatio)),
+        };
+    }
+
+    return {
+        width: Math.round(longEdge * (widthRatio / heightRatio)),
+        height: longEdge,
+    };
+}
+
+function getNanoLongEdge(imageSize: NanoBananaImageSize) {
+    if (imageSize === '4K') return 4096;
+    if (imageSize === '2K') return 2048;
+    return 1024;
+}

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -5,7 +5,7 @@ import { createGoogleImageProvider, extractGoogleImageData } from './ImageProvid
 
 describe('ImageWorkflow', () => {
     it('routes generate requests through the configured provider for the selected model', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
         const providers: ImageProviderRegistry = {
             openai: {
                 generate,
@@ -70,11 +70,13 @@ describe('ImageWorkflow', () => {
             }),
             prompt: 'make it cinematic',
             quality: 'medium',
+            size: '1024x1024',
+            background: 'auto',
         }));
     });
 
     it('falls back to the default generation size when aspect ratio value is unsupported', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
         const workflow = createImageWorkflow({
             openai: {
                 generate,
@@ -247,6 +249,54 @@ describe('ImageWorkflow', () => {
             'user-reference.png',
         ]);
     });
+
+    it('maps nano-banana-pro Editor AI transforms with source handling and Reference image limits', async () => {
+        const edit = vi.fn(async (_request: Parameters<ImageProvider['edit']>[0]) => ({ b64_json: 'edited-nano' }));
+        const workflow = createImageWorkflow({
+            openai: {
+                generate: vi.fn(),
+                edit: vi.fn(),
+            },
+            google: {
+                generate: vi.fn(),
+                edit,
+            },
+        });
+        const references = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+
+        await workflow.edit({
+            apiKey: 'google-key',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            prompt: 'make it cinematic',
+            sourceImage: new Blob(['source'], { type: 'image/png' }),
+            referenceImages: references,
+        });
+
+        const request = edit.mock.calls[0]?.[0];
+        expect(request).toEqual(expect.objectContaining({
+            aspectRatio: '1:1',
+            imageSize: '1K',
+            preserveSourceDimensions: true,
+        }));
+        expect(request?.referenceImages?.map((file) => file.name)).toEqual([
+            'edit-input.png',
+            'ref-0.png',
+            'ref-1.png',
+            'ref-2.png',
+            'ref-3.png',
+            'ref-4.png',
+            'ref-5.png',
+            'ref-6.png',
+            'ref-7.png',
+            'ref-8.png',
+            'ref-9.png',
+            'ref-10.png',
+            'ref-11.png',
+            'ref-12.png',
+        ]);
+    });
 });
 
 describe('googleImageProvider', () => {
@@ -302,7 +352,7 @@ describe('googleImageProvider', () => {
     });
 
     it('normalizes unsupported Nano Banana aspect ratios to 1:1', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -333,7 +383,7 @@ describe('googleImageProvider', () => {
     });
 
     it('uses only the first 14 references for Nano Banana generation requests', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -361,7 +411,7 @@ describe('googleImageProvider', () => {
             referenceImages: references,
         });
 
-        const calledWith = generate.mock.calls[0]?.[0] as { referenceImages: File[] };
+        const calledWith = generate.mock.calls[0]?.[0] as unknown as { referenceImages: File[] };
         expect(calledWith.referenceImages).toHaveLength(14);
         expect(calledWith.referenceImages.map((file) => file.name)).toEqual([
             'ref-0.png',

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -3,14 +3,15 @@ import {
     type ImageBackground,
     type ImageQuality,
 } from '../utils/openai';
-import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, resolveImageModelConfig, type ImageModelSlug, type NanoBananaAspectRatio, type NanoBananaImageSize } from '../utils/openaiModels';
+import {
+    mapImageModelEditProviderRequest,
+    mapImageModelGenerateProviderRequest,
+} from '../image-models/ImageModelControls';
+import { DEFAULT_IMAGE_MODEL, resolveImageModelConfig, type ImageModelSlug, type NanoBananaAspectRatio, type NanoBananaImageSize } from '../utils/openaiModels';
 import { imageProviderRegistry, type ImageProvider, type ImageProviderRegistry, type ImageProviderResponse } from './ImageProvider';
 
 export type { ImageProvider, ImageProviderRegistry } from './ImageProvider';
-
-const VALID_GENERATION_SIZES = new Set(['1024x1024', '1536x1024', '1024x1536', 'auto']);
-const VALID_NANO_ASPECT_RATIOS = new Set<NanoBananaAspectRatio>(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9']);
-export const NANO_REFERENCE_LIMIT = 14;
+export { NANO_REFERENCE_LIMIT } from '../image-models/ImageModelControls';
 
 export interface GenerateImageInput {
     apiKey: string;
@@ -47,33 +48,38 @@ export interface ImageWorkflow {
 export function createImageWorkflow(providers: ImageProviderRegistry = imageProviderRegistry): ImageWorkflow {
     return {
         async generate(input) {
-            const { model, provider } = resolveImageProvider(input.model, providers);
+            const { model, modelSlug, provider } = resolveImageProvider(input.model, providers);
+            const providerRequest = mapImageModelGenerateProviderRequest(modelSlug, {
+                quality: input.quality,
+                aspectRatio: input.aspectRatio,
+                background: input.background,
+                imageSize: input.imageSize,
+                referenceImages: input.referenceImages,
+            });
 
             return requestImageDataUrl(provider.generate({
                 apiKey: input.apiKey,
                 model,
                 prompt: buildGenerationPrompt(input),
-                quality: input.quality,
-                size: sanitizeGenerationSize(input.aspectRatio),
-                background: input.background,
-                aspectRatio: model.slug === NANO_BANANA_PRO_IMAGE_MODEL ? normalizeNanoAspectRatio(input.aspectRatio) : undefined,
-                imageSize: input.imageSize,
-                referenceImages: trimNanoReferences(model.slug, input.referenceImages),
+                ...providerRequest,
             }));
         },
 
         async edit(input) {
-            const { model, provider } = resolveImageProvider(input.model, providers);
+            const { model, modelSlug, provider } = resolveImageProvider(input.model, providers);
+            const providerRequest = mapImageModelEditProviderRequest(modelSlug, {
+                sourceImage: createEditSourceFile(input.sourceImage),
+                referenceImages: input.referenceImages,
+                quality: input.quality,
+                aspectRatio: input.aspectRatio,
+                imageSize: input.imageSize,
+            });
 
             return requestImageDataUrl(provider.edit({
                 apiKey: input.apiKey,
                 model,
                 prompt: input.prompt,
-                quality: input.quality ?? 'medium',
-                aspectRatio: input.aspectRatio,
-                imageSize: input.imageSize,
-                preserveSourceDimensions: model.slug === NANO_BANANA_PRO_IMAGE_MODEL,
-                referenceImages: [createEditSourceFile(input.sourceImage), ...input.referenceImages],
+                ...providerRequest,
             }));
         },
 
@@ -86,28 +92,6 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
         },
     };
 }
-
-const trimNanoReferences = (modelSlug: ImageModelSlug, referenceImages: File[]) => {
-    return modelSlug === NANO_BANANA_PRO_IMAGE_MODEL
-        ? referenceImages.slice(0, NANO_REFERENCE_LIMIT)
-        : referenceImages;
-};
-
-function isNanoAspectRatio(value: string): value is NanoBananaAspectRatio {
-    return VALID_NANO_ASPECT_RATIOS.has(value as NanoBananaAspectRatio);
-}
-
-const normalizeNanoAspectRatio = (size: string): NanoBananaAspectRatio => {
-    const normalizedSize = size.trim();
-    const mapped = (
-        normalizedSize === '1536x1024' ? '3:2' :
-            normalizedSize === '1024x1536' ? '2:3' :
-                normalizedSize === 'auto' || normalizedSize === '1024x1024' ? '1:1' :
-                    normalizedSize
-    );
-
-    return isNanoAspectRatio(mapped) ? mapped : '1:1';
-};
 
 export const imageWorkflow = createImageWorkflow();
 
@@ -123,11 +107,6 @@ const buildGenerationPrompt = (input: GenerateImageInput) => {
         : input.prompt;
 };
 
-const sanitizeGenerationSize = (size: string) => {
-    const normalizedSize = size.trim();
-    return VALID_GENERATION_SIZES.has(normalizedSize) ? normalizedSize : '1024x1024';
-};
-
 const createEditSourceFile = (sourceImage: Blob) => {
     return new File([sourceImage], 'edit-input.png', {
         type: sourceImage.type || 'image/png',
@@ -136,6 +115,7 @@ const createEditSourceFile = (sourceImage: Blob) => {
 
 const resolveImageProvider = (slug: ImageModelSlug = DEFAULT_IMAGE_MODEL, providers: ImageProviderRegistry): {
     model: ReturnType<typeof resolveImageModelConfig>;
+    modelSlug: ImageModelSlug;
     provider: ImageProvider;
 } => {
     const model = resolveImageModelConfig(slug);
@@ -145,7 +125,7 @@ const resolveImageProvider = (slug: ImageModelSlug = DEFAULT_IMAGE_MODEL, provid
         throw new Error(`No image provider configured for ${model.provider}`);
     }
 
-    return { model, provider };
+    return { model, modelSlug: slug, provider };
 };
 
 const requestImageDataUrl = async (request: Promise<ImageProviderResponse>) => {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -1,7 +1,7 @@
 import type { ArchiveImage } from '../db/types';
 import { DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft, type GenerateDraft, type GenerateLineageSource } from '../generate-session/GenerateSession';
-import { DEFAULT_IMAGE_MODEL, isImageModelSlug } from '../utils/openaiModels';
-import type { ImageBackground, ImageQuality } from '../utils/openai';
+import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug } from '../utils/openaiModels';
+import { sanitizeImageModelControls } from '../image-models/ImageModelControls';
 import type { LineageStep } from './LineageStore';
 
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
@@ -19,6 +19,7 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
     lineageSource: GenerateLineageSource;
 } {
     const model = resolveReplayModel(image, step);
+    const replayAspectRatio = asString(step.metadata.aspectRatio) ?? image?.aspectRatio;
 
     return {
         draft: sanitizeGenerateDraft({
@@ -28,17 +29,15 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
             style: asString(step.metadata.style) ?? image?.style ?? 'none',
             lighting: asString(step.metadata.lighting) ?? image?.lighting ?? 'none',
             palette: asString(step.metadata.palette) ?? image?.palette ?? 'none',
-            gptImage2: {
-                ...DEFAULT_GENERATE_DRAFT.gptImage2,
-                quality: asQuality(step.metadata.quality) ?? asQuality(image?.quality) ?? DEFAULT_GENERATE_DRAFT.gptImage2.quality,
-                size: asString(step.metadata.aspectRatio) ?? image?.aspectRatio ?? DEFAULT_GENERATE_DRAFT.gptImage2.size,
-                background: asBackground(step.metadata.background) ?? asBackground(image?.background) ?? DEFAULT_GENERATE_DRAFT.gptImage2.background,
-            },
-            nanoBananaPro: {
-                ...DEFAULT_GENERATE_DRAFT.nanoBananaPro,
-                aspectRatio: asString(step.metadata.aspectRatio) as GenerateDraft['nanoBananaPro']['aspectRatio'] ?? image?.aspectRatio as GenerateDraft['nanoBananaPro']['aspectRatio'] ?? DEFAULT_GENERATE_DRAFT.nanoBananaPro.aspectRatio,
-                imageSize: asString(step.metadata.imageSize) as GenerateDraft['nanoBananaPro']['imageSize'] ?? image?.quality as GenerateDraft['nanoBananaPro']['imageSize'] ?? DEFAULT_GENERATE_DRAFT.nanoBananaPro.imageSize,
-            },
+            gptImage2: model === OPENAI_IMAGE_MODEL ? sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+                quality: step.metadata.quality ?? image?.quality,
+                size: replayAspectRatio,
+                background: step.metadata.background ?? image?.background,
+            }) : DEFAULT_GENERATE_DRAFT.gptImage2,
+            nanoBananaPro: model === NANO_BANANA_PRO_IMAGE_MODEL ? sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
+                aspectRatio: replayAspectRatio,
+                imageSize: step.metadata.imageSize ?? image?.quality,
+            }) : DEFAULT_GENERATE_DRAFT.nanoBananaPro,
             isSaved: false,
         }),
         lineageSource: {
@@ -62,12 +61,4 @@ function resolveReplayModel(image: ArchiveImage | null, step: LineageStep) {
 
 function asString(value: unknown) {
     return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-function asQuality(value: unknown): ImageQuality | null {
-    return value === 'low' || value === 'medium' || value === 'high' ? value : null;
-}
-
-function asBackground(value: unknown): ImageBackground | null {
-    return value === 'auto' || value === 'opaque' || value === 'transparent' ? value : null;
 }

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -22,7 +22,7 @@ describe('openAiImageClient', () => {
 
             expect(result).toEqual({ b64_json: 'generated' });
 
-            const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [url, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
             expect(url).toBe('https://api.openai.com/v1/images/generations');
             expect(request.method).toBe('POST');
 
@@ -65,7 +65,7 @@ describe('openAiImageClient', () => {
             expect(result).toEqual({ b64_json: 'edited' });
             expect(fetchMock).toHaveBeenCalledTimes(1);
 
-            const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [url, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
             expect(url).toBe('https://api.openai.com/v1/images/edits');
             expect(request.method).toBe('POST');
 
@@ -138,7 +138,7 @@ describe('openAiResponsesClient', () => {
 
             expect(result).toEqual({ outputText: 'summary of image' });
 
-            const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [url, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
             expect(url).toBe('https://api.openai.com/v1/responses');
             expect(request.method).toBe('POST');
 
@@ -234,7 +234,7 @@ describe('openAiResponsesClient', () => {
                 userText: 'just text please',
             });
 
-            const [, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
             const body = JSON.parse(String(request.body));
             const userContent = body.input[1].content;
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -6,6 +6,7 @@ export type ImageBackground = 'transparent' | 'opaque' | 'auto';
 
 export interface OpenAiImageRequest {
     apiKey: string;
+    model?: string;
     apiModel?: string;
     endpoints?: {
         generate: string;
@@ -44,7 +45,7 @@ export interface OpenAiResponsesClient {
 export const openAiImageClient: OpenAiImageClient = {
     async createImage(request) {
         const isEdit = request.referenceImages && request.referenceImages.length > 0;
-        const apiModel = request.apiModel ?? OPENAI_IMAGE_MODEL;
+        const apiModel = request.apiModel ?? request.model ?? OPENAI_IMAGE_MODEL;
         const endpoints = request.endpoints ?? IMAGE_MODEL_REGISTRY[OPENAI_IMAGE_MODEL].endpoints;
         const endpoint = isEdit ? endpoints.edit : endpoints.generate;
 

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -7,7 +7,8 @@ import { resolveEditorShortcut } from '../editor/shortcuts';
 import { useEditorController } from '../editor/useEditorController';
 import { useEditorSession } from '../editor/useEditorSession';
 import type { EditorSaveContext } from '../editor/saveEditedImage';
-import { IMAGE_MODEL_REGISTRY, OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig, type ImageModelSlug, type Provider } from '../utils/openaiModels';
+import { OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig, type ImageModelSlug, type Provider } from '../utils/openaiModels';
+import { getImageModelReferenceLimitMessage, getImageModelUiChoices } from '../image-models/ImageModelControls';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
@@ -96,6 +97,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         adjustments,
         onSave,
     });
+    const aiReferenceWarning = getImageModelReferenceLimitMessage(aiEditModel, referenceImages.length, 'AI transforms');
 
     useEffect(() => {
         const isTextInput = (target: EventTarget | null) => {
@@ -299,18 +301,17 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
                             <div className="option-group">
                                 <label>MODEL</label>
                                 <div className="toggle-group">
-                                    {(Object.keys(IMAGE_MODEL_REGISTRY) as ImageModelSlug[]).map((modelSlug) => {
-                                        const config = resolveImageModelConfig(modelSlug);
-                                        const hasKey = !!getProviderKey(config.provider);
+                                    {getImageModelUiChoices().map((choice) => {
+                                        const hasKey = !!getProviderKey(choice.provider);
                                         return (
                                             <button
-                                                key={modelSlug}
-                                                className={aiEditModel === modelSlug ? 'active' : ''}
-                                                onClick={() => setAiEditModel(modelSlug)}
+                                                key={choice.slug}
+                                                className={aiEditModel === choice.slug ? 'active' : ''}
+                                                onClick={() => setAiEditModel(choice.slug)}
                                                 disabled={!hasKey}
-                                                title={hasKey ? config.label : `Add a ${config.provider === 'google' ? 'Google' : 'OpenAI'} API key in Settings`}
+                                                title={hasKey ? choice.label : `Add a ${choice.provider === 'google' ? 'Google' : 'OpenAI'} API key in Settings`}
                                             >
-                                                {config.label}
+                                                {choice.label}
                                             </button>
                                         );
                                     })}
@@ -371,6 +372,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
                             </div>
 
                             {aiError && <div className="error-message mini">{aiError}</div>}
+                            {aiReferenceWarning && <div className="info-message mini">{aiReferenceWarning}</div>}
                             {!activeApiKey && <div className="error-message mini">Set {activeModel.label} API key in Settings</div>}
                         </div>
                     </div>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
-import { useGenerateDraft } from '../generate-session/GenerateSession';
+import { getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
 import { useGenerateController } from '../generate-session/useGenerateController';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
@@ -11,16 +11,19 @@ import { createGoalPromptTranslator } from '../autopilot/GoalPromptTranslator';
 import { createPromptRefiner } from '../autopilot/PromptRefiner';
 import { createSatisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import { resolveReasoningClient } from '../autopilot/ReasoningClient';
-import { NANO_REFERENCE_LIMIT } from '../image-workflow/ImageWorkflow';
 import {
-    IMAGE_MODEL_REGISTRY,
-    NANO_BANANA_PRO_IMAGE_MODEL,
-    OPENAI_IMAGE_MODEL,
+    coerceImageModelControlValue,
+    getImageModelGenerateControls,
+    getImageModelReferenceLimitMessage,
+    getImageModelUiChoices,
+    limitReferenceImagesForImageModel,
+    type ImageModelControlId,
+} from '../image-models/ImageModelControls';
+import {
     OPENAI_RESPONSES_MODEL,
     REASONING_MODEL_REGISTRY,
     resolveImageModelConfig,
     resolveReasoningModelConfig,
-    type ImageModelSlug,
     type Provider,
     type ReasoningModelSlug,
 } from '../utils/openaiModels';
@@ -176,13 +179,9 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
     const goalPromptTranslator = useMemo(() => createGoalPromptTranslator(reasoningClient), [reasoningClient]);
     const satisfactionEvaluator = useMemo(() => createSatisfactionEvaluator(reasoningClient), [reasoningClient]);
     const promptRefiner = useMemo(() => createPromptRefiner(reasoningClient), [reasoningClient]);
-    const gptControls = draft.gptImage2;
-    const nanoControls = draft.nanoBananaPro;
     const referenceCollection = useReferenceImageCollection();
     const referenceImages = referenceCollection.files;
-    const activeReferenceImages = model === NANO_BANANA_PRO_IMAGE_MODEL
-        ? referenceImages.slice(0, NANO_REFERENCE_LIMIT)
-        : referenceImages;
+    const activeReferenceImages = limitReferenceImagesForImageModel(model, referenceImages);
     const referencePreviews = referenceCollection.previews;
     const addReferenceFiles = referenceCollection.addFiles;
     const removeReferenceAt = referenceCollection.removeAt;
@@ -292,9 +291,17 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
 
     const maxApiCalls = maxIterations * 3;
     const isAutopilotMode = mode === 'autopilot';
-    const nanoReferenceWarning = model === NANO_BANANA_PRO_IMAGE_MODEL && referenceImages.length > NANO_REFERENCE_LIMIT
-        ? `Nano Banana Pro uses the first ${NANO_REFERENCE_LIMIT} reference images for generation.`
-        : null;
+    const imageModelReferenceWarning = getImageModelReferenceLimitMessage(model, referenceImages.length, 'generation');
+    const activeModelDraftKey = getImageModelDraftKey(model);
+    const activeModelControls = draft[activeModelDraftKey] as Record<string, string>;
+    const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
+        updateDraft({
+            [activeModelDraftKey]: {
+                ...activeModelControls,
+                [controlId]: coerceImageModelControlValue(model, controlId, value),
+            },
+        } as Partial<GenerateDraft>);
+    };
 
 
 
@@ -310,18 +317,17 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
                     <div className="input-section">
                         <label>IMAGE MODEL</label>
                         <div className="toggle-group">
-                            {(Object.keys(IMAGE_MODEL_REGISTRY) as ImageModelSlug[]).map((modelSlug) => {
-                                const config = resolveImageModelConfig(modelSlug);
-                                const hasKey = !!getProviderKey(config.provider);
+                            {getImageModelUiChoices().map((choice) => {
+                                const hasKey = !!getProviderKey(choice.provider);
                                 return (
                                     <button
-                                        key={modelSlug}
-                                        className={model === modelSlug ? 'active' : ''}
-                                        onClick={() => updateDraft({ model: modelSlug })}
+                                        key={choice.slug}
+                                        className={model === choice.slug ? 'active' : ''}
+                                        onClick={() => updateDraft({ model: choice.slug })}
                                         disabled={!hasKey}
-                                        title={hasKey ? config.label : `Add a ${config.provider === 'google' ? 'Google' : 'OpenAI'} API key in Settings`}
+                                        title={hasKey ? choice.label : `Add a ${choice.provider === 'google' ? 'Google' : 'OpenAI'} API key in Settings`}
                                     >
-                                        {config.label}
+                                        {choice.label}
                                     </button>
                                 );
                             })}
@@ -456,94 +462,28 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
                     </div>
 
                     <div className="options-grid">
-                        {model === OPENAI_IMAGE_MODEL ? (
-                            <>
-                                <div className="option-group">
-                                    <label>QUALITY</label>
-                                    <div className="toggle-group">
-                                        <button
-                                            className={gptControls.quality === 'low' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, quality: 'low' } })}
-                                        >Low</button>
-                                        <button
-                                            className={gptControls.quality === 'medium' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, quality: 'medium' } })}
-                                        >Medium</button>
-                                        <button
-                                            className={gptControls.quality === 'high' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, quality: 'high' } })}
-                                        >High</button>
-                                    </div>
-                                </div>
-
-                                <div className="option-group">
-                                    <label>SIZE</label>
+                        {getImageModelGenerateControls(model).map((control) => (
+                            <div className="option-group" key={control.id}>
+                                <label>{control.label}</label>
+                                {control.kind === 'select' ? (
                                     <CustomSelect
-                                        value={gptControls.size}
-                                        onChange={(v) => updateDraft({ gptImage2: { ...gptControls, size: v } })}
-                                        options={[
-                                            { value: 'auto', label: 'Auto' },
-                                            { value: '1024x1024', label: 'Square (1:1)' },
-                                            { value: '1536x1024', label: 'Wide (3:2)' },
-                                            { value: '1024x1536', label: 'Tall (2:3)' },
-                                        ]}
+                                        value={activeModelControls[control.id] ?? ''}
+                                        onChange={(value) => updateImageModelControl(control.id, value)}
+                                        options={control.options}
                                     />
-                                </div>
-
-                                <div className="option-group">
-                                    <label>BACKGROUND</label>
+                                ) : (
                                     <div className="toggle-group">
-                                        <button
-                                            className={gptControls.background === 'auto' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, background: 'auto' } })}
-                                        >Auto</button>
-                                        <button
-                                            className={gptControls.background === 'opaque' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, background: 'opaque' } })}
-                                        >Opaque</button>
-                                        <button
-                                            className={gptControls.background === 'transparent' ? 'active' : ''}
-                                            onClick={() => updateDraft({ gptImage2: { ...gptControls, background: 'transparent' } })}
-                                        >Transparent</button>
-                                    </div>
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <div className="option-group">
-                                    <label>ASPECT RATIO</label>
-                                    <CustomSelect
-                                        value={nanoControls.aspectRatio}
-                                        onChange={(v) => updateDraft({ nanoBananaPro: { ...nanoControls, aspectRatio: v as typeof nanoControls.aspectRatio } })}
-                                        options={[
-                                            { value: '1:1', label: 'Square (1:1)' },
-                                            { value: '2:3', label: 'Portrait (2:3)' },
-                                            { value: '3:2', label: 'Landscape (3:2)' },
-                                            { value: '3:4', label: 'Portrait (3:4)' },
-                                            { value: '4:3', label: 'Landscape (4:3)' },
-                                            { value: '4:5', label: 'Portrait (4:5)' },
-                                            { value: '5:4', label: 'Landscape (5:4)' },
-                                            { value: '9:16', label: 'Story (9:16)' },
-                                            { value: '16:9', label: 'Widescreen (16:9)' },
-                                            { value: '21:9', label: 'Cinema (21:9)' },
-                                        ]}
-                                    />
-                                </div>
-
-                                <div className="option-group">
-                                    <label>RESOLUTION</label>
-                                    <div className="toggle-group">
-                                        {(['1K', '2K', '4K'] as const).map((imageSize) => (
+                                        {control.options.map((option) => (
                                             <button
-                                                key={imageSize}
-                                                className={nanoControls.imageSize === imageSize ? 'active' : ''}
-                                                onClick={() => updateDraft({ nanoBananaPro: { ...nanoControls, imageSize } })}
-                                            >{imageSize}</button>
+                                                key={option.value}
+                                                className={activeModelControls[control.id] === option.value ? 'active' : ''}
+                                                onClick={() => updateImageModelControl(control.id, option.value)}
+                                            >{option.label}</button>
                                         ))}
                                     </div>
-                                </div>
-                            </>
-                        )}
+                                )}
+                            </div>
+                        ))}
 
                         <div className="option-group">
                             <label>STYLE</label>
@@ -674,7 +614,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
                     {isAutopilotMode && !reasoningApiKey && (
                         <div className="error-message">{activeReasoningModel.label} API key missing. Go to Settings to configure.</div>
                     )}
-                    {nanoReferenceWarning && <div className="info-message">{nanoReferenceWarning}</div>}
+                    {imageModelReferenceWarning && <div className="info-message">{imageModelReferenceWarning}</div>}
                     {error && <div className="error-message">{error}</div>}
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>


### PR DESCRIPTION
## Summary

Implements issues #44 through #52:

- Introduces a shared archive manifest language for ZIP export/import and metadata recovery.
- Concentrates archive layer asset projection, hydration, stale cleanup, and rollback behavior in the archive asset module.
- Adds compatibility coverage for layered archives, missing layer assets, old/non-layered manifests, and malformed layer stacks.
- Centralizes Image model defaults, validation, archive dimensions, provider request mapping, UI facts, and reference limits.
- Drives Generate and Editor Image model controls from shared Image model facts.
- Adds regression coverage for adding another Image model.

## Validation

- `pnpm run typecheck`
- `pnpm run test`