### PR TITLE
Implement the AI transform, generation, and lineage issue chain

### DIFF
--- a/src/archive/ArchiveManifest.test.ts
+++ b/src/archive/ArchiveManifest.test.ts
@@ -7,6 +7,7 @@ import {
     parseLineageManifest,
 } from './ArchiveManifest';
 import type { ArchiveLayerStack } from '../db/types';
+import { OPENAI_IMAGE_MODEL, OPENAI_RESPONSES_MODEL } from '../utils/openaiModels';
 
 describe('ArchiveManifest', () => {
     it('accepts the existing archive manifest version and preserves stable layer ids', () => {
@@ -86,6 +87,93 @@ describe('ArchiveManifest', () => {
                 },
             ],
         })).toThrow('Invalid lineage step type');
+    });
+
+    it('preserves legacy Generate, Editor, and Autopilot lineage metadata', () => {
+        const legacySteps = [
+            createLineageStep({
+                id: 'generate-legacy',
+                stepType: 'reference-generation',
+                metadata: {
+                    prompt: 'legacy prompt',
+                    referenceCount: 2,
+                    referenceIds: ['image-1:reference:0', 'image-1:reference:1'],
+                },
+            }),
+            createLineageStep({
+                id: 'editor-legacy',
+                stepType: 'ai-edit',
+                metadata: {
+                    editPrompt: 'replace the sky',
+                    targetMode: 'selected-layers',
+                    targetLayerCount: 1,
+                    aiResultLayerName: 'AI result',
+                },
+            }),
+            createLineageStep({
+                id: 'autopilot-legacy',
+                stepType: 'autopilot-iteration',
+                metadata: {
+                    goalText: 'make the result moodier',
+                    reasoningModel: OPENAI_RESPONSES_MODEL,
+                    iterationNumber: 2,
+                    evaluatorScore: 86,
+                    evaluatorFeedback: ['needs stronger contrast'],
+                    outputImageDataUrl: 'data:image/png;base64,auto',
+                },
+            }),
+        ];
+
+        expect(parseLineageManifest({
+            version: LINEAGE_MANIFEST_VERSION,
+            steps: legacySteps,
+        }).steps.map((step) => step.metadata)).toEqual(legacySteps.map((step) => step.metadata));
+    });
+
+    it('validates typed lineage metadata while preserving the manifest shape', () => {
+        const typedSteps = [
+            createLineageStep({
+                id: 'generate-typed',
+                stepType: 'reference-generation',
+                metadata: createTypedGenerateMetadata(),
+            }),
+            createLineageStep({
+                id: 'editor-typed',
+                stepType: 'ai-edit',
+                metadata: createTypedEditorMetadata(),
+            }),
+            createLineageStep({
+                id: 'autopilot-typed',
+                stepType: 'autopilot-iteration',
+                metadata: createTypedAutopilotMetadata(),
+            }),
+        ];
+
+        expect(parseLineageManifest({
+            version: LINEAGE_MANIFEST_VERSION,
+            steps: typedSteps,
+        })).toEqual({
+            version: LINEAGE_MANIFEST_VERSION,
+            steps: typedSteps,
+        });
+    });
+
+    it('rejects malformed typed lineage metadata through the shared parser', () => {
+        expect(() => parseLineageManifest({
+            version: LINEAGE_MANIFEST_VERSION,
+            steps: [
+                createLineageStep({
+                    id: 'broken-typed-step',
+                    stepType: 'generation',
+                    metadata: {
+                        imageModel: {
+                            slug: 'not-a-model',
+                            controls: {},
+                        },
+                    },
+                }),
+            ],
+        })).toThrow('Invalid lineage imageModel slug');
     });
 
     it('validates exported layer stacks before they are written to a ZIP manifest', () => {
@@ -171,5 +259,170 @@ function createManifestLayerStack() {
                 locked: false,
             },
         ],
+    };
+}
+
+function createLineageStep(overrides: {
+    id: string;
+    stepType: string;
+    metadata: Record<string, unknown>;
+}) {
+    return {
+        archiveImageId: 'image-1',
+        parentStepId: null,
+        timestamp: '2026-06-05T10:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function createTypedGenerateMetadata() {
+    return {
+        prompt: 'typed prompt',
+        model: OPENAI_IMAGE_MODEL,
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'transparent',
+            },
+        },
+        dimensions: {
+            width: 1024,
+            height: 1024,
+        },
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        width: 1024,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        sourceArchiveImageId: null,
+        referenceImages: {
+            count: 1,
+            ids: ['image-1:reference:0'],
+        },
+        referenceCount: 1,
+        referenceIds: ['image-1:reference:0'],
+    };
+}
+
+function createTypedEditorMetadata() {
+    return {
+        sourceImage: {
+            archiveImageId: 'image-1',
+        },
+        outputImage: {
+            archiveImageId: 'image-2',
+        },
+        save: {
+            overwrite: false,
+            copy: true,
+        },
+        editorAdjustment: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        aiEdit: {
+            prompt: 'replace the sky',
+            imageModel: {
+                slug: OPENAI_IMAGE_MODEL,
+            },
+            referenceImages: {
+                count: 1,
+            },
+            transformTarget: {
+                mode: 'selected-layers',
+                layerCount: 1,
+                includesBaseLayer: false,
+            },
+        },
+        layers: {
+            layered: true,
+            count: 3,
+            visibleCount: 2,
+            aiResultLayer: {
+                id: 'ai-layer',
+                name: 'AI result',
+            },
+        },
+        sourceArchiveImageId: 'image-1',
+        outputArchiveImageId: 'image-2',
+        overwrite: false,
+        editPrompt: 'replace the sky',
+        model: OPENAI_IMAGE_MODEL,
+        referenceCount: 1,
+        editorAdjustments: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        isLayered: true,
+        layerCount: 3,
+        visibleLayerCount: 2,
+        targetMode: 'selected-layers',
+        targetLayerCount: 1,
+        targetIncludesBaseLayer: false,
+        aiResultLayerId: 'ai-layer',
+        aiResultLayerName: 'AI result',
+    };
+}
+
+function createTypedAutopilotMetadata() {
+    return {
+        goal: {
+            text: 'make the result moodier',
+        },
+        iteration: {
+            number: 2,
+        },
+        evaluation: {
+            score: 86,
+            feedback: ['needs stronger contrast'],
+        },
+        replayImage: {
+            dataUrl: 'data:image/png;base64,auto',
+        },
+        run: {
+            label: 'Autopilot Run · make the result moodier',
+        },
+        reasoningModel: {
+            slug: OPENAI_RESPONSES_MODEL,
+        },
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'transparent',
+            },
+        },
+        dimensions: {
+            width: 1024,
+            height: 1024,
+        },
+        prompt: 'typed prompt',
+        model: OPENAI_IMAGE_MODEL,
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        width: 1024,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        goalText: 'make the result moodier',
+        iterationNumber: 2,
+        evaluatorScore: 86,
+        evaluatorFeedback: ['needs stronger contrast'],
+        outputImageDataUrl: 'data:image/png;base64,auto',
+        runLabel: 'Autopilot Run · make the result moodier',
     };
 }

--- a/src/archive/ArchiveManifest.ts
+++ b/src/archive/ArchiveManifest.ts
@@ -1,4 +1,5 @@
 import type { ArchiveLayer, ArchiveLayerKind, ArchiveLayerStack } from '../db/types';
+import { parseLineageMetadata } from '../lineage/lineageMetadata';
 import type { LineageStep } from '../lineage/types';
 
 export const ARCHIVE_MANIFEST_FILE = 'archive-manifest.json';
@@ -181,13 +182,15 @@ function parseLineageStep(value: unknown): LineageStep {
         throw new Error('Invalid lineage metadata');
     }
 
+    const stepType = requireLineageStepType(value.stepType);
+
     return {
         id: requireString(value.id, 'lineage step id'),
         archiveImageId: requireString(value.archiveImageId, 'lineage archiveImageId'),
         parentStepId: value.parentStepId === null ? null : optionalString(value.parentStepId) ?? null,
-        stepType: requireLineageStepType(value.stepType),
+        stepType,
         timestamp: requireString(value.timestamp, 'lineage timestamp'),
-        metadata,
+        metadata: parseLineageMetadata(stepType, metadata),
     };
 }
 

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -2,7 +2,7 @@ import JSZip from 'jszip';
 import { describe, expect, it } from 'vitest';
 import type { ArchiveStore } from './ArchiveStore';
 import type { ArchiveImage } from '../db/types';
-import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE } from './ArchiveTransfer';
+import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE, LINEAGE_MANIFEST_VERSION } from './ArchiveTransfer';
 import { createLineageStore, type LineageMetadataPort, type LineageStep, type LineageStore } from '../lineage/LineageStore';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
@@ -68,6 +68,48 @@ describe('ArchiveTransfer', () => {
                 expect.objectContaining({ id: 'step-4', stepType: 'save-as-copy' }),
             ],
         });
+    });
+
+    it('round-trips typed Generate lineage metadata without changing the lineage manifest version', async () => {
+        const sourceLineage = createStore();
+        const metadata = createTypedGenerateMetadata();
+        await sourceLineage.save({
+            id: 'typed-generate-step',
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'reference-generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata,
+        });
+
+        const zipBytes = await buildArchiveZip([createImages()[0]!], { lineageStore: sourceLineage });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const manifest = JSON.parse(await zip.file(LINEAGE_MANIFEST_FILE)!.async('text')) as {
+            version: number;
+            steps: LineageStep[];
+        };
+
+        expect(manifest.version).toBe(LINEAGE_MANIFEST_VERSION);
+        expect(manifest.steps).toEqual([
+            expect.objectContaining({
+                id: 'typed-generate-step',
+                metadata,
+            }),
+        ]);
+
+        const importedLineage = createStore();
+        const summary = await importArchiveZip(zipBytes, {
+            archiveStore: new InMemoryArchiveStore(),
+            lineageStore: importedLineage,
+        });
+
+        expect(summary.importedStepIds).toEqual(['typed-generate-step']);
+        await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
+            expect.objectContaining({
+                id: 'typed-generate-step',
+                metadata,
+            }),
+        ]);
     });
 
     it('round-trips archive images and lineage relationships through ZIP import', async () => {
@@ -320,6 +362,41 @@ function createImages(): ArchiveImage[] {
             references: [],
         },
     ];
+}
+
+function createTypedGenerateMetadata() {
+    return {
+        prompt: 'glass city at dawn',
+        model: OPENAI_IMAGE_MODEL,
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'transparent',
+            },
+        },
+        dimensions: {
+            width: 1024,
+            height: 1024,
+        },
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        width: 1024,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        sourceArchiveImageId: 'source-image',
+        referenceImages: {
+            count: 1,
+            ids: ['image-1:reference:0'],
+        },
+        referenceCount: 1,
+        referenceIds: ['image-1:reference:0'],
+    };
 }
 
 async function seedLineage(lineage: LineageStore) {

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -4,7 +4,7 @@ import type { ArchiveStore } from './ArchiveStore';
 import type { ArchiveImage } from '../db/types';
 import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE, LINEAGE_MANIFEST_VERSION } from './ArchiveTransfer';
 import { createLineageStore, type LineageMetadataPort, type LineageStep, type LineageStore } from '../lineage/LineageStore';
-import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import { OPENAI_IMAGE_MODEL, OPENAI_RESPONSES_MODEL } from '../utils/openaiModels';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -70,16 +70,34 @@ describe('ArchiveTransfer', () => {
         });
     });
 
-    it('round-trips typed Generate lineage metadata without changing the lineage manifest version', async () => {
+    it('round-trips typed Generate, Editor, and Autopilot lineage metadata without changing the lineage manifest version', async () => {
         const sourceLineage = createStore();
-        const metadata = createTypedGenerateMetadata();
+        const generateMetadata = createTypedGenerateMetadata();
+        const editorMetadata = createTypedEditorMetadata();
+        const autopilotMetadata = createTypedAutopilotMetadata();
         await sourceLineage.save({
             id: 'typed-generate-step',
             archiveImageId: 'image-1',
             parentStepId: null,
             stepType: 'reference-generation',
             timestamp: '2026-04-04T09:00:00.000Z',
-            metadata,
+            metadata: generateMetadata,
+        });
+        await sourceLineage.save({
+            id: 'typed-editor-step',
+            archiveImageId: 'image-1',
+            parentStepId: 'typed-generate-step',
+            stepType: 'ai-edit',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: editorMetadata,
+        });
+        await sourceLineage.save({
+            id: 'typed-autopilot-step',
+            archiveImageId: 'image-1',
+            parentStepId: 'typed-editor-step',
+            stepType: 'autopilot-iteration',
+            timestamp: '2026-04-04T11:00:00.000Z',
+            metadata: autopilotMetadata,
         });
 
         const zipBytes = await buildArchiveZip([createImages()[0]!], { lineageStore: sourceLineage });
@@ -93,7 +111,15 @@ describe('ArchiveTransfer', () => {
         expect(manifest.steps).toEqual([
             expect.objectContaining({
                 id: 'typed-generate-step',
-                metadata,
+                metadata: generateMetadata,
+            }),
+            expect.objectContaining({
+                id: 'typed-editor-step',
+                metadata: editorMetadata,
+            }),
+            expect.objectContaining({
+                id: 'typed-autopilot-step',
+                metadata: autopilotMetadata,
             }),
         ]);
 
@@ -103,11 +129,19 @@ describe('ArchiveTransfer', () => {
             lineageStore: importedLineage,
         });
 
-        expect(summary.importedStepIds).toEqual(['typed-generate-step']);
+        expect(summary.importedStepIds).toEqual(['typed-generate-step', 'typed-editor-step', 'typed-autopilot-step']);
         await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
             expect.objectContaining({
                 id: 'typed-generate-step',
-                metadata,
+                metadata: generateMetadata,
+            }),
+            expect.objectContaining({
+                id: 'typed-editor-step',
+                metadata: editorMetadata,
+            }),
+            expect.objectContaining({
+                id: 'typed-autopilot-step',
+                metadata: autopilotMetadata,
             }),
         ]);
     });
@@ -396,6 +430,123 @@ function createTypedGenerateMetadata() {
         },
         referenceCount: 1,
         referenceIds: ['image-1:reference:0'],
+    };
+}
+
+function createTypedEditorMetadata() {
+    return {
+        sourceImage: {
+            archiveImageId: 'image-1',
+        },
+        outputImage: {
+            archiveImageId: 'image-1',
+        },
+        save: {
+            overwrite: true,
+            copy: false,
+        },
+        editorAdjustment: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        aiEdit: {
+            prompt: 'add neon reflections',
+            imageModel: {
+                slug: OPENAI_IMAGE_MODEL,
+            },
+            referenceImages: {
+                count: 1,
+            },
+            transformTarget: {
+                mode: 'selected-layers',
+                layerCount: 1,
+                includesBaseLayer: false,
+            },
+        },
+        layers: {
+            layered: true,
+            count: 3,
+            visibleCount: 2,
+            aiResultLayer: {
+                id: 'ai-layer',
+                name: 'AI result',
+            },
+        },
+        sourceArchiveImageId: 'image-1',
+        outputArchiveImageId: 'image-1',
+        overwrite: true,
+        editPrompt: 'add neon reflections',
+        model: OPENAI_IMAGE_MODEL,
+        referenceCount: 1,
+        editorAdjustments: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        isLayered: true,
+        layerCount: 3,
+        visibleLayerCount: 2,
+        targetMode: 'selected-layers',
+        targetLayerCount: 1,
+        targetIncludesBaseLayer: false,
+        aiResultLayerId: 'ai-layer',
+        aiResultLayerName: 'AI result',
+    };
+}
+
+function createTypedAutopilotMetadata() {
+    return {
+        goal: {
+            text: 'make the result moodier',
+        },
+        iteration: {
+            number: 1,
+        },
+        evaluation: {
+            score: 86,
+            feedback: ['needs stronger contrast'],
+        },
+        replayImage: {
+            dataUrl: 'data:image/png;base64,auto',
+        },
+        run: {
+            label: 'Autopilot Run · make the result moodier',
+        },
+        reasoningModel: {
+            slug: OPENAI_RESPONSES_MODEL,
+        },
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'transparent',
+            },
+        },
+        dimensions: {
+            width: 1024,
+            height: 1024,
+        },
+        prompt: 'glass city at dawn',
+        model: OPENAI_IMAGE_MODEL,
+        quality: 'high',
+        aspectRatio: '1024x1024',
+        background: 'transparent',
+        width: 1024,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        goalText: 'make the result moodier',
+        iterationNumber: 1,
+        evaluatorScore: 86,
+        evaluatorFeedback: ['needs stronger contrast'],
+        outputImageDataUrl: 'data:image/png;base64,auto',
+        runLabel: 'Autopilot Run · make the result moodier',
     };
 }
 

--- a/src/archive/recoverArchiveMetadata.test.ts
+++ b/src/archive/recoverArchiveMetadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { LineageStep } from '../lineage/types';
+import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { recoverArchiveMetadataFromManifests } from './recoverArchiveMetadata';
 
 describe('recoverArchiveMetadataFromManifests', () => {
@@ -10,6 +11,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
             ['ref_image-1_0', 'data:image/png;base64,reference'],
         ]);
         const lineage = new InMemoryLineage();
+        const generateMetadata = createTypedGenerateMetadata();
 
         const summary = await recoverArchiveMetadataFromManifests({
             version: 1,
@@ -84,7 +86,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     parentStepId: null,
                     stepType: 'generation',
                     timestamp: '2026-05-30T16:10:56.590Z',
-                    metadata: { prompt: 'original prompt' },
+                    metadata: generateMetadata,
                 },
             ],
         }, { metadata, blobs, lineage });
@@ -112,6 +114,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
         expect(lineage.steps.get('step-1')).toEqual(expect.objectContaining({
             archiveImageId: 'image-1',
             stepType: 'generation',
+            metadata: generateMetadata,
         }));
     });
 
@@ -216,4 +219,39 @@ class InMemoryLineage {
         this.steps.set(step.id, step);
         return step;
     }
+}
+
+function createTypedGenerateMetadata() {
+    return {
+        prompt: 'original prompt',
+        model: OPENAI_IMAGE_MODEL,
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'medium',
+                size: '1536x1024',
+                background: 'auto',
+            },
+        },
+        dimensions: {
+            width: 1536,
+            height: 1024,
+        },
+        quality: 'medium',
+        aspectRatio: '1536x1024',
+        background: 'auto',
+        width: 1536,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        sourceArchiveImageId: null,
+        referenceImages: {
+            count: 1,
+            ids: ['image-1:reference:0'],
+        },
+        referenceCount: 1,
+        referenceIds: ['image-1:reference:0'],
+    };
 }

--- a/src/archive/recoverArchiveMetadata.test.ts
+++ b/src/archive/recoverArchiveMetadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { LineageStep } from '../lineage/types';
-import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import { OPENAI_IMAGE_MODEL, OPENAI_RESPONSES_MODEL } from '../utils/openaiModels';
 import { recoverArchiveMetadataFromManifests } from './recoverArchiveMetadata';
 
 describe('recoverArchiveMetadataFromManifests', () => {
@@ -12,6 +12,8 @@ describe('recoverArchiveMetadataFromManifests', () => {
         ]);
         const lineage = new InMemoryLineage();
         const generateMetadata = createTypedGenerateMetadata();
+        const editorMetadata = createTypedEditorMetadata();
+        const autopilotMetadata = createTypedAutopilotMetadata();
 
         const summary = await recoverArchiveMetadataFromManifests({
             version: 1,
@@ -88,13 +90,29 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     timestamp: '2026-05-30T16:10:56.590Z',
                     metadata: generateMetadata,
                 },
+                {
+                    id: 'step-2',
+                    archiveImageId: 'image-1',
+                    parentStepId: 'step-1',
+                    stepType: 'ai-edit',
+                    timestamp: '2026-05-30T16:11:56.590Z',
+                    metadata: editorMetadata,
+                },
+                {
+                    id: 'step-3',
+                    archiveImageId: 'image-1',
+                    parentStepId: 'step-2',
+                    stepType: 'autopilot-iteration',
+                    timestamp: '2026-05-30T16:12:56.590Z',
+                    metadata: autopilotMetadata,
+                },
             ],
         }, { metadata, blobs, lineage });
 
         expect(summary).toEqual({
             restoredImages: 1,
             skippedMissingImageBlobs: ['missing-image'],
-            restoredLineageSteps: 1,
+            restoredLineageSteps: 3,
         });
         expect(metadata.records.get('image-1')).toEqual(expect.objectContaining({
             id: 'image-1',
@@ -115,6 +133,16 @@ describe('recoverArchiveMetadataFromManifests', () => {
             archiveImageId: 'image-1',
             stepType: 'generation',
             metadata: generateMetadata,
+        }));
+        expect(lineage.steps.get('step-2')).toEqual(expect.objectContaining({
+            archiveImageId: 'image-1',
+            stepType: 'ai-edit',
+            metadata: editorMetadata,
+        }));
+        expect(lineage.steps.get('step-3')).toEqual(expect.objectContaining({
+            archiveImageId: 'image-1',
+            stepType: 'autopilot-iteration',
+            metadata: autopilotMetadata,
         }));
     });
 
@@ -253,5 +281,122 @@ function createTypedGenerateMetadata() {
         },
         referenceCount: 1,
         referenceIds: ['image-1:reference:0'],
+    };
+}
+
+function createTypedEditorMetadata() {
+    return {
+        sourceImage: {
+            archiveImageId: 'image-1',
+        },
+        outputImage: {
+            archiveImageId: 'image-1',
+        },
+        save: {
+            overwrite: true,
+            copy: false,
+        },
+        editorAdjustment: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        aiEdit: {
+            prompt: 'replace the sky',
+            imageModel: {
+                slug: OPENAI_IMAGE_MODEL,
+            },
+            referenceImages: {
+                count: 1,
+            },
+            transformTarget: {
+                mode: 'selected-layers',
+                layerCount: 1,
+                includesBaseLayer: false,
+            },
+        },
+        layers: {
+            layered: true,
+            count: 3,
+            visibleCount: 2,
+            aiResultLayer: {
+                id: 'ai-layer',
+                name: 'AI result',
+            },
+        },
+        sourceArchiveImageId: 'image-1',
+        outputArchiveImageId: 'image-1',
+        overwrite: true,
+        editPrompt: 'replace the sky',
+        model: OPENAI_IMAGE_MODEL,
+        referenceCount: 1,
+        editorAdjustments: {
+            brightness: 110,
+            contrast: 100,
+            saturation: 120,
+            filter: 'none',
+        },
+        isLayered: true,
+        layerCount: 3,
+        visibleLayerCount: 2,
+        targetMode: 'selected-layers',
+        targetLayerCount: 1,
+        targetIncludesBaseLayer: false,
+        aiResultLayerId: 'ai-layer',
+        aiResultLayerName: 'AI result',
+    };
+}
+
+function createTypedAutopilotMetadata() {
+    return {
+        goal: {
+            text: 'make the result moodier',
+        },
+        iteration: {
+            number: 1,
+        },
+        evaluation: {
+            score: 86,
+            feedback: ['needs stronger contrast'],
+        },
+        replayImage: {
+            dataUrl: 'data:image/png;base64,auto',
+        },
+        run: {
+            label: 'Autopilot Run · make the result moodier',
+        },
+        reasoningModel: {
+            slug: OPENAI_RESPONSES_MODEL,
+        },
+        imageModel: {
+            slug: OPENAI_IMAGE_MODEL,
+            controls: {
+                quality: 'medium',
+                size: '1536x1024',
+                background: 'auto',
+            },
+        },
+        dimensions: {
+            width: 1536,
+            height: 1024,
+        },
+        prompt: 'original prompt',
+        model: OPENAI_IMAGE_MODEL,
+        quality: 'medium',
+        aspectRatio: '1536x1024',
+        background: 'auto',
+        width: 1536,
+        height: 1024,
+        imageSize: null,
+        style: 'none',
+        lighting: 'none',
+        palette: 'none',
+        goalText: 'make the result moodier',
+        iterationNumber: 1,
+        evaluatorScore: 86,
+        evaluatorFeedback: ['needs stronger contrast'],
+        outputImageDataUrl: 'data:image/png;base64,auto',
+        runLabel: 'Autopilot Run · make the result moodier',
     };
 }

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -127,6 +127,44 @@ describe('AutopilotSession', () => {
         expect(callbacks.onIterationComplete.mock.calls.map(([, runningBest]) => runningBest.iterationNumber)).toEqual([1, 1]);
     });
 
+    it('freezes the Reference image snapshot for every iteration', async () => {
+        const lineage = createStore();
+        const firstReference = new File(['reference-0'], 'ref-0.png', { type: 'image/png' });
+        const secondReference = new File(['reference-1'], 'ref-1.png', { type: 'image/png' });
+        const settings = createSettings({
+            referenceImages: [firstReference, secondReference],
+        });
+        const seenReferenceNames: string[][] = [];
+        const generate = vi.fn(async (input: GenerateImageInput) => {
+            seenReferenceNames.push(input.referenceImages.map((file) => file.name));
+            input.referenceImages.push(new File(['request-mutation'], `request-mutated-${seenReferenceNames.length}.png`, { type: 'image/png' }));
+            settings.referenceImages.push(new File(['external-mutation'], `external-${seenReferenceNames.length}.png`, { type: 'image/png' }));
+
+            return `data:image/png;base64,iteration-${seenReferenceNames.length}`;
+        });
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings,
+            apiKey: 'key',
+            maxIterations: 2,
+            satisfactionThreshold: 90,
+            generate,
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ score: 50, feedback: ['Keep going.'] })
+                .mockResolvedValueOnce({ score: 95, feedback: ['Strong match.'] }),
+            refine: vi.fn().mockResolvedValueOnce('prompt 2'),
+            lineageStore: lineage,
+        }).run();
+
+        expect(result.status).toBe('satisfied');
+        expect(seenReferenceNames).toEqual([
+            ['ref-0.png', 'ref-1.png'],
+            ['ref-0.png', 'ref-1.png'],
+        ]);
+    });
+
     it('stops early when the satisfaction threshold is met', async () => {
         const lineage = createStore();
         const generate = vi.fn().mockResolvedValueOnce('data:image/png;base64,one');
@@ -219,7 +257,9 @@ function createStore(): LineageStore {
     });
 }
 
-function createSettings(): Omit<GenerateImageInput, 'apiKey' | 'prompt'> {
+function createSettings(
+    overrides: Partial<Omit<GenerateImageInput, 'apiKey' | 'prompt'>> = {},
+): Omit<GenerateImageInput, 'apiKey' | 'prompt'> {
     return {
         model: OPENAI_IMAGE_MODEL,
         quality: 'high' as const,
@@ -229,5 +269,6 @@ function createSettings(): Omit<GenerateImageInput, 'apiKey' | 'prompt'> {
         lighting: 'golden hour',
         palette: 'copper + teal + cream',
         referenceImages: [],
+        ...overrides,
     };
 }

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { createAutopilotSession } from './AutopilotSession';
 import type { LineageMetadataPort, LineageStep } from '../lineage/LineageStore';
 import { createLineageStore, type LineageStore } from '../lineage/LineageStore';
+import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
+import { GEMINI_FLASH_REASONING_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -52,6 +54,7 @@ describe('AutopilotSession', () => {
             initialPrompt: 'prompt 1',
             settings: createSettings(),
             apiKey: 'key',
+            reasoningModel: GEMINI_FLASH_REASONING_MODEL,
             maxIterations: 3,
             satisfactionThreshold: 90,
             generate,
@@ -74,6 +77,28 @@ describe('AutopilotSession', () => {
         await expect(lineage.getChildren('step-2')).resolves.toEqual([
             expect.objectContaining({ id: 'step-3', parentStepId: 'step-2' }),
         ]);
+        await expect(lineage.getById('step-1')).resolves.toEqual(expect.objectContaining({
+            parentStepId: null,
+            metadata: expect.objectContaining({
+                goal: { text: 'A cinematic portrait' },
+                reasoningModel: { slug: GEMINI_FLASH_REASONING_MODEL },
+                imageModel: {
+                    slug: OPENAI_IMAGE_MODEL,
+                    controls: {
+                        quality: 'high',
+                        size: '1024x1024',
+                        background: 'transparent',
+                    },
+                },
+                iteration: { number: 1 },
+                evaluation: {
+                    score: 40,
+                    feedback: ['Needs stronger lighting.'],
+                },
+                replayImage: { dataUrl: 'data:image/png;base64,one' },
+                run: { label: 'Autopilot Run · A cinematic portrait' },
+            }),
+        }));
     });
 
     it('exposes a running best that breaks score ties by earliest iteration', async () => {
@@ -194,8 +219,9 @@ function createStore(): LineageStore {
     });
 }
 
-function createSettings() {
+function createSettings(): Omit<GenerateImageInput, 'apiKey' | 'prompt'> {
     return {
+        model: OPENAI_IMAGE_MODEL,
         quality: 'high' as const,
         aspectRatio: '1024x1024',
         background: 'transparent' as const,

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -75,14 +75,16 @@ class DefaultAutopilotSession implements AutopilotSession {
         const reasoningApiKey = this.input.reasoningApiKey ?? this.input.apiKey;
         const iterations: AutopilotIteration[] = [];
         const runId = this.input.makeRunId?.() ?? crypto.randomUUID();
+        const runSettings = snapshotAutopilotSettings(this.input.settings);
         let currentPrompt = this.input.initialPrompt;
         let parentStepId = this.input.initialParentStepId ?? null;
         let runningBest: AutopilotIteration | null = null;
 
         for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
             try {
+                const iterationSettings = snapshotAutopilotSettings(runSettings);
                 const imageDataUrl = await generate({
-                    ...this.input.settings,
+                    ...iterationSettings,
                     apiKey: this.input.apiKey,
                     prompt: currentPrompt,
                 });
@@ -105,7 +107,7 @@ class DefaultAutopilotSession implements AutopilotSession {
                         iterationNumber,
                         evaluation,
                         prompt: currentPrompt,
-                        settings: this.input.settings,
+                        settings: snapshotAutopilotSettings(runSettings),
                         outputImageDataUrl: imageDataUrl,
                     }),
                 });
@@ -186,4 +188,13 @@ function pickBetterIteration(best: AutopilotIteration | null, candidate: Autopil
 
 export function createAutopilotSession(input: CreateAutopilotSessionInput): AutopilotSession {
     return new DefaultAutopilotSession(input);
+}
+
+function snapshotAutopilotSettings(
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>,
+): Omit<GenerateImageInput, 'apiKey' | 'prompt'> {
+    return {
+        ...settings,
+        referenceImages: settings.referenceImages.slice(),
+    };
 }

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -3,6 +3,7 @@ import { satisfactionEvaluator } from './SatisfactionEvaluator';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { buildAutopilotLineageMetadata } from '../lineage/autopilotLineageMetadata';
 
 export const DEFAULT_AUTOPILOT_MAX_ITERATIONS = 4;
 export const MAX_AUTOPILOT_ITERATIONS = 8;
@@ -98,23 +99,15 @@ class DefaultAutopilotSession implements AutopilotSession {
                     parentStepId,
                     stepType: 'autopilot-iteration',
                     timestamp: new Date().toISOString(),
-                    metadata: {
-                        goalText: this.input.goal,
-                        reasoningModel: this.input.reasoningModel ?? null,
+                    metadata: buildAutopilotLineageMetadata({
+                        goal: this.input.goal,
+                        reasoningModel: this.input.reasoningModel,
                         iterationNumber,
-                        evaluatorScore: evaluation.score,
-                        evaluatorFeedback: evaluation.feedback,
+                        evaluation,
                         prompt: currentPrompt,
-                        model: this.input.settings.model ?? null,
-                        quality: this.input.settings.quality,
-                        aspectRatio: this.input.settings.aspectRatio,
-                        imageSize: this.input.settings.imageSize ?? null,
-                        background: this.input.settings.background,
-                        style: this.input.settings.style,
-                        lighting: this.input.settings.lighting,
-                        palette: this.input.settings.palette,
+                        settings: this.input.settings,
                         outputImageDataUrl: imageDataUrl,
-                    },
+                    }),
                 });
 
                 const completedIteration: AutopilotIteration = {

--- a/src/editor/aiTransform.test.ts
+++ b/src/editor/aiTransform.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ArchiveLayerStack } from '../db/types';
+import type { EditorAdjustments, EditorDraft } from './layers';
+import { pushHistory, redoHistory, undoHistory } from './layers';
+import {
+    applyAiTransformResultToDraft,
+    renderAiTransformEditInput,
+    type AiTransformRenderer,
+} from './aiTransform';
+
+const adjustments: EditorAdjustments = {
+    brightness: 100,
+    contrast: 100,
+    saturation: 100,
+    filter: 'none',
+};
+
+describe('Editor AI transforms', () => {
+    it('renders selected layers as the editable source and the full composition as context', async () => {
+        const layerStack = createLayerStack();
+        const userReferences = [
+            new File(['user-a'], 'user-a.png', { type: 'image/png' }),
+            new File(['user-b'], 'user-b.png', { type: 'image/png' }),
+        ];
+        const render = createRecordingRenderer();
+
+        const result = await renderAiTransformEditInput({
+            draft: createDraft(layerStack, ['layer-1']),
+            adjustments,
+            referenceImages: userReferences,
+            render,
+        });
+
+        expect(result.targetPlan.mode).toBe('selected-layers');
+        expect(result.referenceImages).toBe(userReferences);
+        expect(result.compositionContextImage?.name).toBe('composition-context.png');
+        expect(render).toHaveBeenCalledTimes(2);
+
+        const sourceCall = render.mock.calls[0];
+        const contextCall = render.mock.calls[1];
+        expect(sourceCall?.[0].layers.map((layer) => layer.id)).toEqual(['layer-1']);
+        expect(sourceCall?.[2]).toEqual({ x: 100, y: 120, width: 200, height: 220 });
+        expect(contextCall?.[0].layers.map((layer) => layer.id)).toEqual(['base', 'layer-1', 'layer-2']);
+        expect(contextCall?.[2]).toEqual({ x: 0, y: 0, width: 1000, height: 800 });
+    });
+
+    it('renders whole-composition edits from the full layer stack without composition context', async () => {
+        const layerStack = createLayerStack();
+        const render = createRecordingRenderer();
+
+        const result = await renderAiTransformEditInput({
+            draft: createDraft(layerStack, ['base']),
+            adjustments,
+            referenceImages: [],
+            render,
+        });
+
+        expect(result.targetPlan.mode).toBe('whole-composition');
+        expect(result.compositionContextImage).toBeNull();
+        expect(render).toHaveBeenCalledTimes(1);
+        expect(render.mock.calls[0]?.[0].layers.map((layer) => layer.id)).toEqual(['base', 'layer-1', 'layer-2']);
+        expect(render.mock.calls[0]?.[2]).toEqual({ x: 0, y: 0, width: 1000, height: 800 });
+    });
+
+    it('inserts selected-layer AI results above the topmost target and hides non-base targets', () => {
+        const draft = createDraft(createLayerStack(), ['layer-1', 'layer-2']);
+        const input = applyAiTransformResultToDraft(
+            draft,
+            {
+                mode: 'selected-layers',
+                targetLayerIds: ['layer-1', 'layer-2'],
+                targetBounds: { x: 100, y: 120, width: 450, height: 300 },
+                requiresCompositionContext: true,
+                metadata: {
+                    targetMode: 'selected-layers',
+                    targetLayerCount: 2,
+                    targetIncludesBaseLayer: false,
+                },
+            },
+            'data:image/png;base64,ai',
+            () => 'ai-layer',
+        );
+
+        expect(input.resultLayerName).toBe('AI result');
+        expect(input.draft.selectedLayerIds).toEqual(['ai-layer']);
+        expect(input.draft.primarySelectedLayerId).toBe('ai-layer');
+        expect(input.draft.layerStack.layers.map((layer) => [layer.id, layer.visible])).toEqual([
+            ['base', true],
+            ['layer-1', false],
+            ['layer-2', false],
+            ['ai-layer', true],
+        ]);
+        expect(input.draft.layerStack.layers.at(-1)).toEqual(expect.objectContaining({
+            id: 'ai-layer',
+            x: 100,
+            y: 120,
+            width: 450,
+            height: 300,
+        }));
+    });
+
+    it('inserts whole-composition AI results above visible targets and restores through undo and redo', () => {
+        const beforeDraft = createDraft(createLayerStack(), ['base']);
+        const after = applyAiTransformResultToDraft(
+            beforeDraft,
+            {
+                mode: 'whole-composition',
+                targetLayerIds: ['base', 'layer-1', 'layer-2'],
+                targetBounds: { x: 0, y: 0, width: 1000, height: 800 },
+                requiresCompositionContext: false,
+                metadata: {
+                    targetMode: 'whole-composition',
+                    targetLayerCount: null,
+                    targetIncludesBaseLayer: null,
+                },
+            },
+            'data:image/png;base64,ai',
+            () => 'whole-ai-layer',
+        );
+        const history = pushHistory({ past: [], present: beforeDraft, future: [] }, after.draft);
+        const undone = undoHistory(history);
+        const redone = redoHistory(undone);
+
+        expect(after.draft.layerStack.layers.map((layer) => [layer.id, layer.visible])).toEqual([
+            ['base', true],
+            ['layer-1', false],
+            ['layer-2', false],
+            ['whole-ai-layer', true],
+        ]);
+        expect(after.draft.selectedLayerIds).toEqual(['whole-ai-layer']);
+        expect(undone.present).toEqual(beforeDraft);
+        expect(redone.present).toEqual(after.draft);
+    });
+});
+
+function createRecordingRenderer() {
+    return vi.fn<AiTransformRenderer>(async (layerStack) =>
+        new Blob([layerStack.layers.map((layer) => layer.id).join(',')], { type: 'image/png' }),
+    );
+}
+
+function createDraft(layerStack: ArchiveLayerStack, selectedLayerIds: string[]): EditorDraft {
+    return {
+        layerStack,
+        adjustments,
+        references: [],
+        selectedLayerIds,
+        primarySelectedLayerId: selectedLayerIds[0] ?? null,
+    };
+}
+
+function createLayerStack(): ArchiveLayerStack {
+    return {
+        canvasWidth: 1000,
+        canvasHeight: 800,
+        layers: [
+            {
+                id: 'base',
+                name: 'Base',
+                kind: 'base',
+                assetUrl: 'data:image/png;base64,base',
+                x: 0,
+                y: 0,
+                width: 1000,
+                height: 800,
+                rotation: 0,
+                opacity: 1,
+                visible: true,
+                locked: true,
+            },
+            {
+                id: 'layer-1',
+                name: 'Layer 1',
+                kind: 'uploaded',
+                assetUrl: 'data:image/png;base64,one',
+                x: 100,
+                y: 120,
+                width: 200,
+                height: 220,
+                rotation: 0,
+                opacity: 1,
+                visible: true,
+                locked: false,
+            },
+            {
+                id: 'layer-2',
+                name: 'Layer 2',
+                kind: 'uploaded',
+                assetUrl: 'data:image/png;base64,two',
+                x: 450,
+                y: 260,
+                width: 100,
+                height: 160,
+                rotation: 0,
+                opacity: 0.8,
+                visible: true,
+                locked: false,
+            },
+        ],
+    };
+}

--- a/src/editor/aiTransform.test.ts
+++ b/src/editor/aiTransform.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ArchiveLayerStack } from '../db/types';
 import type { EditorAdjustments, EditorDraft } from './layers';
 import { pushHistory, redoHistory, undoHistory } from './layers';
+import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import {
     applyAiTransformResultToDraft,
+    getAiTransformSaveProvenance,
     renderAiTransformEditInput,
     type AiTransformRenderer,
 } from './aiTransform';
@@ -130,6 +132,48 @@ describe('Editor AI transforms', () => {
         expect(after.draft.selectedLayerIds).toEqual(['whole-ai-layer']);
         expect(undone.present).toEqual(beforeDraft);
         expect(redone.present).toEqual(after.draft);
+    });
+
+    it('resolves save provenance only while the AI result layer exists in the present draft', () => {
+        const beforeDraft = createDraft(createLayerStack(), ['layer-1']);
+        const after = applyAiTransformResultToDraft(
+            beforeDraft,
+            {
+                mode: 'selected-layers',
+                targetLayerIds: ['layer-1'],
+                targetBounds: { x: 100, y: 120, width: 200, height: 220 },
+                requiresCompositionContext: true,
+                metadata: {
+                    targetMode: 'selected-layers',
+                    targetLayerCount: 1,
+                    targetIncludesBaseLayer: false,
+                },
+            },
+            'data:image/png;base64,ai',
+            () => 'ai-layer',
+            {
+                prompt: 'replace the jacket',
+                model: OPENAI_IMAGE_MODEL,
+            },
+        );
+        const history = pushHistory({ past: [], present: beforeDraft, future: [] }, after.draft);
+        const undone = undoHistory(history);
+        const redone = redoHistory(undone);
+
+        expect(getAiTransformSaveProvenance(after.draft, after.provenance)).toEqual({
+            aiEditPrompt: 'replace the jacket',
+            aiEditModel: OPENAI_IMAGE_MODEL,
+            targetMode: 'selected-layers',
+            targetLayerCount: 1,
+            targetIncludesBaseLayer: false,
+            aiResultLayerId: 'ai-layer',
+            aiResultLayerName: 'AI result',
+        });
+        expect(getAiTransformSaveProvenance(undone.present, after.provenance)).toBeNull();
+        expect(getAiTransformSaveProvenance(redone.present, after.provenance)).toEqual(expect.objectContaining({
+            aiEditPrompt: 'replace the jacket',
+            aiResultLayerId: 'ai-layer',
+        }));
     });
 });
 

--- a/src/editor/aiTransform.ts
+++ b/src/editor/aiTransform.ts
@@ -1,0 +1,109 @@
+import type { ArchiveLayerStack } from '../db/types';
+import {
+    insertAiResultLayer,
+    planAiTransformTarget,
+    type AiTransformTargetPlan,
+    type EditorAdjustments,
+    type EditorDraft,
+    type LayerBounds,
+} from './layers';
+import { renderLayerStackToBlob } from './renderLayerStack';
+
+export type AiTransformRenderer = (
+    layerStack: ArchiveLayerStack,
+    adjustments: EditorAdjustments,
+    bounds: LayerBounds,
+) => Promise<Blob>;
+
+export interface RenderAiTransformEditInputOptions {
+    draft: EditorDraft;
+    adjustments: EditorAdjustments;
+    referenceImages: File[];
+    render?: AiTransformRenderer;
+}
+
+export interface RenderedAiTransformEditInput {
+    targetPlan: AiTransformTargetPlan;
+    sourceImage: Blob;
+    compositionContextImage: File | null;
+    referenceImages: File[];
+}
+
+export interface AppliedAiTransformResult {
+    draft: EditorDraft;
+    resultLayerId: string;
+    resultLayerName: string | null;
+}
+
+export async function renderAiTransformEditInput({
+    draft,
+    adjustments,
+    referenceImages,
+    render = renderLayerStackToBlob,
+}: RenderAiTransformEditInputOptions): Promise<RenderedAiTransformEditInput> {
+    const targetPlan = planAiTransformTarget(draft);
+    const sourceLayerStack = buildAiTransformSourceLayerStack(draft.layerStack, targetPlan);
+    const sourceImage = await render(sourceLayerStack, adjustments, targetPlan.targetBounds);
+    const compositionContextImage = targetPlan.requiresCompositionContext
+        ? blobToFile(
+            await render(draft.layerStack, adjustments, getWholeCompositionBounds(draft.layerStack)),
+            'composition-context.png',
+        )
+        : null;
+
+    return {
+        targetPlan,
+        sourceImage,
+        compositionContextImage,
+        referenceImages,
+    };
+}
+
+export function applyAiTransformResultToDraft(
+    draft: EditorDraft,
+    targetPlan: AiTransformTargetPlan,
+    resultUrl: string,
+    makeId: () => string,
+): AppliedAiTransformResult {
+    const result = insertAiResultLayer(draft.layerStack, targetPlan.targetLayerIds, resultUrl, makeId);
+    const resultLayer = result.layerStack.layers.find((layer) => layer.id === result.layerId);
+
+    return {
+        draft: {
+            ...draft,
+            layerStack: result.layerStack,
+            selectedLayerIds: [result.layerId],
+            primarySelectedLayerId: result.layerId,
+        },
+        resultLayerId: result.layerId,
+        resultLayerName: resultLayer?.name ?? null,
+    };
+}
+
+function buildAiTransformSourceLayerStack(
+    layerStack: ArchiveLayerStack,
+    targetPlan: AiTransformTargetPlan,
+): ArchiveLayerStack {
+    if (targetPlan.mode === 'whole-composition') {
+        return layerStack;
+    }
+
+    const targetIds = new Set(targetPlan.targetLayerIds);
+    return {
+        ...layerStack,
+        layers: layerStack.layers.filter((layer) => targetIds.has(layer.id)),
+    };
+}
+
+function getWholeCompositionBounds(layerStack: ArchiveLayerStack): LayerBounds {
+    return {
+        x: 0,
+        y: 0,
+        width: layerStack.canvasWidth,
+        height: layerStack.canvasHeight,
+    };
+}
+
+function blobToFile(blob: Blob, name: string) {
+    return new File([blob], name, { type: blob.type || 'image/png' });
+}

--- a/src/editor/aiTransform.ts
+++ b/src/editor/aiTransform.ts
@@ -1,8 +1,10 @@
 import type { ArchiveLayerStack } from '../db/types';
+import type { ImageModelSlug } from '../utils/openaiModels';
 import {
     insertAiResultLayer,
     planAiTransformTarget,
     type AiTransformTargetPlan,
+    type AiTransformTargetMetadata,
     type EditorAdjustments,
     type EditorDraft,
     type LayerBounds,
@@ -33,6 +35,19 @@ export interface AppliedAiTransformResult {
     draft: EditorDraft;
     resultLayerId: string;
     resultLayerName: string | null;
+    provenance: AiTransformSaveProvenance | null;
+}
+
+export interface AiTransformSaveProvenance extends AiTransformTargetMetadata {
+    aiEditPrompt: string;
+    aiEditModel: ImageModelSlug;
+    aiResultLayerId: string;
+    aiResultLayerName: string | null;
+}
+
+export interface AiTransformProvenanceInput {
+    prompt: string;
+    model: ImageModelSlug;
 }
 
 export async function renderAiTransformEditInput({
@@ -64,9 +79,11 @@ export function applyAiTransformResultToDraft(
     targetPlan: AiTransformTargetPlan,
     resultUrl: string,
     makeId: () => string,
+    provenanceInput?: AiTransformProvenanceInput,
 ): AppliedAiTransformResult {
     const result = insertAiResultLayer(draft.layerStack, targetPlan.targetLayerIds, resultUrl, makeId);
     const resultLayer = result.layerStack.layers.find((layer) => layer.id === result.layerId);
+    const resultLayerName = resultLayer?.name ?? null;
 
     return {
         draft: {
@@ -76,7 +93,37 @@ export function applyAiTransformResultToDraft(
             primarySelectedLayerId: result.layerId,
         },
         resultLayerId: result.layerId,
-        resultLayerName: resultLayer?.name ?? null,
+        resultLayerName,
+        provenance: provenanceInput
+            ? {
+                aiEditPrompt: provenanceInput.prompt,
+                aiEditModel: provenanceInput.model,
+                targetMode: targetPlan.metadata.targetMode,
+                targetLayerCount: targetPlan.metadata.targetLayerCount,
+                targetIncludesBaseLayer: targetPlan.metadata.targetIncludesBaseLayer,
+                aiResultLayerId: result.layerId,
+                aiResultLayerName: resultLayerName,
+            }
+            : null,
+    };
+}
+
+export function getAiTransformSaveProvenance(
+    draft: EditorDraft | null,
+    provenance: AiTransformSaveProvenance | null,
+): AiTransformSaveProvenance | null {
+    if (!draft || !provenance) {
+        return null;
+    }
+
+    const resultLayer = draft.layerStack.layers.find((layer) => layer.id === provenance.aiResultLayerId);
+    if (!resultLayer || resultLayer.kind !== 'ai-result') {
+        return null;
+    }
+
+    return {
+        ...provenance,
+        aiResultLayerName: resultLayer.name,
     };
 }
 

--- a/src/editor/layers.test.ts
+++ b/src/editor/layers.test.ts
@@ -11,6 +11,7 @@ import {
     hydrateLayerStack,
     insertAiResultLayer,
     moveLayer,
+    planAiTransformTarget,
     pushHistory,
     repairEditorDraftForImage,
     redoHistory,
@@ -265,6 +266,120 @@ describe('layer editor helpers', () => {
             height: 614.4000000000001,
         });
     });
+
+    it('plans selected visible non-base layers as a bounded AI transform target', () => {
+        const layerStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        const plan = planAiTransformTarget(createDraft(layerStack, ['layer-1']));
+
+        expect(plan).toEqual({
+            mode: 'selected-layers',
+            targetLayerIds: ['layer-1'],
+            targetBounds: {
+                x: 204.8,
+                y: 204.8,
+                width: 614.4000000000001,
+                height: 614.4000000000001,
+            },
+            requiresCompositionContext: true,
+            metadata: {
+                targetMode: 'selected-layers',
+                targetLayerCount: 1,
+                targetIncludesBaseLayer: false,
+            },
+        });
+    });
+
+    it('plans base-plus-non-base selection as selected layers anchored by the base bounds', () => {
+        const layerStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        const plan = planAiTransformTarget(createDraft(layerStack, ['layer-1', 'base']));
+
+        expect(plan).toEqual({
+            mode: 'selected-layers',
+            targetLayerIds: ['base', 'layer-1'],
+            targetBounds: { x: 0, y: 0, width: 1024, height: 1024 },
+            requiresCompositionContext: true,
+            metadata: {
+                targetMode: 'selected-layers',
+                targetLayerCount: 2,
+                targetIncludesBaseLayer: true,
+            },
+        });
+    });
+
+    it('falls back to a whole-composition AI transform target for base-only selection', () => {
+        const layerStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        const plan = planAiTransformTarget(createDraft(layerStack, ['base']));
+
+        expect(plan).toEqual({
+            mode: 'whole-composition',
+            targetLayerIds: ['base', 'layer-1'],
+            targetBounds: { x: 0, y: 0, width: 1024, height: 1024 },
+            requiresCompositionContext: false,
+            metadata: {
+                targetMode: 'whole-composition',
+                targetLayerCount: null,
+                targetIncludesBaseLayer: null,
+            },
+        });
+    });
+
+    it('falls back to a whole-composition AI transform target for hidden selected layers', () => {
+        const visibleStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+        const layerStack = updateLayer(visibleStack, 'layer-1', { visible: false });
+
+        const plan = planAiTransformTarget(createDraft(layerStack, ['layer-1']));
+
+        expect(plan).toEqual({
+            mode: 'whole-composition',
+            targetLayerIds: ['base'],
+            targetBounds: { x: 0, y: 0, width: 1024, height: 1024 },
+            requiresCompositionContext: false,
+            metadata: {
+                targetMode: 'whole-composition',
+                targetLayerCount: null,
+                targetIncludesBaseLayer: null,
+            },
+        });
+    });
+
+    it('falls back to a whole-composition AI transform target for missing selected layers', () => {
+        const layerStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        const plan = planAiTransformTarget(createDraft(layerStack, ['missing-layer']));
+
+        expect(plan).toEqual({
+            mode: 'whole-composition',
+            targetLayerIds: ['base', 'layer-1'],
+            targetBounds: { x: 0, y: 0, width: 1024, height: 1024 },
+            requiresCompositionContext: false,
+            metadata: {
+                targetMode: 'whole-composition',
+                targetLayerCount: null,
+                targetIncludesBaseLayer: null,
+            },
+        });
+    });
+
+    it('falls back to a whole-composition AI transform target when no layers are selected', () => {
+        const layerStack = addUploadedLayer(createStack(), 'data:image/png;base64,upload', () => 'layer-1').layerStack;
+
+        const plan = planAiTransformTarget(createDraft(layerStack, []));
+
+        expect(plan).toEqual({
+            mode: 'whole-composition',
+            targetLayerIds: ['base', 'layer-1'],
+            targetBounds: { x: 0, y: 0, width: 1024, height: 1024 },
+            requiresCompositionContext: false,
+            metadata: {
+                targetMode: 'whole-composition',
+                targetLayerCount: null,
+                targetIncludesBaseLayer: null,
+            },
+        });
+    });
 });
 
 function createImage(): ArchiveImage {
@@ -288,4 +403,14 @@ function createStack(): ArchiveLayerStack {
         width: 1024,
         height: 1024,
     });
+}
+
+function createDraft(layerStack: ArchiveLayerStack, selectedLayerIds: string[]) {
+    return {
+        layerStack,
+        adjustments: { brightness: 100, contrast: 100, saturation: 100, filter: 'none' },
+        references: ['data:image/png;base64,reference'],
+        selectedLayerIds,
+        primarySelectedLayerId: selectedLayerIds[0] ?? null,
+    };
 }

--- a/src/editor/layers.ts
+++ b/src/editor/layers.ts
@@ -299,6 +299,63 @@ export interface LayerBounds {
     height: number;
 }
 
+export type AiTransformTargetMode = 'whole-composition' | 'selected-layers';
+
+export interface AiTransformTargetMetadata {
+    targetMode: AiTransformTargetMode;
+    targetLayerCount: number | null;
+    targetIncludesBaseLayer: boolean | null;
+}
+
+export interface AiTransformTargetPlan {
+    mode: AiTransformTargetMode;
+    targetLayerIds: string[];
+    targetBounds: LayerBounds;
+    requiresCompositionContext: boolean;
+    metadata: AiTransformTargetMetadata;
+}
+
+export function planAiTransformTarget(draft: EditorDraft): AiTransformTargetPlan {
+    const selectedIds = new Set(draft.selectedLayerIds);
+    const selectedVisibleLayers = draft.layerStack.layers.filter((layer) => selectedIds.has(layer.id) && layer.visible);
+    const hasSelectedNonBaseLayer = selectedVisibleLayers.some((layer) => layer.kind !== 'base');
+
+    if (hasSelectedNonBaseLayer) {
+        const targetLayerIds = selectedVisibleLayers.map((layer) => layer.id);
+        const targetBounds = getCombinedLayerBounds(draft.layerStack, targetLayerIds);
+
+        if (targetBounds) {
+            return {
+                mode: 'selected-layers',
+                targetLayerIds,
+                targetBounds,
+                requiresCompositionContext: true,
+                metadata: {
+                    targetMode: 'selected-layers',
+                    targetLayerCount: targetLayerIds.length,
+                    targetIncludesBaseLayer: selectedVisibleLayers.some((layer) => layer.kind === 'base'),
+                },
+            };
+        }
+    }
+
+    const targetLayerIds = draft.layerStack.layers
+        .filter((layer) => layer.visible)
+        .map((layer) => layer.id);
+
+    return {
+        mode: 'whole-composition',
+        targetLayerIds,
+        targetBounds: getWholeCompositionBounds(draft.layerStack),
+        requiresCompositionContext: false,
+        metadata: {
+            targetMode: 'whole-composition',
+            targetLayerCount: null,
+            targetIncludesBaseLayer: null,
+        },
+    };
+}
+
 export function getCombinedLayerBounds(layerStack: ArchiveLayerStack, layerIds: string[]): LayerBounds | null {
     const ids = new Set(layerIds);
     const targetLayers = layerStack.layers.filter((layer) => ids.has(layer.id) && layer.visible);
@@ -316,6 +373,15 @@ export function getCombinedLayerBounds(layerStack: ArchiveLayerStack, layerIds: 
         y: minY,
         width: maxX - minX,
         height: maxY - minY,
+    };
+}
+
+function getWholeCompositionBounds(layerStack: ArchiveLayerStack): LayerBounds {
+    return {
+        x: 0,
+        y: 0,
+        width: layerStack.canvasWidth,
+        height: layerStack.canvasHeight,
     };
 }
 

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -218,6 +218,41 @@ describe('saveEditedImage', () => {
         expect(steps.at(-1)?.metadata).not.toHaveProperty('layerStack');
     });
 
+    it('counts only saved user Reference images in AI edit lineage metadata', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        const savedImage = await saveEditedImage(createArchiveImage(), 'data:image/png;base64,edited-with-refs', {
+            ...createSaveContext(),
+            isCopy: true,
+            references: [
+                'data:image/png;base64,user-ref-1',
+                'data:image/png;base64,user-ref-2',
+            ],
+            aiEditPrompt: 'blend the selected subject into the scene',
+            targetMode: 'selected-layers',
+            targetLayerCount: 1,
+            targetIncludesBaseLayer: false,
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            makeId: () => 'edit-with-user-refs',
+        });
+
+        const steps = await lineage.getByArchiveImageId(savedImage.id);
+        expect(steps.at(-1)).toEqual(expect.objectContaining({
+            stepType: 'ai-edit',
+            metadata: expect.objectContaining({
+                referenceCount: 2,
+                targetMode: 'selected-layers',
+            }),
+        }));
+        expect(savedImage.references).toEqual([
+            'data:image/png;base64,user-ref-1',
+            'data:image/png;base64,user-ref-2',
+        ]);
+    });
+
 
     it('uses an explicit parent step id when forking from an older lineage step', async () => {
         const lineage = createStore();

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -59,6 +59,30 @@ describe('saveEditedImage', () => {
                 stepType: 'ai-edit',
                 timestamp: '2026-04-04T12:00:00.000Z',
                 metadata: expect.objectContaining({
+                    sourceImage: {
+                        archiveImageId: 'source-image',
+                    },
+                    outputImage: {
+                        archiveImageId: 'branch-image',
+                    },
+                    save: {
+                        overwrite: false,
+                        copy: true,
+                    },
+                    aiEdit: {
+                        prompt: 'add a moonlit skyline',
+                        imageModel: {
+                            slug: OPENAI_IMAGE_MODEL,
+                        },
+                        referenceImages: {
+                            count: 1,
+                        },
+                        transformTarget: {
+                            mode: null,
+                            layerCount: null,
+                            includesBaseLayer: null,
+                        },
+                    },
                     sourceArchiveImageId: 'source-image',
                     outputArchiveImageId: 'branch-image',
                     editPrompt: 'add a moonlit skyline',
@@ -95,6 +119,23 @@ describe('saveEditedImage', () => {
                 parentStepId: 'step-2',
                 stepType: 'save-as-copy',
                 metadata: expect.objectContaining({
+                    sourceImage: {
+                        archiveImageId: 'source-image',
+                    },
+                    outputImage: {
+                        archiveImageId: 'manual-branch',
+                    },
+                    save: {
+                        overwrite: false,
+                        copy: true,
+                    },
+                    editorAdjustment: {
+                        brightness: 110,
+                        contrast: 95,
+                        saturation: 125,
+                        filter: 'sepia(100%)',
+                    },
+                    aiEdit: null,
                     sourceArchiveImageId: 'source-image',
                     outputArchiveImageId: 'manual-branch',
                     overwrite: false,
@@ -126,6 +167,23 @@ describe('saveEditedImage', () => {
                 stepType: 'overwrite',
                 timestamp: '2026-04-04T13:00:00.000Z',
                 metadata: expect.objectContaining({
+                    sourceImage: {
+                        archiveImageId: 'source-image',
+                    },
+                    outputImage: {
+                        archiveImageId: 'source-image',
+                    },
+                    save: {
+                        overwrite: true,
+                        copy: false,
+                    },
+                    editorAdjustment: {
+                        brightness: 110,
+                        contrast: 95,
+                        saturation: 125,
+                        filter: 'sepia(100%)',
+                    },
+                    aiEdit: null,
                     sourceArchiveImageId: 'source-image',
                     outputArchiveImageId: 'source-image',
                     overwrite: true,
@@ -180,6 +238,11 @@ describe('saveEditedImage', () => {
         const steps = await lineage.getByArchiveImageId('nano-edit-copy');
         expect(steps.at(-1)?.metadata).toEqual(expect.objectContaining({
             model: NANO_BANANA_PRO_IMAGE_MODEL,
+            aiEdit: expect.objectContaining({
+                imageModel: {
+                    slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                },
+            }),
         }));
     });
 
@@ -206,6 +269,17 @@ describe('saveEditedImage', () => {
         expect(savedImage.layerStack?.layers.map((layer) => layer.id)).toEqual(['base', 'upload', 'ai-layer']);
         const steps = await lineage.getByArchiveImageId('layered-copy');
         expect(steps.at(-1)?.metadata).toEqual(expect.objectContaining({
+            editPrompt: 'replace the sky',
+            model: OPENAI_IMAGE_MODEL,
+            layers: {
+                layered: true,
+                count: 3,
+                visibleCount: 2,
+                aiResultLayer: {
+                    id: 'ai-layer',
+                    name: 'AI result',
+                },
+            },
             isLayered: true,
             layerCount: 3,
             visibleLayerCount: 2,
@@ -216,6 +290,7 @@ describe('saveEditedImage', () => {
             aiResultLayerName: 'AI result',
         }));
         expect(steps.at(-1)?.metadata).not.toHaveProperty('layerStack');
+        expect(JSON.stringify(steps.at(-1)?.metadata)).not.toContain('data:image/png;base64');
     });
 
     it('counts only saved user Reference images in AI edit lineage metadata', async () => {
@@ -245,6 +320,20 @@ describe('saveEditedImage', () => {
             metadata: expect.objectContaining({
                 referenceCount: 2,
                 targetMode: 'selected-layers',
+                aiEdit: {
+                    prompt: 'blend the selected subject into the scene',
+                    imageModel: {
+                        slug: OPENAI_IMAGE_MODEL,
+                    },
+                    referenceImages: {
+                        count: 2,
+                    },
+                    transformTarget: {
+                        mode: 'selected-layers',
+                        layerCount: 1,
+                        includesBaseLayer: false,
+                    },
+                },
             }),
         }));
         expect(savedImage.references).toEqual([

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -1,4 +1,5 @@
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
+import { buildEditorLineageMetadata } from '../lineage/editorLineageMetadata';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { EditorAdjustments } from './layers';
 
@@ -90,30 +91,18 @@ function resolveStepType(context: EditorSaveContext) {
 }
 
 function buildMetadata(sourceImage: ArchiveImage, savedImage: ArchiveImage, context: EditorSaveContext) {
-    const layerStack = context.layerStack ?? savedImage.layerStack;
-    const layerCount = layerStack?.layers.length ?? null;
-    const visibleLayerCount = layerStack?.layers.filter((layer) => layer.visible).length ?? null;
-
-    return {
-        sourceArchiveImageId: sourceImage.id,
-        outputArchiveImageId: savedImage.id,
-        overwrite: !context.isCopy,
-        editPrompt: context.aiEditPrompt?.trim() || null,
-        model: context.aiEditModel ?? sourceImage.model ?? null,
-        referenceCount: savedImage.references?.length ?? 0,
-        editorAdjustments: {
-            brightness: context.adjustments.brightness,
-            contrast: context.adjustments.contrast,
-            saturation: context.adjustments.saturation,
-            filter: context.adjustments.filter,
-        },
-        isLayered: !!layerStack && layerStack.layers.some((layer) => layer.kind !== 'base'),
-        layerCount,
-        visibleLayerCount,
-        targetMode: context.targetMode ?? null,
-        targetLayerCount: context.targetLayerCount ?? null,
-        targetIncludesBaseLayer: context.targetIncludesBaseLayer ?? null,
-        aiResultLayerId: context.aiResultLayerId ?? null,
-        aiResultLayerName: context.aiResultLayerName ?? null,
-    } satisfies Record<string, unknown>;
+    return buildEditorLineageMetadata({
+        sourceImage,
+        savedImage,
+        isCopy: context.isCopy,
+        adjustments: context.adjustments,
+        layerStack: context.layerStack,
+        targetMode: context.targetMode,
+        targetLayerCount: context.targetLayerCount,
+        targetIncludesBaseLayer: context.targetIncludesBaseLayer,
+        aiResultLayerId: context.aiResultLayerId,
+        aiResultLayerName: context.aiResultLayerName,
+        aiEditPrompt: context.aiEditPrompt,
+        aiEditModel: context.aiEditModel,
+    });
 }

--- a/src/editor/useEditorController.test.ts
+++ b/src/editor/useEditorController.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ArchiveLayerStack } from '../db/types';
+import type { EditImageInput } from '../image-workflow/ImageWorkflow';
+import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import type { AiTransformRenderer } from './aiTransform';
+import type { EditorAdjustments, EditorDraft } from './layers';
+import { pushHistory, redoHistory, undoHistory, updateLayer } from './layers';
+import { buildEditorSaveContext, runEditorAiTransform } from './useEditorController';
+
+const adjustments: EditorAdjustments = {
+    brightness: 100,
+    contrast: 100,
+    saturation: 100,
+    filter: 'none',
+};
+
+describe('Editor controller AI transform flow', () => {
+    it('runs an end-to-end selected-layer transform and builds save-after-transform provenance', async () => {
+        const draft = createDraft(createLayerStack(), ['layer-1']);
+        const referenceImages = [
+            new File(['reference'], 'reference.png', { type: 'image/png' }),
+        ];
+        const render = createRecordingRenderer();
+        const editImage = vi.fn(async (_input: EditImageInput) => 'data:image/png;base64,ai-result');
+
+        const result = await runEditorAiTransform({
+            apiKey: 'sk-test',
+            model: OPENAI_IMAGE_MODEL,
+            prompt: '  replace the jacket  ',
+            draft,
+            adjustments,
+            referenceImages,
+            makeId: () => 'ai-layer',
+            editImage,
+            render,
+        });
+
+        expect(render).toHaveBeenCalledTimes(2);
+        expect(editImage).toHaveBeenCalledWith(expect.objectContaining({
+            apiKey: 'sk-test',
+            model: OPENAI_IMAGE_MODEL,
+            prompt: 'replace the jacket',
+            sourceImage: expect.any(Blob),
+            compositionContextImage: expect.any(File),
+            referenceImages,
+            quality: 'medium',
+        }));
+        expect(result.draft.layerStack.layers.map((layer) => [layer.id, layer.visible])).toEqual([
+            ['base', true],
+            ['layer-1', false],
+            ['ai-layer', true],
+            ['layer-2', true],
+        ]);
+
+        const context = buildEditorSaveContext({
+            isCopy: false,
+            references: ['data:image/png;base64,reference'],
+            adjustments,
+            draft: result.draft,
+            aiTransformProvenance: result.provenance,
+        });
+
+        expect(context).toEqual(expect.objectContaining({
+            isCopy: false,
+            aiEditPrompt: 'replace the jacket',
+            aiEditModel: OPENAI_IMAGE_MODEL,
+            targetMode: 'selected-layers',
+            targetLayerCount: 1,
+            targetIncludesBaseLayer: false,
+            aiResultLayerId: 'ai-layer',
+            aiResultLayerName: 'AI result',
+        }));
+        expect(context.layerStack?.layers.map((layer) => [layer.id, layer.visible])).toEqual([
+            ['base', true],
+            ['layer-1', false],
+            ['ai-layer', true],
+            ['layer-2', true],
+        ]);
+    });
+
+    it('drops stale save provenance after undoing the AI result layer', async () => {
+        const draft = createDraft(createLayerStack(), ['layer-1']);
+        const result = await runTransform(draft);
+        const history = pushHistory({ past: [], present: draft, future: [] }, result.draft);
+        const undone = undoHistory(history);
+
+        const context = buildEditorSaveContext({
+            isCopy: false,
+            references: [],
+            adjustments,
+            draft: undone.present,
+            aiTransformProvenance: result.provenance,
+        });
+
+        expect(context.aiEditPrompt).toBeUndefined();
+        expect(context.aiEditModel).toBeUndefined();
+        expect(context.targetMode).toBeUndefined();
+        expect(context.aiResultLayerId).toBeUndefined();
+        expect(context.layerStack?.layers.map((layer) => layer.id)).toEqual(['base', 'layer-1', 'layer-2']);
+    });
+
+    it('restores save provenance after redoing the AI result layer', async () => {
+        const draft = createDraft(createLayerStack(), ['layer-1']);
+        const result = await runTransform(draft);
+        const history = pushHistory({ past: [], present: draft, future: [] }, result.draft);
+        const redone = redoHistory(undoHistory(history));
+
+        const context = buildEditorSaveContext({
+            isCopy: false,
+            references: [],
+            adjustments,
+            draft: redone.present,
+            aiTransformProvenance: result.provenance,
+        });
+
+        expect(context).toEqual(expect.objectContaining({
+            aiEditPrompt: 'replace the jacket',
+            aiEditModel: OPENAI_IMAGE_MODEL,
+            targetMode: 'selected-layers',
+            targetLayerCount: 1,
+            targetIncludesBaseLayer: false,
+            aiResultLayerId: 'ai-layer',
+            aiResultLayerName: 'AI result',
+        }));
+    });
+
+    it('uses the present editor draft for layered save metadata after manual layer changes', async () => {
+        const result = await runTransform(createDraft(createLayerStack(), ['layer-1']));
+        const renamedLayerStack = updateLayer(result.draft.layerStack, 'ai-layer', { name: 'Retouched jacket' });
+        const changedDraft = {
+            ...result.draft,
+            layerStack: renamedLayerStack,
+        };
+
+        const context = buildEditorSaveContext({
+            isCopy: true,
+            references: [],
+            adjustments,
+            draft: changedDraft,
+            aiTransformProvenance: result.provenance,
+        });
+
+        expect(context.aiResultLayerName).toBe('Retouched jacket');
+        expect(context.layerStack?.layers.find((layer) => layer.id === 'ai-layer')?.name).toBe('Retouched jacket');
+    });
+});
+
+async function runTransform(draft: EditorDraft) {
+    return runEditorAiTransform({
+        apiKey: 'sk-test',
+        model: OPENAI_IMAGE_MODEL,
+        prompt: 'replace the jacket',
+        draft,
+        adjustments,
+        referenceImages: [],
+        makeId: () => 'ai-layer',
+        editImage: vi.fn(async () => 'data:image/png;base64,ai-result'),
+        render: createRecordingRenderer(),
+    });
+}
+
+function createRecordingRenderer() {
+    return vi.fn<AiTransformRenderer>(async (layerStack) =>
+        new Blob([layerStack.layers.map((layer) => layer.id).join(',')], { type: 'image/png' }),
+    );
+}
+
+function createDraft(layerStack: ArchiveLayerStack, selectedLayerIds: string[]): EditorDraft {
+    return {
+        layerStack,
+        adjustments,
+        references: [],
+        selectedLayerIds,
+        primarySelectedLayerId: selectedLayerIds[0] ?? null,
+    };
+}
+
+function createLayerStack(): ArchiveLayerStack {
+    return {
+        canvasWidth: 1000,
+        canvasHeight: 800,
+        layers: [
+            {
+                id: 'base',
+                name: 'Base',
+                kind: 'base',
+                assetUrl: 'data:image/png;base64,base',
+                x: 0,
+                y: 0,
+                width: 1000,
+                height: 800,
+                rotation: 0,
+                opacity: 1,
+                visible: true,
+                locked: true,
+            },
+            {
+                id: 'layer-1',
+                name: 'Layer 1',
+                kind: 'uploaded',
+                assetUrl: 'data:image/png;base64,one',
+                x: 100,
+                y: 120,
+                width: 200,
+                height: 220,
+                rotation: 0,
+                opacity: 1,
+                visible: true,
+                locked: false,
+            },
+            {
+                id: 'layer-2',
+                name: 'Layer 2',
+                kind: 'uploaded',
+                assetUrl: 'data:image/png;base64,two',
+                x: 450,
+                y: 260,
+                width: 100,
+                height: 160,
+                rotation: 0,
+                opacity: 0.8,
+                visible: true,
+                locked: false,
+            },
+        ],
+    };
+}

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -1,8 +1,13 @@
 import { useCallback, useState } from 'react';
-import type { ArchiveLayerStack } from '../db/types';
-import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { imageWorkflow, type EditImageInput } from '../image-workflow/ImageWorkflow';
 import type { ImageModelSlug } from '../utils/openaiModels';
-import { applyAiTransformResultToDraft, renderAiTransformEditInput } from './aiTransform';
+import {
+    applyAiTransformResultToDraft,
+    getAiTransformSaveProvenance,
+    renderAiTransformEditInput,
+    type AiTransformRenderer,
+    type AiTransformSaveProvenance,
+} from './aiTransform';
 import {
     hasDurableLayerStack,
     type EditorAdjustments,
@@ -15,8 +20,6 @@ interface UseEditorControllerOptions {
     model: ImageModelSlug;
     isCanvasReady: boolean;
     draft: EditorDraft | null;
-    layerStack: ArchiveLayerStack | null;
-    selectedLayerIds: string[];
     commitDraft: (draft: EditorDraft, recordHistory?: boolean) => void;
     referenceImages: File[];
     addReferenceFiles: (files: File[]) => void;
@@ -31,7 +34,6 @@ export function useEditorController({
     model,
     isCanvasReady,
     draft,
-    layerStack,
     commitDraft,
     referenceImages,
     addReferenceFiles,
@@ -44,13 +46,7 @@ export function useEditorController({
     const [aiLoading, setAiLoading] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
     const [isDragging, setIsDragging] = useState(false);
-    const [lastAiEditPrompt, setLastAiEditPrompt] = useState<string | null>(null);
-    const [lastAiEditModel, setLastAiEditModel] = useState<ImageModelSlug | null>(null);
-    const [lastAiTargetMode, setLastAiTargetMode] = useState<'whole-composition' | 'selected-layers' | null>(null);
-    const [lastAiTargetLayerCount, setLastAiTargetLayerCount] = useState<number | null>(null);
-    const [lastAiTargetIncludesBaseLayer, setLastAiTargetIncludesBaseLayer] = useState<boolean | null>(null);
-    const [lastAiResultLayerId, setLastAiResultLayerId] = useState<string | null>(null);
-    const [lastAiResultLayerName, setLastAiResultLayerName] = useState<string | null>(null);
+    const [aiTransformProvenance, setAiTransformProvenance] = useState<AiTransformSaveProvenance | null>(null);
 
     const save = useCallback(async (isCopy: boolean = false) => {
         if (!isCanvasReady) {
@@ -60,40 +56,28 @@ export function useEditorController({
         try {
             const dataUrl = await exportDataUrl();
             const references = await serializeReferences();
-            await Promise.resolve(onSave(dataUrl, {
+            await Promise.resolve(onSave(dataUrl, buildEditorSaveContext({
                 isCopy,
                 references,
                 adjustments,
-                layerStack: layerStack && hasDurableLayerStack(layerStack) ? layerStack : null,
-                aiEditPrompt: lastAiEditPrompt,
-                aiEditModel: lastAiEditModel,
-                targetMode: lastAiEditPrompt ? lastAiTargetMode : null,
-                targetLayerCount: lastAiTargetLayerCount,
-                targetIncludesBaseLayer: lastAiTargetIncludesBaseLayer,
-                aiResultLayerId: lastAiResultLayerId,
-                aiResultLayerName: lastAiResultLayerName,
-            }));
+                draft,
+                aiTransformProvenance,
+            })));
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'Failed to save image');
         }
     }, [
         adjustments,
+        aiTransformProvenance,
+        draft,
         exportDataUrl,
         isCanvasReady,
-        lastAiEditModel,
-        lastAiEditPrompt,
-        lastAiResultLayerId,
-        lastAiResultLayerName,
-        lastAiTargetIncludesBaseLayer,
-        lastAiTargetLayerCount,
-        lastAiTargetMode,
-        layerStack,
         onSave,
         serializeReferences,
     ]);
 
     const applyAiEdit = useCallback(async () => {
-        if (!apiKey || !aiPrompt.trim() || !draft || !layerStack || !isCanvasReady) {
+        if (!apiKey || !aiPrompt.trim() || !draft || !isCanvasReady) {
             return;
         }
 
@@ -101,42 +85,25 @@ export function useEditorController({
         setAiError(null);
 
         try {
-            const editInput = await renderAiTransformEditInput({
-                draft,
-                adjustments,
-                referenceImages,
-            });
-            const resultUrl = await imageWorkflow.edit({
+            const result = await runEditorAiTransform({
                 apiKey,
                 model,
                 prompt: aiPrompt,
-                sourceImage: editInput.sourceImage,
-                compositionContextImage: editInput.compositionContextImage,
-                referenceImages: editInput.referenceImages,
-                quality: 'medium',
-            });
-            const result = applyAiTransformResultToDraft(
                 draft,
-                editInput.targetPlan,
-                resultUrl,
-                () => crypto.randomUUID(),
-            );
+                adjustments,
+                referenceImages,
+                makeId: () => crypto.randomUUID(),
+            });
 
             commitDraft(result.draft);
-            setLastAiEditPrompt(aiPrompt.trim());
-            setLastAiEditModel(model);
-            setLastAiTargetMode(editInput.targetPlan.metadata.targetMode);
-            setLastAiTargetLayerCount(editInput.targetPlan.metadata.targetLayerCount);
-            setLastAiTargetIncludesBaseLayer(editInput.targetPlan.metadata.targetIncludesBaseLayer);
-            setLastAiResultLayerId(result.resultLayerId);
-            setLastAiResultLayerName(result.resultLayerName);
+            setAiTransformProvenance(result.provenance);
             setAiPrompt('');
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'AI Edit failed');
         } finally {
             setAiLoading(false);
         }
-    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, isCanvasReady, layerStack, model, referenceImages]);
+    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, isCanvasReady, model, referenceImages]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();
@@ -170,5 +137,91 @@ export function useEditorController({
         handleDragOver,
         handleDragLeave,
         handleDrop,
+    };
+}
+
+type EditImage = (input: EditImageInput) => Promise<string>;
+
+export interface RunEditorAiTransformOptions {
+    apiKey: string;
+    model: ImageModelSlug;
+    prompt: string;
+    draft: EditorDraft;
+    adjustments: EditorAdjustments;
+    referenceImages: File[];
+    makeId: () => string;
+    editImage?: EditImage;
+    render?: AiTransformRenderer;
+}
+
+export async function runEditorAiTransform({
+    apiKey,
+    model,
+    prompt,
+    draft,
+    adjustments,
+    referenceImages,
+    makeId,
+    editImage = imageWorkflow.edit,
+    render,
+}: RunEditorAiTransformOptions) {
+    const trimmedPrompt = prompt.trim();
+    const editInput = await renderAiTransformEditInput({
+        draft,
+        adjustments,
+        referenceImages,
+        render,
+    });
+    const resultUrl = await editImage({
+        apiKey,
+        model,
+        prompt: trimmedPrompt,
+        sourceImage: editInput.sourceImage,
+        compositionContextImage: editInput.compositionContextImage,
+        referenceImages: editInput.referenceImages,
+        quality: 'medium',
+    });
+
+    return applyAiTransformResultToDraft(
+        draft,
+        editInput.targetPlan,
+        resultUrl,
+        makeId,
+        {
+            prompt: trimmedPrompt,
+            model,
+        },
+    );
+}
+
+export interface BuildEditorSaveContextOptions {
+    isCopy: boolean;
+    references: string[];
+    adjustments: EditorAdjustments;
+    draft: EditorDraft | null;
+    aiTransformProvenance: AiTransformSaveProvenance | null;
+}
+
+export function buildEditorSaveContext({
+    isCopy,
+    references,
+    adjustments,
+    draft,
+    aiTransformProvenance,
+}: BuildEditorSaveContextOptions): EditorSaveContext {
+    const saveProvenance = getAiTransformSaveProvenance(draft, aiTransformProvenance);
+
+    return {
+        isCopy,
+        references,
+        adjustments,
+        layerStack: draft && hasDurableLayerStack(draft.layerStack) ? draft.layerStack : null,
+        aiEditPrompt: saveProvenance?.aiEditPrompt,
+        aiEditModel: saveProvenance?.aiEditModel,
+        targetMode: saveProvenance?.targetMode,
+        targetLayerCount: saveProvenance?.targetLayerCount,
+        targetIncludesBaseLayer: saveProvenance?.targetIncludesBaseLayer,
+        aiResultLayerId: saveProvenance?.aiResultLayerId,
+        aiResultLayerName: saveProvenance?.aiResultLayerName,
     };
 }

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -1,16 +1,13 @@
 import { useCallback, useState } from 'react';
 import type { ArchiveLayerStack } from '../db/types';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
-import { dataURLtoFile } from '../utils/file';
 import type { ImageModelSlug } from '../utils/openaiModels';
+import { applyAiTransformResultToDraft, renderAiTransformEditInput } from './aiTransform';
 import {
     hasDurableLayerStack,
-    insertAiResultLayer,
-    planAiTransformTarget,
     type EditorAdjustments,
     type EditorDraft,
 } from './layers';
-import { renderLayerStackToBlob } from './renderLayerStack';
 import type { EditorSaveContext } from './saveEditedImage';
 
 interface UseEditorControllerOptions {
@@ -25,7 +22,6 @@ interface UseEditorControllerOptions {
     addReferenceFiles: (files: File[]) => void;
     serializeReferences: () => Promise<string[]>;
     exportDataUrl: () => Promise<string>;
-    exportBlob: () => Promise<Blob>;
     adjustments: EditorAdjustments;
     onSave: (updatedUrl: string, context: EditorSaveContext) => void | Promise<void>;
 }
@@ -41,7 +37,6 @@ export function useEditorController({
     addReferenceFiles,
     serializeReferences,
     exportDataUrl,
-    exportBlob,
     adjustments,
     onSave,
 }: UseEditorControllerOptions) {
@@ -106,48 +101,42 @@ export function useEditorController({
         setAiError(null);
 
         try {
-            const targetPlan = planAiTransformTarget(draft);
-            const sourceLayerStack = draft.layerStack;
-            const sourceImage = targetPlan.mode === 'selected-layers'
-                ? await renderLayerStackToBlob({
-                    ...sourceLayerStack,
-                    layers: sourceLayerStack.layers.filter((layer) => targetPlan.targetLayerIds.includes(layer.id)),
-                }, adjustments, targetPlan.targetBounds)
-                : await exportBlob();
-            const contextReferences = targetPlan.requiresCompositionContext
-                ? [dataURLtoFile(await exportDataUrl(), 'composition-context.png')]
-                : [];
+            const editInput = await renderAiTransformEditInput({
+                draft,
+                adjustments,
+                referenceImages,
+            });
             const resultUrl = await imageWorkflow.edit({
                 apiKey,
                 model,
                 prompt: aiPrompt,
-                sourceImage,
-                referenceImages: [...contextReferences, ...referenceImages],
+                sourceImage: editInput.sourceImage,
+                compositionContextImage: editInput.compositionContextImage,
+                referenceImages: editInput.referenceImages,
                 quality: 'medium',
             });
-            const result = insertAiResultLayer(sourceLayerStack, targetPlan.targetLayerIds, resultUrl, () => crypto.randomUUID());
-            const resultLayer = result.layerStack.layers.find((layer) => layer.id === result.layerId);
+            const result = applyAiTransformResultToDraft(
+                draft,
+                editInput.targetPlan,
+                resultUrl,
+                () => crypto.randomUUID(),
+            );
 
-            commitDraft({
-                ...draft,
-                layerStack: result.layerStack,
-                selectedLayerIds: [result.layerId],
-                primarySelectedLayerId: result.layerId,
-            });
+            commitDraft(result.draft);
             setLastAiEditPrompt(aiPrompt.trim());
             setLastAiEditModel(model);
-            setLastAiTargetMode(targetPlan.metadata.targetMode);
-            setLastAiTargetLayerCount(targetPlan.metadata.targetLayerCount);
-            setLastAiTargetIncludesBaseLayer(targetPlan.metadata.targetIncludesBaseLayer);
-            setLastAiResultLayerId(result.layerId);
-            setLastAiResultLayerName(resultLayer?.name ?? null);
+            setLastAiTargetMode(editInput.targetPlan.metadata.targetMode);
+            setLastAiTargetLayerCount(editInput.targetPlan.metadata.targetLayerCount);
+            setLastAiTargetIncludesBaseLayer(editInput.targetPlan.metadata.targetIncludesBaseLayer);
+            setLastAiResultLayerId(result.resultLayerId);
+            setLastAiResultLayerName(result.resultLayerName);
             setAiPrompt('');
         } catch (err: unknown) {
             setAiError(err instanceof Error ? err.message : 'AI Edit failed');
         } finally {
             setAiLoading(false);
         }
-    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, exportBlob, exportDataUrl, isCanvasReady, layerStack, model, referenceImages]);
+    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, isCanvasReady, layerStack, model, referenceImages]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -4,9 +4,9 @@ import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { dataURLtoFile } from '../utils/file';
 import type { ImageModelSlug } from '../utils/openaiModels';
 import {
-    getCombinedLayerBounds,
     hasDurableLayerStack,
     insertAiResultLayer,
+    planAiTransformTarget,
     type EditorAdjustments,
     type EditorDraft,
 } from './layers';
@@ -36,7 +36,6 @@ export function useEditorController({
     isCanvasReady,
     draft,
     layerStack,
-    selectedLayerIds,
     commitDraft,
     referenceImages,
     addReferenceFiles,
@@ -107,19 +106,15 @@ export function useEditorController({
         setAiError(null);
 
         try {
-            const selectedVisibleLayerIds = selectedLayerIds.filter((layerId) => {
-                const layer = layerStack.layers.find((entry) => entry.id === layerId);
-                return layer?.visible;
-            });
-            const hasSelectedTargets = selectedVisibleLayerIds.length > 0 && !selectedVisibleLayerIds.every((layerId) => layerId === 'base');
-            const bounds = hasSelectedTargets ? getCombinedLayerBounds(layerStack, selectedVisibleLayerIds) : null;
-            const sourceImage = hasSelectedTargets && bounds
+            const targetPlan = planAiTransformTarget(draft);
+            const sourceLayerStack = draft.layerStack;
+            const sourceImage = targetPlan.mode === 'selected-layers'
                 ? await renderLayerStackToBlob({
-                    ...layerStack,
-                    layers: layerStack.layers.filter((layer) => selectedVisibleLayerIds.includes(layer.id)),
-                }, adjustments, bounds)
+                    ...sourceLayerStack,
+                    layers: sourceLayerStack.layers.filter((layer) => targetPlan.targetLayerIds.includes(layer.id)),
+                }, adjustments, targetPlan.targetBounds)
                 : await exportBlob();
-            const contextReferences = hasSelectedTargets
+            const contextReferences = targetPlan.requiresCompositionContext
                 ? [dataURLtoFile(await exportDataUrl(), 'composition-context.png')]
                 : [];
             const resultUrl = await imageWorkflow.edit({
@@ -130,8 +125,7 @@ export function useEditorController({
                 referenceImages: [...contextReferences, ...referenceImages],
                 quality: 'medium',
             });
-            const targetIds = hasSelectedTargets ? selectedVisibleLayerIds : ['base'];
-            const result = insertAiResultLayer(layerStack, targetIds, resultUrl, () => crypto.randomUUID());
+            const result = insertAiResultLayer(sourceLayerStack, targetPlan.targetLayerIds, resultUrl, () => crypto.randomUUID());
             const resultLayer = result.layerStack.layers.find((layer) => layer.id === result.layerId);
 
             commitDraft({
@@ -142,9 +136,9 @@ export function useEditorController({
             });
             setLastAiEditPrompt(aiPrompt.trim());
             setLastAiEditModel(model);
-            setLastAiTargetMode(hasSelectedTargets ? 'selected-layers' : 'whole-composition');
-            setLastAiTargetLayerCount(hasSelectedTargets ? selectedVisibleLayerIds.length : null);
-            setLastAiTargetIncludesBaseLayer(hasSelectedTargets ? selectedVisibleLayerIds.includes('base') : null);
+            setLastAiTargetMode(targetPlan.metadata.targetMode);
+            setLastAiTargetLayerCount(targetPlan.metadata.targetLayerCount);
+            setLastAiTargetIncludesBaseLayer(targetPlan.metadata.targetIncludesBaseLayer);
             setLastAiResultLayerId(result.layerId);
             setLastAiResultLayerName(resultLayer?.name ?? null);
             setAiPrompt('');
@@ -153,7 +147,7 @@ export function useEditorController({
         } finally {
             setAiLoading(false);
         }
-    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, exportBlob, exportDataUrl, isCanvasReady, layerStack, model, referenceImages, selectedLayerIds]);
+    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, exportBlob, exportDataUrl, isCanvasReady, layerStack, model, referenceImages]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft } from './GenerateSession';
+import type { StorageProvider } from '../services/StorageService';
+import { createGenerateSessionStore, DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft } from './GenerateSession';
 
 describe('GenerateSession draft migration', () => {
     it('migrates legacy flat controls into the gpt-image-2 block', () => {
@@ -57,4 +58,52 @@ describe('GenerateSession draft migration', () => {
             },
         });
     });
+
+    it('persists the current result with its used Reference image snapshot', async () => {
+        const store = createGenerateSessionStore({
+            blobStorage: new InMemoryStorageProvider(),
+        });
+        const references = [
+            'data:image/png;base64,used-ref-0',
+            'data:image/png;base64,used-ref-1',
+        ];
+
+        await store.saveCurrentResult('data:image/png;base64,result', references);
+
+        await expect(store.loadCurrentResult()).resolves.toBe('data:image/png;base64,result');
+        await expect(store.loadCurrentResultReferences()).resolves.toEqual(references);
+
+        await store.saveCurrentResult('data:image/png;base64,legacy-result');
+
+        await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
+
+        await store.clearCurrentResult();
+
+        await expect(store.loadCurrentResult()).resolves.toBeNull();
+        await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
+    });
 });
+
+class InMemoryStorageProvider implements StorageProvider {
+    private readonly values = new Map<string, string>();
+
+    async save(key: string, data: string): Promise<void> {
+        this.values.set(key, data);
+    }
+
+    async load(key: string): Promise<string | null> {
+        return this.values.get(key) ?? null;
+    }
+
+    async remove(key: string): Promise<void> {
+        this.values.delete(key);
+    }
+
+    async clearAll(): Promise<void> {
+        this.values.clear();
+    }
+
+    async listKeys(): Promise<string[]> {
+        return Array.from(this.values.keys());
+    }
+}

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -22,6 +22,7 @@ import {
 
 const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
+const GENERATE_CURRENT_RESULT_REFERENCES_KEY = 'generate_current_result_references';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
 const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 
@@ -64,7 +65,8 @@ export interface GenerateSessionStore {
     saveLineageSource(source: GenerateLineageSource): void;
     clearLineageSource(): void;
     loadCurrentResult(): Promise<string | null>;
-    saveCurrentResult(result: string): Promise<void>;
+    loadCurrentResultReferences(): Promise<string[] | null>;
+    saveCurrentResult(result: string, usedReferences?: string[] | null): Promise<void>;
     clearCurrentResult(): Promise<void>;
     consumeTransferredReferences(): Promise<string[]>;
 }
@@ -163,12 +165,37 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         return this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
     }
 
-    saveCurrentResult(result: string): Promise<void> {
-        return this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
+    async loadCurrentResultReferences(): Promise<string[] | null> {
+        const value = await this.blobStorage.load(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+        if (!value) {
+            return null;
+        }
+
+        try {
+            const references = JSON.parse(value) as unknown;
+            return Array.isArray(references) && references.every((reference) => typeof reference === 'string')
+                ? references
+                : null;
+        } catch {
+            return null;
+        }
     }
 
-    clearCurrentResult(): Promise<void> {
-        return this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY);
+    async saveCurrentResult(result: string, usedReferences: string[] | null = null): Promise<void> {
+        await this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
+        if (Array.isArray(usedReferences)) {
+            await this.blobStorage.save(GENERATE_CURRENT_RESULT_REFERENCES_KEY, JSON.stringify(usedReferences));
+            return;
+        }
+
+        await this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+    }
+
+    async clearCurrentResult(): Promise<void> {
+        await Promise.all([
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY),
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY),
+        ]);
     }
 
     async consumeTransferredReferences(): Promise<string[]> {

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runGenerateAutopilot } from './runGenerateAutopilot';
+import { NANO_BANANA_PRO_IMAGE_MODEL } from '../utils/openaiModels';
+import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
+import type { LineageStep, SaveLineageStepInput } from '../lineage/LineageStore';
 
 describe('runGenerateAutopilot', () => {
     it('delegates to AutopilotSession and persists the best result', async () => {
@@ -77,8 +80,102 @@ describe('runGenerateAutopilot', () => {
         }));
         expect(run).toHaveBeenCalledOnce();
         expect(onSessionCreated).toHaveBeenCalledWith(expect.objectContaining({ run, cancel }));
-        expect(saveCurrentResult).toHaveBeenCalledWith('data:image/png;base64,best');
+        expect(saveCurrentResult).toHaveBeenCalledWith('data:image/png;base64,best', []);
         expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'autopilot:run:iteration:1', stepId: 'step-1' });
         expect(outcome.session.cancel).toBe(cancel);
+    });
+
+    it('limits and persists the provider-used Reference image snapshot for Nano Banana Pro runs', async () => {
+        const selectedReferenceFiles = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+        const expectedProviderReferenceFiles = selectedReferenceFiles.slice(0, 14);
+        const expectedProviderReferenceNames = expectedProviderReferenceFiles.map((file) => file.name);
+        const selectedReferenceDataUrls = selectedReferenceFiles.map((file, index) =>
+            `data:${file.type};base64,reference-${index}`,
+        );
+        const referenceDataUrlByFile = new Map<File, string>(
+            selectedReferenceFiles.map((file, index) => [file, selectedReferenceDataUrls[index]]),
+        );
+        const seenReferenceNames: string[][] = [];
+        const generate = vi.fn(async (input: GenerateImageInput) => {
+            seenReferenceNames.push(input.referenceImages.map((file) => file.name));
+            input.referenceImages.push(new File(['request-mutation'], `request-mutated-${seenReferenceNames.length}.png`, { type: 'image/png' }));
+            selectedReferenceFiles.unshift(new File(['new-reference'], `new-ref-${seenReferenceNames.length}.png`, { type: 'image/png' }));
+
+            return `data:image/png;base64,iteration-${seenReferenceNames.length}`;
+        });
+        const saveCurrentResult = vi.fn(async () => undefined);
+        const serializeReferences = vi.fn(async (files: File[]) =>
+            files.map((file) => referenceDataUrlByFile.get(file) ?? 'data:image/png;base64,unknown'),
+        );
+        let nextStep = 0;
+        const saveLineageStep = vi.fn(async (step: SaveLineageStepInput): Promise<LineageStep> => {
+            nextStep += 1;
+            return {
+                id: `step-${nextStep}`,
+                archiveImageId: step.archiveImageId,
+                parentStepId: step.parentStepId ?? null,
+                stepType: step.stepType,
+                timestamp: step.timestamp ?? '2026-06-05T12:00:00.000Z',
+                metadata: step.metadata,
+            };
+        });
+
+        const outcome = await runGenerateAutopilot({
+            goal: 'A cinematic portrait',
+            apiKey: 'key',
+            reasoningApiKey: 'reasoning-key',
+            draft: {
+                model: NANO_BANANA_PRO_IMAGE_MODEL,
+                prompt: 'prompt 1',
+                style: 'risograph poster',
+                lighting: 'golden hour',
+                palette: 'copper + teal + cream',
+                gptImage2: {
+                    quality: 'high',
+                    size: '1024x1024',
+                    background: 'transparent',
+                },
+                nanoBananaPro: {
+                    aspectRatio: '16:9',
+                    imageSize: '4K',
+                },
+                isSaved: false,
+            },
+            referenceImages: selectedReferenceFiles,
+            sessionStore: {
+                loadLineageSource: () => null,
+                saveCurrentResult,
+                saveLineageSource: vi.fn(),
+            },
+            lineageStore: {
+                save: saveLineageStep,
+            },
+            workflow: {
+                generate,
+                serializeReferences,
+            },
+            evaluate: vi.fn()
+                .mockResolvedValueOnce({ score: 45, feedback: ['Needs stronger lighting.'] })
+                .mockResolvedValueOnce({ score: 88, feedback: ['Best so far.'] }),
+            refine: vi.fn().mockResolvedValueOnce('best prompt'),
+            maxIterations: 2,
+            satisfactionThreshold: 90,
+        });
+
+        expect(seenReferenceNames).toEqual([
+            expectedProviderReferenceNames,
+            expectedProviderReferenceNames,
+        ]);
+        expect(serializeReferences).toHaveBeenCalledWith(expectedProviderReferenceFiles);
+        expect(saveCurrentResult).toHaveBeenCalledWith(
+            'data:image/png;base64,iteration-2',
+            selectedReferenceDataUrls.slice(0, 14),
+        );
+        expect(outcome.usedReferenceImages.map((file) => file.name)).toEqual(
+            expectedProviderReferenceNames,
+        );
+        expect(outcome.usedReferences).toEqual(selectedReferenceDataUrls.slice(0, 14));
     });
 });

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -5,6 +5,7 @@ import type { ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { promptRefiner } from '../autopilot/PromptRefiner';
 import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
+import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageModelControls';
 
 interface RunGenerateAutopilotInput {
     goal: string;
@@ -16,7 +17,7 @@ interface RunGenerateAutopilotInput {
     sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'saveCurrentResult' | 'saveLineageSource'>;
     lineageStore: Pick<LineageStore, 'save'>;
     createSession?: typeof createAutopilotSession;
-    workflow?: Pick<ImageWorkflow, 'generate'>;
+    workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     evaluate?: typeof satisfactionEvaluator.evaluate;
     refine?: typeof promptRefiner.refine;
     maxIterations?: number;
@@ -29,11 +30,16 @@ interface RunGenerateAutopilotInput {
 export interface RunGenerateAutopilotOutcome {
     session: ReturnType<typeof createAutopilotSession>;
     result: AutopilotSessionResult;
+    usedReferenceImages: File[];
+    usedReferences: string[] | null;
 }
 
 export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Promise<RunGenerateAutopilotOutcome> {
     const createSession = input.createSession ?? createAutopilotSession;
+    const workflow = input.workflow ?? imageWorkflow;
     const controls = getActiveGenerateControls(input.draft);
+    const referenceRunPlan = buildImageModelGenerateReferenceRunPlan(input.draft.model, input.referenceImages);
+    const usedReferenceImages = referenceRunPlan.providerReferenceImages.slice();
     const session = createSession({
         goal: input.goal,
         initialPrompt: input.draft.prompt,
@@ -46,7 +52,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
             style: input.draft.style,
             lighting: input.draft.lighting,
             palette: input.draft.palette,
-            referenceImages: input.referenceImages,
+            referenceImages: usedReferenceImages,
         },
         apiKey: input.apiKey,
         reasoningApiKey: input.reasoningApiKey,
@@ -54,7 +60,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
         initialParentStepId: input.sessionStore.loadLineageSource()?.stepId ?? null,
         maxIterations: input.maxIterations,
         satisfactionThreshold: input.satisfactionThreshold,
-        generate: (request) => (input.workflow ?? imageWorkflow).generate(request),
+        generate: (request) => workflow.generate(request),
         evaluate: input.evaluate,
         refine: input.refine,
         lineageStore: input.lineageStore,
@@ -65,9 +71,11 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
     });
     input.onSessionCreated?.(session);
     const result = await session.run();
+    let usedReferences: string[] | null = null;
 
     if (result.bestIteration) {
-        await input.sessionStore.saveCurrentResult(result.bestIteration.imageDataUrl);
+        usedReferences = await workflow.serializeReferences(usedReferenceImages.slice());
+        await input.sessionStore.saveCurrentResult(result.bestIteration.imageDataUrl, usedReferences);
         input.sessionStore.saveLineageSource({
             archiveImageId: result.bestIteration.archiveImageId,
             stepId: result.bestIteration.stepId,
@@ -77,5 +85,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
     return {
         session,
         result,
+        usedReferenceImages: usedReferenceImages.slice(),
+        usedReferences,
     };
 }

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -126,6 +126,38 @@ describe('saveGeneratedImage', () => {
         ]);
     });
 
+    it('records Nano Banana Pro reference-generation lineage from the saved used Reference images', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const references = Array.from({ length: 14 }, (_, index) => `data:image/png;base64,used-ref-${index}`);
+        const image = createArchiveImage({
+            id: 'generated-nano-with-refs',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            references,
+        });
+
+        const savedImage = await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        expect(savedImage.references).toEqual(references);
+        await expect(lineage.getByArchiveImageId('generated-nano-with-refs')).resolves.toEqual([
+            expect.objectContaining({
+                stepType: 'reference-generation',
+                metadata: expect.objectContaining({
+                    referenceImages: {
+                        count: references.length,
+                        ids: references.map((_, index) => `generated-nano-with-refs:reference:${index}`),
+                    },
+                    referenceCount: references.length,
+                    referenceIds: references.map((_, index) => `generated-nano-with-refs:reference:${index}`),
+                }),
+            }),
+        ]);
+    });
+
     it('records nano-banana-pro archive metadata dimensions through shared Image model controls', async () => {
         const lineage = createStore();
         const sessionStore = createSessionStore();

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -60,6 +60,18 @@ describe('saveGeneratedImage', () => {
                 metadata: expect.objectContaining({
                     prompt: savedImage.prompt,
                     model: OPENAI_IMAGE_MODEL,
+                    imageModel: {
+                        slug: OPENAI_IMAGE_MODEL,
+                        controls: {
+                            quality: savedImage.quality,
+                            size: savedImage.aspectRatio,
+                            background: savedImage.background,
+                        },
+                    },
+                    dimensions: {
+                        width: 1024,
+                        height: 1024,
+                    },
                     quality: savedImage.quality,
                     aspectRatio: savedImage.aspectRatio,
                     background: savedImage.background,
@@ -67,7 +79,12 @@ describe('saveGeneratedImage', () => {
                     height: 1024,
                     imageSize: null,
                     sourceArchiveImageId: null,
+                    referenceImages: {
+                        count: 0,
+                        ids: [],
+                    },
                     referenceIds: [],
+                    referenceCount: 0,
                 }),
             }),
         ]);
@@ -92,6 +109,13 @@ describe('saveGeneratedImage', () => {
             expect.objectContaining({
                 stepType: 'reference-generation',
                 metadata: expect.objectContaining({
+                    referenceImages: {
+                        count: 2,
+                        ids: [
+                            'generated-2:reference:0',
+                            'generated-2:reference:1',
+                        ],
+                    },
                     referenceCount: 2,
                     referenceIds: [
                         'generated-2:reference:0',
@@ -126,6 +150,17 @@ describe('saveGeneratedImage', () => {
                 stepType: 'generation',
                 metadata: expect.objectContaining({
                     model: NANO_BANANA_PRO_IMAGE_MODEL,
+                    imageModel: {
+                        slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                        controls: {
+                            aspectRatio: '16:9',
+                            imageSize: '2K',
+                        },
+                    },
+                    dimensions: {
+                        width: 2048,
+                        height: 1152,
+                    },
                     quality: '2K',
                     aspectRatio: '16:9',
                     background: 'auto',

--- a/src/generate-session/saveGeneratedImage.ts
+++ b/src/generate-session/saveGeneratedImage.ts
@@ -1,10 +1,6 @@
 import type { ArchiveImage } from '../db/types';
-import {
-    buildImageModelArchiveFields,
-    sanitizeArchiveImageModelControls,
-} from '../image-models/ImageModelControls';
+import { buildGenerateLineageMetadata } from '../lineage/generateLineageMetadata';
 import type { LineageStore } from '../lineage/LineageStore';
-import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, isImageModelSlug } from '../utils/openaiModels';
 import type { GenerateLineageSource, GenerateSessionStore } from './GenerateSession';
 
 export interface SaveGeneratedImageDeps {
@@ -22,7 +18,10 @@ export async function saveGeneratedImage(image: ArchiveImage, deps: SaveGenerate
         parentStepId: await resolveParentStepId(lineageSource, deps.lineageStore),
         stepType: savedImage.references && savedImage.references.length > 0 ? 'reference-generation' : 'generation',
         timestamp: savedImage.timestamp,
-        metadata: buildGenerationMetadata(savedImage, lineageSource),
+        metadata: buildGenerateLineageMetadata({
+            image: savedImage,
+            sourceArchiveImageId: lineageSource?.archiveImageId ?? null,
+        }),
     });
 
     deps.sessionStore.clearLineageSource();
@@ -44,31 +43,4 @@ async function resolveParentStepId(
 
     const sourceSteps = await lineageStore.getByArchiveImageId(lineageSource.archiveImageId);
     return sourceSteps.at(-1)?.id ?? null;
-}
-
-function buildGenerationMetadata(image: ArchiveImage, lineageSource: GenerateLineageSource | null) {
-    const model = isImageModelSlug(image.model) ? image.model : DEFAULT_IMAGE_MODEL;
-    const imageModelControls = sanitizeArchiveImageModelControls(model, image);
-    const imageModelArchiveFields = buildImageModelArchiveFields(model, imageModelControls);
-
-    return {
-        prompt: image.prompt,
-        model: image.model ?? null,
-        quality: image.quality,
-        aspectRatio: image.aspectRatio,
-        background: image.background,
-        width: image.width ?? imageModelArchiveFields.width,
-        height: image.height ?? imageModelArchiveFields.height,
-        imageSize: model === NANO_BANANA_PRO_IMAGE_MODEL ? imageModelArchiveFields.quality : null,
-        style: image.style ?? 'none',
-        lighting: image.lighting ?? 'none',
-        palette: image.palette ?? 'none',
-        referenceIds: (image.references ?? []).map((_, index) => createReferenceId(image.id, index)),
-        referenceCount: image.references?.length ?? 0,
-        sourceArchiveImageId: lineageSource?.archiveImageId ?? null,
-    } satisfies Record<string, unknown>;
-}
-
-function createReferenceId(archiveImageId: string, index: number) {
-    return `${archiveImageId}:reference:${index}`;
 }

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageModelControls';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
-import { buildGeneratedArchiveImage } from './useGenerateController';
+import {
+    buildGeneratedArchiveImage,
+    buildGeneratedArchiveImageForSave,
+    snapshotGeneratedReferenceImages,
+} from './useGenerateController';
 
 describe('Generate controller Image model archive metadata', () => {
     it('builds gpt-image-2 archive metadata from shared Image model controls', () => {
@@ -57,6 +62,49 @@ describe('Generate controller Image model archive metadata', () => {
             height: 2304,
             references: [],
         });
+    });
+});
+
+describe('Generate controller Reference image provenance', () => {
+    it('saves an over-limit Nano Banana Pro result from the used Reference image snapshot', async () => {
+        const draft = createDraft({
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+        });
+        const selectedReferenceFiles = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+        const selectedReferenceDataUrls = selectedReferenceFiles.map((file, index) =>
+            `data:${file.type};base64,reference-${index}`,
+        );
+        const changedReferenceDataUrls = [
+            'data:image/png;base64,new-reference',
+            ...selectedReferenceDataUrls,
+        ];
+        const referenceRunPlan = buildImageModelGenerateReferenceRunPlan(
+            NANO_BANANA_PRO_IMAGE_MODEL,
+            selectedReferenceFiles,
+        );
+        const serializeReferenceFiles = vi.fn(async (files: File[]) =>
+            files.map((file) => selectedReferenceDataUrls[selectedReferenceFiles.indexOf(file)]),
+        );
+        const serializeReferences = vi.fn(async () => changedReferenceDataUrls);
+
+        const usedReferences = await snapshotGeneratedReferenceImages({
+            referenceImages: referenceRunPlan.providerReferenceImages,
+            serializeReferenceFiles,
+        });
+        const image = await buildGeneratedArchiveImageForSave({
+            id: 'generated-nano-with-refs',
+            url: 'data:image/png;base64,nano-result',
+            timestamp: '2026-06-05T12:00:00.000Z',
+            draft,
+            usedReferences,
+            serializeReferences,
+        });
+
+        expect(serializeReferenceFiles).toHaveBeenCalledWith(selectedReferenceFiles.slice(0, 14));
+        expect(serializeReferences).not.toHaveBeenCalled();
+        expect(image.references).toEqual(selectedReferenceDataUrls.slice(0, 14));
     });
 });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -247,14 +247,14 @@ export function useGenerateController({
         });
 
         try {
-            const usedReferenceImages = referenceImages.slice();
+            const runReferenceImages = referenceImages.slice();
             const outcome = await runGenerateAutopilot({
                 goal: input.goal,
                 apiKey,
                 reasoningApiKey,
                 reasoningModel,
                 draft,
-                referenceImages: usedReferenceImages,
+                referenceImages: runReferenceImages,
                 sessionStore: session,
                 lineageStore: lineage,
                 workflow,
@@ -284,8 +284,8 @@ export function useGenerateController({
             });
 
             if (outcome.result.bestIteration) {
-                const usedReferences = await snapshotGeneratedReferenceImages({
-                    referenceImages: usedReferenceImages,
+                const usedReferences = outcome.usedReferences ?? await snapshotGeneratedReferenceImages({
+                    referenceImages: outcome.usedReferenceImages,
                     serializeReferenceFiles: workflow.serializeReferences,
                 });
                 setCurrentResult(outcome.result.bestIteration.imageDataUrl);

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -37,8 +37,8 @@ interface UseGenerateControllerOptions {
     serializeReferences: () => Promise<string[]>;
     onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
     lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
-    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
-    workflow?: Pick<ImageWorkflow, 'generate'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'loadCurrentResultReferences' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
+    workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     createAutopilot?: typeof createAutopilotSession;
     evaluate?: typeof satisfactionEvaluator.evaluate;
     refine?: typeof promptRefiner.refine;
@@ -50,6 +50,20 @@ interface BuildGeneratedArchiveImageInput {
     timestamp: string;
     draft: GenerateDraft;
     references: string[];
+}
+
+interface SnapshotGeneratedReferenceImagesInput {
+    referenceImages: File[];
+    serializeReferenceFiles: (files: File[]) => Promise<string[]>;
+}
+
+interface BuildGeneratedArchiveImageForSaveInput {
+    id: string;
+    url: string;
+    timestamp: string;
+    draft: GenerateDraft;
+    usedReferences: string[] | null;
+    serializeReferences: () => Promise<string[]>;
 }
 
 export function buildGeneratedArchiveImage({
@@ -79,6 +93,32 @@ export function buildGeneratedArchiveImage({
     };
 }
 
+export function snapshotGeneratedReferenceImages({
+    referenceImages,
+    serializeReferenceFiles,
+}: SnapshotGeneratedReferenceImagesInput): Promise<string[]> {
+    return serializeReferenceFiles(referenceImages.slice());
+}
+
+export async function buildGeneratedArchiveImageForSave({
+    id,
+    url,
+    timestamp,
+    draft,
+    usedReferences,
+    serializeReferences,
+}: BuildGeneratedArchiveImageForSaveInput): Promise<ArchiveImage> {
+    const references = usedReferences ?? await serializeReferences();
+
+    return buildGeneratedArchiveImage({
+        id,
+        url,
+        timestamp,
+        draft,
+        references,
+    });
+}
+
 export function useGenerateController({
     apiKey,
     reasoningApiKey,
@@ -97,6 +137,7 @@ export function useGenerateController({
     refine,
 }: UseGenerateControllerOptions) {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
+    const [currentResultReferences, setCurrentResultReferences] = useState<string[] | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [autopilot, setAutopilot] = useState<AutopilotProgressState>({
@@ -113,9 +154,13 @@ export function useGenerateController({
     }, [setDraft]);
 
     useEffect(() => {
-        session.loadCurrentResult().then((value) => {
+        Promise.all([
+            session.loadCurrentResult(),
+            session.loadCurrentResultReferences(),
+        ]).then(([value, references]) => {
             if (value) {
                 setCurrentResult(value);
+                setCurrentResultReferences(references);
             }
         });
 
@@ -145,6 +190,11 @@ export function useGenerateController({
 
         try {
             const controls = getActiveGenerateControls(draft);
+            const usedReferenceImages = referenceImages.slice();
+            const usedReferences = await snapshotGeneratedReferenceImages({
+                referenceImages: usedReferenceImages,
+                serializeReferenceFiles: workflow.serializeReferences,
+            });
             const imageUrl = await workflow.generate({
                 apiKey,
                 model: draft.model,
@@ -156,12 +206,13 @@ export function useGenerateController({
                 style: draft.style,
                 lighting: draft.lighting,
                 palette: draft.palette,
-                referenceImages,
+                referenceImages: usedReferenceImages,
             });
 
             setCurrentResult(imageUrl);
+            setCurrentResultReferences(usedReferences);
             updateDraft({ isSaved: false });
-            await session.saveCurrentResult(imageUrl);
+            await session.saveCurrentResult(imageUrl, usedReferences);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to generate image');
         } finally {
@@ -186,6 +237,7 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        setCurrentResultReferences(null);
         setAutopilot({
             running: true,
             iterations: [],
@@ -195,13 +247,14 @@ export function useGenerateController({
         });
 
         try {
+            const usedReferenceImages = referenceImages.slice();
             const outcome = await runGenerateAutopilot({
                 goal: input.goal,
                 apiKey,
                 reasoningApiKey,
                 reasoningModel,
                 draft,
-                referenceImages,
+                referenceImages: usedReferenceImages,
                 sessionStore: session,
                 lineageStore: lineage,
                 workflow,
@@ -231,11 +284,17 @@ export function useGenerateController({
             });
 
             if (outcome.result.bestIteration) {
+                const usedReferences = await snapshotGeneratedReferenceImages({
+                    referenceImages: usedReferenceImages,
+                    serializeReferenceFiles: workflow.serializeReferences,
+                });
                 setCurrentResult(outcome.result.bestIteration.imageDataUrl);
+                setCurrentResultReferences(usedReferences);
                 updateDraft({
                     prompt: outcome.result.bestIteration.prompt,
                     isSaved: false,
                 });
+                await session.saveCurrentResult(outcome.result.bestIteration.imageDataUrl, usedReferences);
             }
 
             if (outcome.result.status === 'failed' && outcome.result.error) {
@@ -266,14 +325,15 @@ export function useGenerateController({
         }
 
         try {
-            const references = await serializeReferences();
-            await saveGeneratedImage(buildGeneratedArchiveImage({
+            const image = await buildGeneratedArchiveImageForSave({
                 id: crypto.randomUUID(),
                 url: currentResult,
                 timestamp: new Date().toISOString(),
                 draft,
-                references,
-            }), {
+                usedReferences: currentResultReferences,
+                serializeReferences,
+            });
+            await saveGeneratedImage(image, {
                 saveImage: async (image) => Promise.resolve(onSaveImage(image)),
                 lineageStore: lineage,
                 sessionStore: session,
@@ -282,7 +342,7 @@ export function useGenerateController({
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [currentResult, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
+    }, [currentResult, currentResultReferences, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
 
     const download = useCallback(() => {
         if (!currentResult) {
@@ -294,6 +354,7 @@ export function useGenerateController({
 
     const clear = useCallback(async () => {
         setCurrentResult(null);
+        setCurrentResultReferences(null);
         await session.clearCurrentResult();
     }, [session]);
 

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     IMAGE_MODEL_CONTROL_FACTS,
+    buildImageModelGenerateReferenceRunPlan,
     buildImageModelArchiveFields,
     coerceImageModelControlValue,
     getDefaultImageModelControls,
@@ -145,6 +146,83 @@ describe('Image model controls', () => {
             imageSize: '4K',
             referenceImages: references.slice(0, 14),
         });
+    });
+
+    it('keeps Generate Reference run plans aligned with Provider requests when the Image model changes', () => {
+        const references = Array.from({ length: 15 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+
+        const openAiRunPlan = buildImageModelGenerateReferenceRunPlan(OPENAI_IMAGE_MODEL, references);
+        const openAiProviderRequest = mapImageModelGenerateProviderRequest(OPENAI_IMAGE_MODEL, {
+            quality: 'high',
+            aspectRatio: '1536x1024',
+            background: 'transparent',
+            referenceImages: references,
+        });
+
+        expect(openAiRunPlan.referenceLimitMessage).toBeNull();
+        expect(openAiProviderRequest.referenceImages).toEqual(openAiRunPlan.providerReferenceImages);
+        expect(openAiProviderRequest.referenceImages).toHaveLength(15);
+
+        const nanoRunPlan = buildImageModelGenerateReferenceRunPlan(NANO_BANANA_PRO_IMAGE_MODEL, references);
+        const nanoProviderRequest = mapImageModelGenerateProviderRequest(NANO_BANANA_PRO_IMAGE_MODEL, {
+            quality: 'high',
+            aspectRatio: '1024x1536',
+            background: 'transparent',
+            imageSize: '4K',
+            referenceImages: references,
+        });
+
+        expect(nanoRunPlan.referenceLimitMessage).toBe(
+            'Nano Banana Pro uses the first 14 reference images for generation.',
+        );
+        expect(nanoProviderRequest.referenceImages).toEqual(nanoRunPlan.providerReferenceImages);
+        expect(nanoProviderRequest.referenceImages.map((file) => file.name)).toEqual([
+            'ref-0.png',
+            'ref-1.png',
+            'ref-2.png',
+            'ref-3.png',
+            'ref-4.png',
+            'ref-5.png',
+            'ref-6.png',
+            'ref-7.png',
+            'ref-8.png',
+            'ref-9.png',
+            'ref-10.png',
+            'ref-11.png',
+            'ref-12.png',
+            'ref-13.png',
+        ]);
+    });
+
+    it('applies future gpt-image-2 Reference limits from Image model facts consistently', () => {
+        const references = Array.from({ length: 3 }, (_, index) =>
+            new File([`reference-${index}`], `ref-${index}.png`, { type: 'image/png' }),
+        );
+        const openAiFacts = IMAGE_MODEL_CONTROL_FACTS[OPENAI_IMAGE_MODEL] as {
+            referenceLimit: number | null;
+        };
+        const originalReferenceLimit = openAiFacts.referenceLimit;
+
+        try {
+            openAiFacts.referenceLimit = 2;
+            const runPlan = buildImageModelGenerateReferenceRunPlan(OPENAI_IMAGE_MODEL, references);
+            const providerRequest = mapImageModelGenerateProviderRequest(OPENAI_IMAGE_MODEL, {
+                quality: 'high',
+                aspectRatio: '1536x1024',
+                background: 'transparent',
+                referenceImages: references,
+            });
+
+            expect(runPlan.referenceLimitMessage).toBe(
+                'GPT Image 2 uses the first 2 reference images for generation.',
+            );
+            expect(providerRequest.referenceImages).toEqual(runPlan.providerReferenceImages);
+            expect(providerRequest.referenceImages.map((file) => file.name)).toEqual(['ref-0.png', 'ref-1.png']);
+        } finally {
+            openAiFacts.referenceLimit = originalReferenceLimit;
+        }
     });
 
     it('maps Editor Provider requests with source and Reference image limits for each Image model', () => {

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -233,17 +233,19 @@ describe('Image model controls', () => {
 
         expect(mapImageModelEditProviderRequest(OPENAI_IMAGE_MODEL, {
             sourceImage,
+            compositionContextImage: references[1],
             referenceImages: references.slice(0, 1),
             quality: 'low',
         })).toEqual({
             quality: 'low',
             size: '1024x1024',
             background: 'auto',
-            referenceImages: [sourceImage, references[0]],
+            referenceImages: [sourceImage, references[1], references[0]],
         });
 
         const nanoRequest = mapImageModelEditProviderRequest(NANO_BANANA_PRO_IMAGE_MODEL, {
             sourceImage,
+            compositionContextImage: new File(['context'], 'composition-context.png', { type: 'image/png' }),
             referenceImages: references,
         });
 
@@ -251,9 +253,13 @@ describe('Image model controls', () => {
             aspectRatio: '1:1',
             imageSize: '1K',
             preserveSourceDimensions: true,
-            referenceImages: [sourceImage, ...references.slice(0, 13)],
+            referenceImages: [
+                sourceImage,
+                expect.objectContaining({ name: 'composition-context.png' }),
+                ...references.slice(0, 14),
+            ],
         });
-        expect(nanoRequest.referenceImages).toHaveLength(14);
+        expect(nanoRequest.referenceImages).toHaveLength(16);
     });
 
     it('exposes shared UI facts for Reference image limits used by Generate and Editor', () => {

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -54,6 +54,11 @@ export interface ImageModelGenerateControl {
     options: ImageModelControlOption[];
 }
 
+export interface ImageModelGenerateReferenceRunPlan<T> {
+    providerReferenceImages: T[];
+    referenceLimitMessage: string | null;
+}
+
 interface ImageModelControlFacts {
     defaults: ImageModelControls;
     generateControls: ImageModelGenerateControl[];
@@ -317,6 +322,8 @@ export function mapImageModelGenerateProviderRequest(
         referenceImages: File[];
     },
 ) {
+    const referenceRunPlan = buildImageModelGenerateReferenceRunPlan(model, input.referenceImages);
+
     if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
         const controls = sanitizeImageModelControls(model, {
             aspectRatio: input.aspectRatio,
@@ -325,7 +332,7 @@ export function mapImageModelGenerateProviderRequest(
         return {
             aspectRatio: controls.aspectRatio,
             imageSize: controls.imageSize,
-            referenceImages: limitReferenceImagesForImageModel(model, input.referenceImages),
+            referenceImages: referenceRunPlan.providerReferenceImages,
         };
     }
 
@@ -333,7 +340,7 @@ export function mapImageModelGenerateProviderRequest(
         quality: coerceImageQuality(input.quality, 'medium'),
         size: coerceGptImageSize(input.aspectRatio, '1024x1024'),
         background: coerceImageBackground(input.background, 'auto'),
-        referenceImages: input.referenceImages,
+        referenceImages: referenceRunPlan.providerReferenceImages,
     };
 }
 
@@ -371,6 +378,16 @@ export function mapImageModelEditProviderRequest(
 export function limitReferenceImagesForImageModel<T>(model: ImageModelSlug, referenceImages: T[]): T[] {
     const limit = IMAGE_MODEL_CONTROL_FACTS[model].referenceLimit;
     return limit === null ? referenceImages : referenceImages.slice(0, limit);
+}
+
+export function buildImageModelGenerateReferenceRunPlan<T>(
+    model: ImageModelSlug,
+    referenceImages: T[],
+): ImageModelGenerateReferenceRunPlan<T> {
+    return {
+        providerReferenceImages: limitReferenceImagesForImageModel(model, referenceImages),
+        referenceLimitMessage: getImageModelReferenceLimitMessage(model, referenceImages.length, 'generation'),
+    };
 }
 
 export function getImageModelReferenceLimitMessage(

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -348,12 +348,18 @@ export function mapImageModelEditProviderRequest(
     model: ImageModelSlug,
     input: {
         sourceImage: File;
+        compositionContextImage?: File | null;
         referenceImages: File[];
         quality?: ImageQuality;
         aspectRatio?: NanoBananaAspectRatio;
         imageSize?: NanoBananaImageSize;
     },
 ) {
+    const referenceImages = [
+        ...(input.compositionContextImage ? [input.compositionContextImage] : []),
+        ...limitReferenceImagesForImageModel(model, input.referenceImages),
+    ];
+
     if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
         const controls = sanitizeImageModelControls(model, {
             aspectRatio: input.aspectRatio,
@@ -363,7 +369,7 @@ export function mapImageModelEditProviderRequest(
             aspectRatio: controls.aspectRatio,
             imageSize: controls.imageSize,
             preserveSourceDimensions: true,
-            referenceImages: [input.sourceImage, ...input.referenceImages.slice(0, NANO_REFERENCE_LIMIT - 1)],
+            referenceImages: [input.sourceImage, ...referenceImages],
         };
     }
 
@@ -371,7 +377,7 @@ export function mapImageModelEditProviderRequest(
         quality: coerceImageQuality(input.quality, 'medium'),
         size: '1024x1024',
         background: 'auto' as ImageBackground,
-        referenceImages: [input.sourceImage, ...input.referenceImages],
+        referenceImages: [input.sourceImage, ...referenceImages],
     };
 }
 

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -219,7 +219,36 @@ describe('ImageWorkflow', () => {
         })).rejects.toThrow('No image data returned from image provider');
     });
 
-    it('sends the editable source before composition context and user references', async () => {
+    it('sends whole-composition edit requests with the editable source before user references', async () => {
+        let seenReferenceImages: File[] = [];
+        const edit = vi.fn(async (input: Parameters<ImageProvider['edit']>[0]) => {
+            seenReferenceImages = input.referenceImages ?? [];
+            return { b64_json: 'edited' };
+        });
+        const providers: ImageProviderRegistry = {
+            openai: {
+                generate: vi.fn(),
+                edit,
+            },
+        };
+        const workflow = createImageWorkflow(providers);
+        const sourceImage = new Blob(['whole-composition'], { type: 'image/png' });
+        const userReference = new File(['reference'], 'user-reference.png', { type: 'image/png' });
+
+        await workflow.edit({
+            apiKey: 'sk-test',
+            prompt: 'make it cinematic',
+            sourceImage,
+            referenceImages: [userReference],
+        });
+
+        expect(seenReferenceImages.map((file) => file.name)).toEqual([
+            'edit-input.png',
+            'user-reference.png',
+        ]);
+    });
+
+    it('sends selected-layer edit requests with composition context before user references', async () => {
         let seenReferenceImages: File[] = [];
         const edit = vi.fn(async (input: Parameters<ImageProvider['edit']>[0]) => {
             seenReferenceImages = input.referenceImages ?? [];
@@ -240,7 +269,8 @@ describe('ImageWorkflow', () => {
             apiKey: 'sk-test',
             prompt: 'replace the sky',
             sourceImage,
-            referenceImages: [compositionContext, userReference],
+            compositionContextImage: compositionContext,
+            referenceImages: [userReference],
         });
 
         expect(seenReferenceImages.map((file) => file.name)).toEqual([
@@ -271,6 +301,7 @@ describe('ImageWorkflow', () => {
             model: NANO_BANANA_PRO_IMAGE_MODEL,
             prompt: 'make it cinematic',
             sourceImage: new Blob(['source'], { type: 'image/png' }),
+            compositionContextImage: new File(['composition'], 'composition-context.png', { type: 'image/png' }),
             referenceImages: references,
         });
 
@@ -282,6 +313,7 @@ describe('ImageWorkflow', () => {
         }));
         expect(request?.referenceImages?.map((file) => file.name)).toEqual([
             'edit-input.png',
+            'composition-context.png',
             'ref-0.png',
             'ref-1.png',
             'ref-2.png',
@@ -295,6 +327,7 @@ describe('ImageWorkflow', () => {
             'ref-10.png',
             'ref-11.png',
             'ref-12.png',
+            'ref-13.png',
         ]);
     });
 });

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -32,6 +32,7 @@ export interface EditImageInput {
     model?: ImageModelSlug;
     prompt: string;
     sourceImage: Blob;
+    compositionContextImage?: File | null;
     referenceImages: File[];
     quality?: ImageQuality;
     aspectRatio?: NanoBananaAspectRatio;
@@ -69,6 +70,7 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
             const { model, modelSlug, provider } = resolveImageProvider(input.model, providers);
             const providerRequest = mapImageModelEditProviderRequest(modelSlug, {
                 sourceImage: createEditSourceFile(input.sourceImage),
+                compositionContextImage: input.compositionContextImage,
                 referenceImages: input.referenceImages,
                 quality: input.quality,
                 aspectRatio: input.aspectRatio,

--- a/src/lineage/autopilotLineageMetadata.ts
+++ b/src/lineage/autopilotLineageMetadata.ts
@@ -1,0 +1,339 @@
+import {
+    buildImageModelArchiveFields,
+    sanitizeImageModelControls,
+    type GptImage2Controls,
+    type NanoBananaProControls,
+} from '../image-models/ImageModelControls';
+import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
+import {
+    DEFAULT_IMAGE_MODEL,
+    NANO_BANANA_PRO_IMAGE_MODEL,
+    OPENAI_IMAGE_MODEL,
+    isImageModelSlug,
+    isReasoningModelSlug,
+    type ImageModelSlug,
+    type ReasoningModelSlug,
+} from '../utils/openaiModels';
+
+export interface AutopilotLineageGoal {
+    text: string;
+}
+
+export interface AutopilotLineageIteration {
+    number: number;
+}
+
+export interface AutopilotLineageEvaluation {
+    score: number;
+    feedback: string[];
+}
+
+export interface AutopilotLineageReplayImage {
+    dataUrl: string;
+}
+
+export interface AutopilotLineageRun {
+    label: string;
+}
+
+export interface AutopilotLineageReasoningModel {
+    slug: ReasoningModelSlug;
+}
+
+export interface AutopilotLineageDimensions {
+    width: number;
+    height: number;
+}
+
+export type AutopilotLineageImageModel =
+    | {
+        slug: typeof OPENAI_IMAGE_MODEL;
+        controls: GptImage2Controls;
+    }
+    | {
+        slug: typeof NANO_BANANA_PRO_IMAGE_MODEL;
+        controls: NanoBananaProControls;
+    };
+
+export interface AutopilotLineageMetadata extends Record<string, unknown> {
+    goal: AutopilotLineageGoal;
+    iteration: AutopilotLineageIteration;
+    evaluation: AutopilotLineageEvaluation;
+    replayImage: AutopilotLineageReplayImage;
+    run: AutopilotLineageRun;
+    reasoningModel: AutopilotLineageReasoningModel | null;
+    imageModel: AutopilotLineageImageModel;
+    dimensions: AutopilotLineageDimensions;
+    prompt: string;
+    model: ImageModelSlug;
+    quality: string;
+    aspectRatio: string;
+    background: string;
+    width: number;
+    height: number;
+    imageSize: string | null;
+    style: string;
+    lighting: string;
+    palette: string;
+    goalText: string;
+    iterationNumber: number;
+    evaluatorScore: number;
+    evaluatorFeedback: string[];
+    outputImageDataUrl: string;
+    runLabel: string;
+}
+
+export interface AutopilotTimelineMetadata {
+    goalText: string | null;
+    iterationNumber: number | null;
+    evaluatorScore: number | null;
+    evaluatorFeedback: string[];
+    replayImageDataUrl: string | null;
+    runLabel: string;
+}
+
+export interface AutopilotGenerateReplayMetadata {
+    imageModel: AutopilotLineageImageModel | null;
+    model: ImageModelSlug | null;
+    prompt: string | null;
+    style: string | null;
+    lighting: string | null;
+    palette: string | null;
+    quality: unknown;
+    aspectRatio: string | null;
+    imageSize: unknown;
+    background: unknown;
+}
+
+export function buildAutopilotLineageMetadata(input: {
+    goal: string;
+    reasoningModel?: string;
+    iterationNumber: number;
+    evaluation: {
+        score: number;
+        feedback: string[];
+    };
+    prompt: string;
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>;
+    outputImageDataUrl: string;
+}): AutopilotLineageMetadata {
+    const model = isImageModelSlug(input.settings.model) ? input.settings.model : DEFAULT_IMAGE_MODEL;
+    const controls = buildAutopilotImageModelControls(model, input.settings);
+    const archiveFields = buildImageModelArchiveFields(model, controls);
+    const runLabel = buildAutopilotRunLabel(input.goal);
+    const feedback = input.evaluation.feedback.filter((entry) => entry.trim().length > 0);
+
+    return {
+        goal: {
+            text: input.goal,
+        },
+        iteration: {
+            number: input.iterationNumber,
+        },
+        evaluation: {
+            score: input.evaluation.score,
+            feedback,
+        },
+        replayImage: {
+            dataUrl: input.outputImageDataUrl,
+        },
+        run: {
+            label: runLabel,
+        },
+        reasoningModel: buildAutopilotReasoningModel(input.reasoningModel),
+        imageModel: buildAutopilotLineageImageModel(model, controls),
+        dimensions: {
+            width: archiveFields.width,
+            height: archiveFields.height,
+        },
+        prompt: input.prompt,
+        model,
+        quality: archiveFields.quality,
+        aspectRatio: archiveFields.aspectRatio,
+        background: archiveFields.background,
+        width: archiveFields.width,
+        height: archiveFields.height,
+        imageSize: model === NANO_BANANA_PRO_IMAGE_MODEL ? archiveFields.quality : null,
+        style: input.settings.style,
+        lighting: input.settings.lighting,
+        palette: input.settings.palette,
+        goalText: input.goal,
+        iterationNumber: input.iterationNumber,
+        evaluatorScore: input.evaluation.score,
+        evaluatorFeedback: feedback,
+        outputImageDataUrl: input.outputImageDataUrl,
+        runLabel,
+    };
+}
+
+export function readAutopilotTimelineMetadata(metadata: Record<string, unknown>): AutopilotTimelineMetadata {
+    const goal = asRecord(metadata.goal);
+    const iteration = asRecord(metadata.iteration);
+    const evaluation = asRecord(metadata.evaluation);
+    const replayImage = asRecord(metadata.replayImage);
+    const run = asRecord(metadata.run);
+    const goalText = asString(goal?.text) ?? asString(metadata.goalText);
+
+    return {
+        goalText,
+        iterationNumber: asFiniteNumber(iteration?.number) ?? asFiniteNumber(metadata.iterationNumber),
+        evaluatorScore: asFiniteNumber(evaluation?.score) ?? asFiniteNumber(metadata.evaluatorScore),
+        evaluatorFeedback: readStringArray(evaluation?.feedback, metadata.evaluatorFeedback),
+        replayImageDataUrl: asString(replayImage?.dataUrl) ?? asString(metadata.outputImageDataUrl),
+        runLabel: asString(run?.label) ?? asString(metadata.runLabel) ?? buildAutopilotRunLabel(goalText),
+    };
+}
+
+export function readAutopilotGenerateReplayMetadata(metadata: Record<string, unknown>): AutopilotGenerateReplayMetadata {
+    const imageModel = readAutopilotLineageImageModel(metadata);
+
+    return {
+        imageModel,
+        model: imageModel?.slug ?? (isImageModelSlug(metadata.model) ? metadata.model : null),
+        prompt: asString(metadata.prompt),
+        style: asString(metadata.style),
+        lighting: asString(metadata.lighting),
+        palette: asString(metadata.palette),
+        quality: metadata.quality,
+        aspectRatio: asString(metadata.aspectRatio),
+        imageSize: metadata.imageSize,
+        background: metadata.background,
+    };
+}
+
+export function readAutopilotLineageImageModel(metadata: Record<string, unknown>): AutopilotLineageImageModel | null {
+    const imageModel = asRecord(metadata.imageModel);
+    if (!imageModel || !isImageModelSlug(imageModel.slug)) {
+        return null;
+    }
+
+    return buildAutopilotLineageImageModel(
+        imageModel.slug,
+        sanitizeImageModelControls(imageModel.slug, imageModel.controls),
+    );
+}
+
+export function readAutopilotLineageReasoningModel(metadata: Record<string, unknown>): AutopilotLineageReasoningModel | null {
+    const reasoningModel = asRecord(metadata.reasoningModel);
+    if (reasoningModel && isReasoningModelSlug(reasoningModel.slug)) {
+        return {
+            slug: reasoningModel.slug,
+        };
+    }
+
+    if (isReasoningModelSlug(metadata.reasoningModel)) {
+        return {
+            slug: metadata.reasoningModel,
+        };
+    }
+
+    return null;
+}
+
+function buildAutopilotImageModelControls(
+    model: typeof OPENAI_IMAGE_MODEL,
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>,
+): GptImage2Controls;
+function buildAutopilotImageModelControls(
+    model: typeof NANO_BANANA_PRO_IMAGE_MODEL,
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>,
+): NanoBananaProControls;
+function buildAutopilotImageModelControls(
+    model: ImageModelSlug,
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>,
+): GptImage2Controls | NanoBananaProControls;
+function buildAutopilotImageModelControls(
+    model: ImageModelSlug,
+    settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>,
+) {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return sanitizeImageModelControls(model, {
+            aspectRatio: settings.aspectRatio,
+            imageSize: settings.imageSize,
+        });
+    }
+
+    return sanitizeImageModelControls(model, {
+        quality: settings.quality,
+        size: settings.aspectRatio,
+        background: settings.background,
+    });
+}
+
+function buildAutopilotLineageImageModel(
+    model: typeof OPENAI_IMAGE_MODEL,
+    controls: GptImage2Controls,
+): AutopilotLineageImageModel;
+function buildAutopilotLineageImageModel(
+    model: typeof NANO_BANANA_PRO_IMAGE_MODEL,
+    controls: NanoBananaProControls,
+): AutopilotLineageImageModel;
+function buildAutopilotLineageImageModel(
+    model: ImageModelSlug,
+    controls: GptImage2Controls | NanoBananaProControls,
+): AutopilotLineageImageModel;
+function buildAutopilotLineageImageModel(
+    model: ImageModelSlug,
+    controls: GptImage2Controls | NanoBananaProControls,
+): AutopilotLineageImageModel {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return {
+            slug: model,
+            controls: sanitizeImageModelControls(model, controls),
+        };
+    }
+
+    return {
+        slug: model,
+        controls: sanitizeImageModelControls(model, controls),
+    };
+}
+
+function buildAutopilotReasoningModel(reasoningModel: string | undefined): AutopilotLineageReasoningModel | null {
+    return isReasoningModelSlug(reasoningModel)
+        ? { slug: reasoningModel }
+        : null;
+}
+
+function buildAutopilotRunLabel(goalText: string | null) {
+    const goal = excerpt(goalText, 36);
+    return goal ? `Autopilot Run · ${goal}` : 'Autopilot Run';
+}
+
+function excerpt(value: string | null, maxLength: number) {
+    if (!value) {
+        return null;
+    }
+
+    const normalized = value.trim().replace(/\s+/g, ' ');
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength - 1)}...`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function asString(value: unknown) {
+    return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function asFiniteNumber(value: unknown) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readStringArray(primary: unknown, fallback: unknown) {
+    const primaryValues = asStringArray(primary);
+    return primaryValues.length > 0 ? primaryValues : asStringArray(fallback);
+}
+
+function asStringArray(value: unknown) {
+    return Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+        : [];
+}

--- a/src/lineage/editorLineageMetadata.ts
+++ b/src/lineage/editorLineageMetadata.ts
@@ -1,0 +1,308 @@
+import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
+import type { EditorAdjustments } from '../editor/layers';
+import { isImageModelSlug, type ImageModelSlug } from '../utils/openaiModels';
+
+export type EditorLineageTargetMode = 'whole-composition' | 'selected-layers';
+
+export interface EditorLineageArchiveImageFact {
+    archiveImageId: string;
+}
+
+export interface EditorLineageSaveState {
+    overwrite: boolean;
+    copy: boolean;
+}
+
+export interface EditorLineageAdjustment {
+    brightness: number;
+    contrast: number;
+    saturation: number;
+    filter: string;
+}
+
+export interface EditorLineageImageModel {
+    slug: ImageModelSlug;
+}
+
+export interface EditorLineageReferenceImages {
+    count: number;
+}
+
+export interface EditorLineageAiTransformTarget {
+    mode: EditorLineageTargetMode | null;
+    layerCount: number | null;
+    includesBaseLayer: boolean | null;
+}
+
+export interface EditorLineageAiEdit {
+    prompt: string;
+    imageModel: EditorLineageImageModel | null;
+    referenceImages: EditorLineageReferenceImages;
+    transformTarget: EditorLineageAiTransformTarget;
+}
+
+export interface EditorLineageAiResultLayerFact {
+    id: string | null;
+    name: string | null;
+}
+
+export interface EditorLineageLayers {
+    layered: boolean;
+    count: number | null;
+    visibleCount: number | null;
+    aiResultLayer: EditorLineageAiResultLayerFact | null;
+}
+
+export interface EditorLineageMetadata extends Record<string, unknown> {
+    sourceImage: EditorLineageArchiveImageFact;
+    outputImage: EditorLineageArchiveImageFact;
+    save: EditorLineageSaveState;
+    editorAdjustment: EditorLineageAdjustment;
+    aiEdit: EditorLineageAiEdit | null;
+    layers: EditorLineageLayers;
+    sourceArchiveImageId: string;
+    outputArchiveImageId: string;
+    overwrite: boolean;
+    editPrompt: string | null;
+    model: string | null;
+    referenceCount: number;
+    editorAdjustments: EditorLineageAdjustment;
+    isLayered: boolean;
+    layerCount: number | null;
+    visibleLayerCount: number | null;
+    targetMode: EditorLineageTargetMode | null;
+    targetLayerCount: number | null;
+    targetIncludesBaseLayer: boolean | null;
+    aiResultLayerId: string | null;
+    aiResultLayerName: string | null;
+}
+
+export interface EditorTimelineMetadata {
+    editPrompt: string | null;
+    editorAdjustment: EditorLineageAdjustment | null;
+    layers: EditorLineageLayers;
+    aiTransformTarget: EditorLineageAiTransformTarget;
+}
+
+export function buildEditorLineageMetadata(input: {
+    sourceImage: ArchiveImage;
+    savedImage: ArchiveImage;
+    isCopy: boolean;
+    adjustments: EditorAdjustments;
+    layerStack?: ArchiveLayerStack | null;
+    targetMode?: EditorLineageTargetMode | null;
+    targetLayerCount?: number | null;
+    targetIncludesBaseLayer?: boolean | null;
+    aiResultLayerId?: string | null;
+    aiResultLayerName?: string | null;
+    aiEditPrompt?: string | null;
+    aiEditModel?: string | null;
+}): EditorLineageMetadata {
+    const layerStack = input.layerStack ?? input.savedImage.layerStack;
+    const editPrompt = normalizeString(input.aiEditPrompt);
+    const model = input.aiEditModel ?? input.sourceImage.model ?? null;
+    const referenceCount = input.savedImage.references?.length ?? 0;
+    const editorAdjustment = buildEditorAdjustment(input.adjustments);
+    const aiTransformTarget = {
+        mode: normalizeTargetMode(input.targetMode),
+        layerCount: normalizeNullableNumber(input.targetLayerCount),
+        includesBaseLayer: normalizeNullableBoolean(input.targetIncludesBaseLayer),
+    };
+    const layers = buildEditorLayers({
+        layerStack,
+        aiResultLayerId: input.aiResultLayerId ?? null,
+        aiResultLayerName: input.aiResultLayerName ?? null,
+    });
+
+    return {
+        sourceImage: {
+            archiveImageId: input.sourceImage.id,
+        },
+        outputImage: {
+            archiveImageId: input.savedImage.id,
+        },
+        save: {
+            overwrite: !input.isCopy,
+            copy: input.isCopy,
+        },
+        editorAdjustment,
+        aiEdit: editPrompt
+            ? {
+                prompt: editPrompt,
+                imageModel: buildEditorLineageImageModel(model),
+                referenceImages: {
+                    count: referenceCount,
+                },
+                transformTarget: aiTransformTarget,
+            }
+            : null,
+        layers,
+        sourceArchiveImageId: input.sourceImage.id,
+        outputArchiveImageId: input.savedImage.id,
+        overwrite: !input.isCopy,
+        editPrompt,
+        model,
+        referenceCount,
+        editorAdjustments: editorAdjustment,
+        isLayered: layers.layered,
+        layerCount: layers.count,
+        visibleLayerCount: layers.visibleCount,
+        targetMode: aiTransformTarget.mode,
+        targetLayerCount: aiTransformTarget.layerCount,
+        targetIncludesBaseLayer: aiTransformTarget.includesBaseLayer,
+        aiResultLayerId: layers.aiResultLayer?.id ?? null,
+        aiResultLayerName: layers.aiResultLayer?.name ?? null,
+    };
+}
+
+export function readEditorTimelineMetadata(metadata: Record<string, unknown>): EditorTimelineMetadata {
+    return {
+        editPrompt: readEditorLineageEditPrompt(metadata),
+        editorAdjustment: readEditorLineageAdjustment(metadata),
+        layers: readEditorLineageLayers(metadata),
+        aiTransformTarget: readEditorLineageAiTransformTarget(metadata),
+    };
+}
+
+export function readEditorLineageEditPrompt(metadata: Record<string, unknown>): string | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+
+    return normalizeString(aiEdit?.prompt) ?? normalizeString(metadata.editPrompt);
+}
+
+export function readEditorLineageAdjustment(metadata: Record<string, unknown>): EditorLineageAdjustment | null {
+    return readAdjustment(metadata.editorAdjustment) ?? readAdjustment(metadata.editorAdjustments);
+}
+
+export function readEditorLineageImageModel(metadata: Record<string, unknown>): EditorLineageImageModel | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+    const imageModel = asRecord(aiEdit?.imageModel);
+    if (imageModel && isImageModelSlug(imageModel.slug)) {
+        return {
+            slug: imageModel.slug,
+        };
+    }
+
+    return isImageModelSlug(metadata.model)
+        ? { slug: metadata.model }
+        : null;
+}
+
+export function readEditorLineageLayers(metadata: Record<string, unknown>): EditorLineageLayers {
+    const layers = asRecord(metadata.layers);
+
+    return {
+        layered: asBoolean(layers?.layered) ?? metadata.isLayered === true,
+        count: asFiniteNumber(layers?.count) ?? asFiniteNumber(metadata.layerCount),
+        visibleCount: asFiniteNumber(layers?.visibleCount) ?? asFiniteNumber(metadata.visibleLayerCount),
+        aiResultLayer: readAiResultLayer(layers?.aiResultLayer)
+            ?? readAiResultLayer({
+                id: metadata.aiResultLayerId,
+                name: metadata.aiResultLayerName,
+            }),
+    };
+}
+
+export function readEditorLineageAiTransformTarget(metadata: Record<string, unknown>): EditorLineageAiTransformTarget {
+    const aiEdit = asRecord(metadata.aiEdit);
+    const transformTarget = asRecord(aiEdit?.transformTarget);
+
+    return {
+        mode: normalizeTargetMode(transformTarget?.mode) ?? normalizeTargetMode(metadata.targetMode),
+        layerCount: asFiniteNumber(transformTarget?.layerCount) ?? asFiniteNumber(metadata.targetLayerCount),
+        includesBaseLayer: asBoolean(transformTarget?.includesBaseLayer) ?? asBoolean(metadata.targetIncludesBaseLayer),
+    };
+}
+
+function buildEditorAdjustment(adjustments: EditorAdjustments): EditorLineageAdjustment {
+    return {
+        brightness: adjustments.brightness,
+        contrast: adjustments.contrast,
+        saturation: adjustments.saturation,
+        filter: adjustments.filter,
+    };
+}
+
+function buildEditorLayers(input: {
+    layerStack?: ArchiveLayerStack | null;
+    aiResultLayerId: string | null;
+    aiResultLayerName: string | null;
+}): EditorLineageLayers {
+    const aiResultLayer = input.aiResultLayerId || input.aiResultLayerName
+        ? {
+            id: input.aiResultLayerId,
+            name: input.aiResultLayerName,
+        }
+        : null;
+
+    return {
+        layered: !!input.layerStack && input.layerStack.layers.some((layer) => layer.kind !== 'base'),
+        count: input.layerStack?.layers.length ?? null,
+        visibleCount: input.layerStack?.layers.filter((layer) => layer.visible).length ?? null,
+        aiResultLayer,
+    };
+}
+
+function buildEditorLineageImageModel(model: string | null): EditorLineageImageModel | null {
+    return isImageModelSlug(model)
+        ? { slug: model }
+        : null;
+}
+
+function readAdjustment(value: unknown): EditorLineageAdjustment | null {
+    const adjustment = asRecord(value);
+    if (!adjustment) {
+        return null;
+    }
+
+    return {
+        brightness: asFiniteNumber(adjustment.brightness) ?? 100,
+        contrast: asFiniteNumber(adjustment.contrast) ?? 100,
+        saturation: asFiniteNumber(adjustment.saturation) ?? 100,
+        filter: normalizeString(adjustment.filter) ?? 'none',
+    };
+}
+
+function readAiResultLayer(value: unknown): EditorLineageAiResultLayerFact | null {
+    const layer = asRecord(value);
+    if (!layer) {
+        return null;
+    }
+
+    const id = normalizeString(layer.id);
+    const name = normalizeString(layer.name);
+
+    return id || name
+        ? { id, name }
+        : null;
+}
+
+function normalizeString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeTargetMode(value: unknown): EditorLineageTargetMode | null {
+    return value === 'whole-composition' || value === 'selected-layers' ? value : null;
+}
+
+function normalizeNullableNumber(value: unknown) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeNullableBoolean(value: unknown) {
+    return typeof value === 'boolean' ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+    return typeof value === 'boolean' ? value : null;
+}

--- a/src/lineage/generateLineageMetadata.ts
+++ b/src/lineage/generateLineageMetadata.ts
@@ -1,0 +1,158 @@
+import type { ArchiveImage } from '../db/types';
+import {
+    buildImageModelArchiveFields,
+    sanitizeArchiveImageModelControls,
+    sanitizeImageModelControls,
+    type GptImage2Controls,
+    type NanoBananaProControls,
+} from '../image-models/ImageModelControls';
+import {
+    DEFAULT_IMAGE_MODEL,
+    NANO_BANANA_PRO_IMAGE_MODEL,
+    OPENAI_IMAGE_MODEL,
+    isImageModelSlug,
+    type ImageModelSlug,
+} from '../utils/openaiModels';
+
+export interface GenerateLineageDimensions {
+    width: number;
+    height: number;
+}
+
+export interface GenerateLineageReferenceImages {
+    count: number;
+    ids: string[];
+}
+
+export type GenerateLineageImageModel =
+    | {
+        slug: typeof OPENAI_IMAGE_MODEL;
+        controls: GptImage2Controls;
+    }
+    | {
+        slug: typeof NANO_BANANA_PRO_IMAGE_MODEL;
+        controls: NanoBananaProControls;
+    };
+
+export interface GenerateLineageMetadata extends Record<string, unknown> {
+    prompt: string;
+    model: ImageModelSlug;
+    imageModel: GenerateLineageImageModel;
+    dimensions: GenerateLineageDimensions;
+    quality: string;
+    aspectRatio: string;
+    background: string;
+    width: number;
+    height: number;
+    imageSize: string | null;
+    style: string;
+    lighting: string;
+    palette: string;
+    sourceArchiveImageId: string | null;
+    referenceImages: GenerateLineageReferenceImages;
+    referenceCount: number;
+    referenceIds: string[];
+}
+
+export function buildGenerateLineageMetadata(input: {
+    image: ArchiveImage;
+    sourceArchiveImageId: string | null;
+}): GenerateLineageMetadata {
+    const model = isImageModelSlug(input.image.model) ? input.image.model : DEFAULT_IMAGE_MODEL;
+    const controls = sanitizeArchiveImageModelControls(model, input.image);
+    const archiveFields = buildImageModelArchiveFields(model, controls);
+    const width = input.image.width ?? archiveFields.width;
+    const height = input.image.height ?? archiveFields.height;
+    const referenceIds = (input.image.references ?? []).map((_, index) => createReferenceId(input.image.id, index));
+
+    return {
+        prompt: input.image.prompt,
+        model,
+        imageModel: buildGenerateLineageImageModel(model, controls),
+        dimensions: {
+            width,
+            height,
+        },
+        quality: archiveFields.quality,
+        aspectRatio: archiveFields.aspectRatio,
+        background: archiveFields.background,
+        width,
+        height,
+        imageSize: model === NANO_BANANA_PRO_IMAGE_MODEL ? archiveFields.quality : null,
+        style: input.image.style ?? 'none',
+        lighting: input.image.lighting ?? 'none',
+        palette: input.image.palette ?? 'none',
+        sourceArchiveImageId: input.sourceArchiveImageId,
+        referenceImages: {
+            count: referenceIds.length,
+            ids: referenceIds,
+        },
+        referenceCount: referenceIds.length,
+        referenceIds,
+    };
+}
+
+export function readGenerateLineageImageModel(metadata: Record<string, unknown>): GenerateLineageImageModel | null {
+    const imageModel = asRecord(metadata.imageModel);
+    if (!imageModel || !isImageModelSlug(imageModel.slug)) {
+        return null;
+    }
+
+    return buildGenerateLineageImageModel(
+        imageModel.slug,
+        sanitizeImageModelControls(imageModel.slug, imageModel.controls),
+    );
+}
+
+export function readGenerateLineageReferenceCount(metadata: Record<string, unknown>): number {
+    const referenceImages = asRecord(metadata.referenceImages);
+    const typedCount = asFiniteNumber(referenceImages?.count);
+    if (typedCount !== null) {
+        return typedCount;
+    }
+
+    return asFiniteNumber(metadata.referenceCount) ?? 0;
+}
+
+function buildGenerateLineageImageModel(
+    model: typeof OPENAI_IMAGE_MODEL,
+    controls: GptImage2Controls,
+): GenerateLineageImageModel;
+function buildGenerateLineageImageModel(
+    model: typeof NANO_BANANA_PRO_IMAGE_MODEL,
+    controls: NanoBananaProControls,
+): GenerateLineageImageModel;
+function buildGenerateLineageImageModel(
+    model: ImageModelSlug,
+    controls: GptImage2Controls | NanoBananaProControls,
+): GenerateLineageImageModel;
+function buildGenerateLineageImageModel(
+    model: ImageModelSlug,
+    controls: GptImage2Controls | NanoBananaProControls,
+): GenerateLineageImageModel {
+    if (model === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return {
+            slug: model,
+            controls: sanitizeImageModelControls(model, controls),
+        };
+    }
+
+    return {
+        slug: model,
+        controls: sanitizeImageModelControls(model, controls),
+    };
+}
+
+function createReferenceId(archiveImageId: string, index: number) {
+    return `${archiveImageId}:reference:${index}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -1,0 +1,252 @@
+import { isImageModelSlug, isReasoningModelSlug } from '../utils/openaiModels';
+import type { LineageStepType } from './types';
+
+export function parseLineageMetadata(
+    stepType: LineageStepType,
+    metadata: Record<string, unknown>,
+): Record<string, unknown> {
+    switch (stepType) {
+        case 'generation':
+        case 'reference-generation':
+            validateGenerateMetadata(metadata);
+            return metadata;
+        case 'ai-edit':
+        case 'manual-edit':
+        case 'overwrite':
+        case 'save-as-copy':
+            validateEditorMetadata(metadata);
+            return metadata;
+        case 'autopilot-iteration':
+            validateAutopilotMetadata(metadata);
+            return metadata;
+    }
+}
+
+function validateGenerateMetadata(metadata: Record<string, unknown>) {
+    validateImageModel(metadata.imageModel);
+    validateDimensions(metadata.dimensions);
+    validateReferenceImages(metadata.referenceImages);
+}
+
+function validateEditorMetadata(metadata: Record<string, unknown>) {
+    validateArchiveImageFact(metadata.sourceImage);
+    validateArchiveImageFact(metadata.outputImage);
+    validateEditorSave(metadata.save);
+    validateEditorAdjustment(metadata.editorAdjustment);
+    validateEditorAiEdit(metadata.aiEdit);
+    validateEditorLayers(metadata.layers);
+}
+
+function validateAutopilotMetadata(metadata: Record<string, unknown>) {
+    validateStringRecordValue(metadata.goal, 'text');
+    validateNumberRecordValue(metadata.iteration, 'number');
+    validateEvaluation(metadata.evaluation);
+    validateStringRecordValue(metadata.replayImage, 'dataUrl');
+    validateStringRecordValue(metadata.run, 'label');
+    validateReasoningModel(metadata.reasoningModel);
+    validateImageModel(metadata.imageModel);
+    validateDimensions(metadata.dimensions);
+}
+
+function validateImageModel(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const imageModel = requireRecord(value, 'lineage imageModel');
+    if (!isImageModelSlug(imageModel.slug)) {
+        throw new Error('Invalid lineage imageModel slug');
+    }
+
+    if (imageModel.controls !== undefined) {
+        requireRecord(imageModel.controls, 'lineage imageModel controls');
+    }
+}
+
+function validateDimensions(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const dimensions = requireRecord(value, 'lineage dimensions');
+    requireFiniteNumber(dimensions.width, 'lineage dimensions width');
+    requireFiniteNumber(dimensions.height, 'lineage dimensions height');
+}
+
+function validateReferenceImages(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const referenceImages = requireRecord(value, 'lineage referenceImages');
+    requireFiniteNumber(referenceImages.count, 'lineage referenceImages count');
+    if (!Array.isArray(referenceImages.ids) || !referenceImages.ids.every((id) => typeof id === 'string')) {
+        throw new Error('Invalid lineage referenceImages ids');
+    }
+}
+
+function validateArchiveImageFact(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    validateStringRecordValue(value, 'archiveImageId');
+}
+
+function validateEditorSave(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const save = requireRecord(value, 'lineage save');
+    requireBoolean(save.overwrite, 'lineage save overwrite');
+    requireBoolean(save.copy, 'lineage save copy');
+}
+
+function validateEditorAdjustment(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const adjustment = requireRecord(value, 'lineage editorAdjustment');
+    requireFiniteNumber(adjustment.brightness, 'lineage editorAdjustment brightness');
+    requireFiniteNumber(adjustment.contrast, 'lineage editorAdjustment contrast');
+    requireFiniteNumber(adjustment.saturation, 'lineage editorAdjustment saturation');
+    requireString(adjustment.filter, 'lineage editorAdjustment filter');
+}
+
+function validateEditorAiEdit(value: unknown) {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    const aiEdit = requireRecord(value, 'lineage aiEdit');
+    requireString(aiEdit.prompt, 'lineage aiEdit prompt');
+    if (aiEdit.imageModel !== undefined && aiEdit.imageModel !== null) {
+        const imageModel = requireRecord(aiEdit.imageModel, 'lineage aiEdit imageModel');
+        if (!isImageModelSlug(imageModel.slug)) {
+            throw new Error('Invalid lineage aiEdit imageModel slug');
+        }
+    }
+    if (aiEdit.referenceImages !== undefined) {
+        const referenceImages = requireRecord(aiEdit.referenceImages, 'lineage aiEdit referenceImages');
+        requireFiniteNumber(referenceImages.count, 'lineage aiEdit referenceImages count');
+    }
+    validateEditorTransformTarget(aiEdit.transformTarget);
+}
+
+function validateEditorTransformTarget(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const transformTarget = requireRecord(value, 'lineage transformTarget');
+    if (
+        transformTarget.mode !== null
+        && transformTarget.mode !== 'whole-composition'
+        && transformTarget.mode !== 'selected-layers'
+    ) {
+        throw new Error('Invalid lineage transformTarget mode');
+    }
+    if (transformTarget.layerCount !== null) {
+        requireFiniteNumber(transformTarget.layerCount, 'lineage transformTarget layerCount');
+    }
+    if (transformTarget.includesBaseLayer !== null) {
+        requireBoolean(transformTarget.includesBaseLayer, 'lineage transformTarget includesBaseLayer');
+    }
+}
+
+function validateEditorLayers(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const layers = requireRecord(value, 'lineage layers');
+    requireBoolean(layers.layered, 'lineage layers layered');
+    if (layers.count !== null) {
+        requireFiniteNumber(layers.count, 'lineage layers count');
+    }
+    if (layers.visibleCount !== null) {
+        requireFiniteNumber(layers.visibleCount, 'lineage layers visibleCount');
+    }
+    if (layers.aiResultLayer !== null && layers.aiResultLayer !== undefined) {
+        const aiResultLayer = requireRecord(layers.aiResultLayer, 'lineage layers aiResultLayer');
+        if (aiResultLayer.id !== null) {
+            requireString(aiResultLayer.id, 'lineage layers aiResultLayer id');
+        }
+        if (aiResultLayer.name !== null) {
+            requireString(aiResultLayer.name, 'lineage layers aiResultLayer name');
+        }
+    }
+}
+
+function validateEvaluation(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const evaluation = requireRecord(value, 'lineage evaluation');
+    requireFiniteNumber(evaluation.score, 'lineage evaluation score');
+    if (!Array.isArray(evaluation.feedback) || !evaluation.feedback.every((entry) => typeof entry === 'string')) {
+        throw new Error('Invalid lineage evaluation feedback');
+    }
+}
+
+function validateReasoningModel(value: unknown) {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    if (typeof value === 'string' && isReasoningModelSlug(value)) {
+        return;
+    }
+
+    const reasoningModel = requireRecord(value, 'lineage reasoningModel');
+    if (!isReasoningModelSlug(reasoningModel.slug)) {
+        throw new Error('Invalid lineage reasoningModel slug');
+    }
+}
+
+function validateStringRecordValue(value: unknown, key: string) {
+    if (value === undefined) {
+        return;
+    }
+
+    const record = requireRecord(value, `lineage ${key}`);
+    requireString(record[key], `lineage ${key}`);
+}
+
+function validateNumberRecordValue(value: unknown, key: string) {
+    if (value === undefined) {
+        return;
+    }
+
+    const record = requireRecord(value, `lineage ${key}`);
+    requireFiniteNumber(record[key], `lineage ${key}`);
+}
+
+function requireRecord(value: unknown, label: string) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string) {
+    if (typeof value !== 'string') {
+        throw new Error(`Invalid ${label}`);
+    }
+}
+
+function requireFiniteNumber(value: unknown, label: string) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(`Invalid ${label}`);
+    }
+}
+
+function requireBoolean(value: unknown, label: string) {
+    if (typeof value !== 'boolean') {
+        throw new Error(`Invalid ${label}`);
+    }
+}

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -163,11 +163,14 @@ describe('loadLineageTimeline', () => {
             stepType: 'autopilot-iteration',
             timestamp: '2026-04-04T08:00:00.000Z',
             metadata: {
-                goalText: 'A moody editorial portrait with electric blue haze',
-                iterationNumber: 1,
-                evaluatorScore: 84,
-                evaluatorFeedback: ['Push the rim light harder.'],
-                outputImageDataUrl: 'data:image/png;base64,auto1',
+                goal: { text: 'A moody editorial portrait with electric blue haze' },
+                iteration: { number: 1 },
+                evaluation: {
+                    score: 84,
+                    feedback: ['Push the rim light harder.'],
+                },
+                replayImage: { dataUrl: 'data:image/png;base64,auto1' },
+                run: { label: 'Autopilot Run · A moody editorial portrait with ele...' },
             },
         });
         const savedStep = createStep({
@@ -208,6 +211,37 @@ describe('loadLineageTimeline', () => {
                 id: 'saved-1',
                 stepType: 'generation',
                 runLabel: null,
+            }),
+        ]);
+    });
+
+    it('summarizes sparse legacy autopilot metadata safely', async () => {
+        const timeline = await loadLineageTimeline('autopilot:legacy:iteration:1', createStore({
+            byArchiveImageId: {
+                'autopilot:legacy:iteration:1': [createStep({
+                    id: 'auto-legacy',
+                    archiveImageId: 'autopilot:legacy:iteration:1',
+                    stepType: 'autopilot-iteration',
+                    timestamp: '2026-04-04T08:00:00.000Z',
+                    metadata: {},
+                })],
+            },
+            byId: {},
+            children: {
+                'auto-legacy': [],
+            },
+        }));
+
+        expect(timeline.entries).toEqual([
+            expect.objectContaining({
+                id: 'auto-legacy',
+                summary: 'Autopilot iteration recorded',
+                goalText: null,
+                iterationNumber: null,
+                evaluatorScore: null,
+                evaluatorFeedback: [],
+                replayImageDataUrl: null,
+                runLabel: 'Autopilot Run',
             }),
         ]);
     });

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -254,6 +254,45 @@ describe('loadLineageTimeline', () => {
             'AI edit: replace the sky · targeted 1 layer · result: AI result',
         ]);
     });
+
+    it('summarizes typed Generate reference metadata and preserves older sparse fallbacks', async () => {
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [
+                    createStep({
+                        id: 'step-typed',
+                        archiveImageId: 'image-1',
+                        stepType: 'reference-generation',
+                        timestamp: '2026-04-04T09:00:00.000Z',
+                        metadata: {
+                            prompt: 'lantern-lit greenhouse',
+                            referenceImages: {
+                                count: 2,
+                                ids: ['image-1:reference:0', 'image-1:reference:1'],
+                            },
+                        },
+                    }),
+                    createStep({
+                        id: 'step-old',
+                        archiveImageId: 'image-1',
+                        stepType: 'generation',
+                        timestamp: '2026-04-04T10:00:00.000Z',
+                        metadata: {},
+                    }),
+                ],
+            },
+            byId: {},
+            children: {
+                'step-typed': [],
+                'step-old': [],
+            },
+        }));
+
+        expect(timeline.entries.map((entry) => entry.summary)).toEqual([
+            'Prompt: lantern-lit greenhouse with 2 references',
+            'Generated from saved settings',
+        ]);
+    });
 });
 
 function createStore(data: {

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -289,6 +289,86 @@ describe('loadLineageTimeline', () => {
         ]);
     });
 
+    it('summarizes typed Editor metadata without legacy flat fields', async () => {
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [
+                    createStep({
+                        id: 'step-1',
+                        archiveImageId: 'image-1',
+                        stepType: 'overwrite',
+                        timestamp: '2026-04-04T09:00:00.000Z',
+                        metadata: {
+                            editorAdjustment: {
+                                brightness: 115,
+                                contrast: 100,
+                                saturation: 125,
+                                filter: 'sepia(100%)',
+                            },
+                        },
+                    }),
+                    createStep({
+                        id: 'step-2',
+                        archiveImageId: 'image-1',
+                        stepType: 'save-as-copy',
+                        timestamp: '2026-04-04T09:30:00.000Z',
+                        metadata: {
+                            layers: {
+                                layered: true,
+                                count: 3,
+                                visibleCount: 2,
+                                aiResultLayer: null,
+                            },
+                        },
+                    }),
+                    createStep({
+                        id: 'step-3',
+                        archiveImageId: 'image-1',
+                        stepType: 'ai-edit',
+                        timestamp: '2026-04-04T10:00:00.000Z',
+                        metadata: {
+                            aiEdit: {
+                                prompt: 'replace the sky',
+                                imageModel: {
+                                    slug: 'gpt-image-2',
+                                },
+                                referenceImages: {
+                                    count: 2,
+                                },
+                                transformTarget: {
+                                    mode: 'selected-layers',
+                                    layerCount: 1,
+                                    includesBaseLayer: false,
+                                },
+                            },
+                            layers: {
+                                layered: true,
+                                count: 3,
+                                visibleCount: 2,
+                                aiResultLayer: {
+                                    id: 'ai-layer',
+                                    name: 'AI result',
+                                },
+                            },
+                        },
+                    }),
+                ],
+            },
+            byId: {},
+            children: {
+                'step-1': [],
+                'step-2': [],
+                'step-3': [],
+            },
+        }));
+
+        expect(timeline.entries.map((entry) => entry.summary)).toEqual([
+            'Adjusted brightness, saturation, filter',
+            'Saved layered copy · 3 layers · 2 visible',
+            'AI edit: replace the sky · targeted 1 layer · result: AI result',
+        ]);
+    });
+
     it('summarizes typed Generate reference metadata and preserves older sparse fallbacks', async () => {
         const timeline = await loadLineageTimeline('image-1', createStore({
             byArchiveImageId: {

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -1,5 +1,11 @@
 import type { LineageStore, LineageStep } from './LineageStore';
 import { readAutopilotTimelineMetadata, type AutopilotTimelineMetadata } from './autopilotLineageMetadata';
+import {
+    readEditorTimelineMetadata,
+    type EditorLineageAdjustment,
+    type EditorLineageLayers,
+    type EditorTimelineMetadata,
+} from './editorLineageMetadata';
 import { readGenerateLineageReferenceCount } from './generateLineageMetadata';
 
 export interface LineageTimelineEntry {
@@ -151,8 +157,8 @@ function getStepLabel(step: LineageStep) {
 function getStepSummary(step: LineageStep) {
     const metadata = step.metadata;
     const prompt = excerpt(asString(metadata.prompt));
-    const editPrompt = excerpt(asString(metadata.editPrompt));
     const referenceCount = readGenerateLineageReferenceCount(metadata);
+    const editorMetadata = readEditorTimelineMetadata(metadata);
 
     switch (step.stepType) {
         case 'generation':
@@ -164,27 +170,32 @@ function getStepSummary(step: LineageStep) {
 
             return prompt ? `Prompt: ${prompt}` : 'Generated from saved references';
         case 'ai-edit':
-            return summarizeLayeredAiEdit(metadata, editPrompt);
+            return summarizeLayeredAiEdit(editorMetadata);
         case 'manual-edit':
-            return summarizeAdjustments(metadata.editorAdjustments) ?? 'Manual adjustments applied';
+            return summarizeAdjustments(editorMetadata.editorAdjustment) ?? 'Manual adjustments applied';
         case 'overwrite':
-            return summarizeLayeredSave(metadata, 'Saved layered image') ?? summarizeAdjustments(metadata.editorAdjustments) ?? 'Saved over current image';
+            return summarizeLayeredSave(editorMetadata.layers, 'Saved layered image')
+                ?? summarizeAdjustments(editorMetadata.editorAdjustment)
+                ?? 'Saved over current image';
         case 'save-as-copy':
-            return summarizeLayeredSave(metadata, 'Saved layered copy') ?? summarizeAdjustments(metadata.editorAdjustments) ?? 'Branched from previous version';
+            return summarizeLayeredSave(editorMetadata.layers, 'Saved layered copy')
+                ?? summarizeAdjustments(editorMetadata.editorAdjustment)
+                ?? 'Branched from previous version';
         case 'autopilot-iteration':
             return summarizeAutopilot(readAutopilotTimelineMetadata(metadata));
     }
 }
 
-function summarizeLayeredAiEdit(metadata: Record<string, unknown>, editPrompt: string | null) {
+function summarizeLayeredAiEdit(metadata: EditorTimelineMetadata) {
+    const editPrompt = excerpt(metadata.editPrompt);
     const base = editPrompt ? `AI edit: ${editPrompt}` : 'AI edit applied';
-    if (metadata.isLayered !== true) {
+    if (!metadata.layers.layered) {
         return base;
     }
 
-    const targetMode = asString(metadata.targetMode);
-    const targetLayerCount = asNumberOrNull(metadata.targetLayerCount);
-    const aiResultLayerName = excerpt(asString(metadata.aiResultLayerName), 32);
+    const targetMode = metadata.aiTransformTarget.mode;
+    const targetLayerCount = metadata.aiTransformTarget.layerCount;
+    const aiResultLayerName = excerpt(metadata.layers.aiResultLayer?.name ?? null, 32);
     const parts = [
         base,
         targetMode === 'selected-layers' && targetLayerCount !== null ? `targeted ${targetLayerCount} layer${targetLayerCount === 1 ? '' : 's'}` : 'whole composition',
@@ -194,13 +205,13 @@ function summarizeLayeredAiEdit(metadata: Record<string, unknown>, editPrompt: s
     return parts.join(' · ');
 }
 
-function summarizeLayeredSave(metadata: Record<string, unknown>, fallback: string) {
-    if (metadata.isLayered !== true) {
+function summarizeLayeredSave(metadata: EditorLineageLayers, fallback: string) {
+    if (!metadata.layered) {
         return null;
     }
 
-    const layerCount = asNumberOrNull(metadata.layerCount);
-    const visibleLayerCount = asNumberOrNull(metadata.visibleLayerCount);
+    const layerCount = metadata.count;
+    const visibleLayerCount = metadata.visibleCount;
     const parts = [
         fallback,
         layerCount !== null ? `${layerCount} layer${layerCount === 1 ? '' : 's'}` : null,
@@ -221,12 +232,11 @@ function summarizeAutopilot(metadata: AutopilotTimelineMetadata) {
     return parts.length > 0 ? parts.join(' · ') : 'Autopilot iteration recorded';
 }
 
-function summarizeAdjustments(value: unknown) {
-    if (!value || typeof value !== 'object') {
+function summarizeAdjustments(adjustments: EditorLineageAdjustment | null) {
+    if (!adjustments) {
         return null;
     }
 
-    const adjustments = value as Record<string, unknown>;
     const changed: string[] = [];
 
     if (adjustments.brightness !== 100) {
@@ -264,8 +274,4 @@ function excerpt(value: string | null, maxLength: number = 72) {
 
 function asString(value: unknown) {
     return typeof value === 'string' && value.trim() ? value : null;
-}
-
-function asNumberOrNull(value: unknown) {
-    return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -1,4 +1,5 @@
 import type { LineageStore, LineageStep } from './LineageStore';
+import { readAutopilotTimelineMetadata, type AutopilotTimelineMetadata } from './autopilotLineageMetadata';
 import { readGenerateLineageReferenceCount } from './generateLineageMetadata';
 
 export interface LineageTimelineEntry {
@@ -99,6 +100,8 @@ async function countDescendants(steps: LineageStep[], store: Pick<LineageStore, 
 }
 
 function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
+    const autopilotMetadata = getAutopilotTimelineMetadata(step);
+
     return {
         id: step.id,
         archiveImageId: step.archiveImageId,
@@ -106,13 +109,19 @@ function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
         label: getStepLabel(step),
         summary: getStepSummary(step),
         timestamp: step.timestamp,
-        goalText: asString(step.metadata.goalText),
-        iterationNumber: asNumberOrNull(step.metadata.iterationNumber),
-        evaluatorScore: asNumberOrNull(step.metadata.evaluatorScore),
-        evaluatorFeedback: asStringArray(step.metadata.evaluatorFeedback),
-        replayImageDataUrl: asString(step.metadata.outputImageDataUrl),
-        runLabel: getRunLabel(step),
+        goalText: autopilotMetadata?.goalText ?? null,
+        iterationNumber: autopilotMetadata?.iterationNumber ?? null,
+        evaluatorScore: autopilotMetadata?.evaluatorScore ?? null,
+        evaluatorFeedback: autopilotMetadata?.evaluatorFeedback ?? [],
+        replayImageDataUrl: autopilotMetadata?.replayImageDataUrl ?? null,
+        runLabel: autopilotMetadata?.runLabel ?? null,
     };
+}
+
+function getAutopilotTimelineMetadata(step: LineageStep): AutopilotTimelineMetadata | null {
+    return step.stepType === 'autopilot-iteration'
+        ? readAutopilotTimelineMetadata(step.metadata)
+        : null;
 }
 
 function summarizeParent(step: LineageStep) {
@@ -163,7 +172,7 @@ function getStepSummary(step: LineageStep) {
         case 'save-as-copy':
             return summarizeLayeredSave(metadata, 'Saved layered copy') ?? summarizeAdjustments(metadata.editorAdjustments) ?? 'Branched from previous version';
         case 'autopilot-iteration':
-            return summarizeAutopilot(metadata);
+            return summarizeAutopilot(readAutopilotTimelineMetadata(metadata));
     }
 }
 
@@ -201,26 +210,15 @@ function summarizeLayeredSave(metadata: Record<string, unknown>, fallback: strin
     return parts.length > 1 ? parts.join(' · ') : fallback;
 }
 
-function summarizeAutopilot(metadata: Record<string, unknown>) {
-    const iterationNumber = asNumberOrNull(metadata.iterationNumber);
-    const score = asNumberOrNull(metadata.evaluatorScore);
-    const goalText = excerpt(asString(metadata.goalText), 56);
+function summarizeAutopilot(metadata: AutopilotTimelineMetadata) {
+    const goalText = excerpt(metadata.goalText, 56);
     const parts = [
-        iterationNumber !== null ? `Iteration ${iterationNumber}` : null,
-        score !== null ? `score ${score}` : null,
+        metadata.iterationNumber !== null ? `Iteration ${metadata.iterationNumber}` : null,
+        metadata.evaluatorScore !== null ? `score ${metadata.evaluatorScore}` : null,
         goalText ? `goal: ${goalText}` : null,
     ].filter(Boolean);
 
     return parts.length > 0 ? parts.join(' · ') : 'Autopilot iteration recorded';
-}
-
-function getRunLabel(step: LineageStep) {
-    if (step.stepType !== 'autopilot-iteration') {
-        return null;
-    }
-
-    const goalText = excerpt(asString(step.metadata.goalText), 36);
-    return goalText ? `Autopilot Run · ${goalText}` : 'Autopilot Run';
 }
 
 function summarizeAdjustments(value: unknown) {
@@ -270,10 +268,4 @@ function asString(value: unknown) {
 
 function asNumberOrNull(value: unknown) {
     return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function asStringArray(value: unknown) {
-    return Array.isArray(value)
-        ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
-        : [];
 }

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -1,4 +1,5 @@
 import type { LineageStore, LineageStep } from './LineageStore';
+import { readGenerateLineageReferenceCount } from './generateLineageMetadata';
 
 export interface LineageTimelineEntry {
     id: string;
@@ -142,7 +143,7 @@ function getStepSummary(step: LineageStep) {
     const metadata = step.metadata;
     const prompt = excerpt(asString(metadata.prompt));
     const editPrompt = excerpt(asString(metadata.editPrompt));
-    const referenceCount = asNumber(metadata.referenceCount);
+    const referenceCount = readGenerateLineageReferenceCount(metadata);
 
     switch (step.stepType) {
         case 'generation':
@@ -265,10 +266,6 @@ function excerpt(value: string | null, maxLength: number = 72) {
 
 function asString(value: unknown) {
     return typeof value === 'string' && value.trim() ? value : null;
-}
-
-function asNumber(value: unknown) {
-    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 function asNumberOrNull(value: unknown) {

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ArchiveImage } from '../db/types';
 import type { LineageStep } from './LineageStore';
 import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
 describe('replayLineageStep', () => {
     it('hydrates a generate draft from lineage metadata and preserves an exact fork source', () => {
@@ -120,6 +121,80 @@ describe('replayLineageStep', () => {
                 imageSize: '4K',
             },
             style: 'isometric diorama',
+        });
+    });
+
+    it('hydrates generate replay from typed Generate lineage metadata without flat legacy fields', () => {
+        const step = createStep({
+            id: 'step-typed',
+            archiveImageId: 'image-typed',
+            stepType: 'generation',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'wide botanical observatory under glass',
+                imageModel: {
+                    slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                    controls: {
+                        aspectRatio: '21:9',
+                        imageSize: '2K',
+                    },
+                },
+                dimensions: {
+                    width: 2048,
+                    height: 878,
+                },
+                sourceArchiveImageId: null,
+                referenceImages: {
+                    count: 0,
+                    ids: [],
+                },
+                style: 'architectural model',
+            },
+        });
+
+        expect(buildGenerateReplay(null, step).draft).toMatchObject({
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            prompt: 'wide botanical observatory under glass',
+            nanoBananaPro: {
+                aspectRatio: '21:9',
+                imageSize: '2K',
+            },
+            gptImage2: {
+                quality: 'medium',
+                size: '1024x1024',
+                background: 'auto',
+            },
+            style: 'architectural model',
+            isSaved: false,
+        });
+    });
+
+    it('falls back to archive image controls for older sparse Generate metadata', () => {
+        const image = createImage({
+            model: OPENAI_IMAGE_MODEL,
+            quality: 'low',
+            aspectRatio: '1024x1536',
+            background: 'opaque',
+        });
+        const step = createStep({
+            id: 'step-old',
+            archiveImageId: 'image-old',
+            stepType: 'generation',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'legacy record',
+            },
+        });
+
+        expect(buildGenerateReplay(image, step).draft).toMatchObject({
+            model: OPENAI_IMAGE_MODEL,
+            prompt: 'legacy record',
+            gptImage2: {
+                quality: 'low',
+                size: '1024x1536',
+                background: 'opaque',
+            },
+            isSaved: false,
         });
     });
 });

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -98,6 +98,76 @@ describe('replayLineageStep', () => {
         });
     });
 
+    it('hydrates a generate draft from typed autopilot image model metadata', () => {
+        const step = createStep({
+            id: 'step-auto-typed',
+            archiveImageId: 'autopilot:run:iteration:3',
+            stepType: 'autopilot-iteration',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'editorial portrait, deep blue haze, dramatic rim light',
+                imageModel: {
+                    slug: OPENAI_IMAGE_MODEL,
+                    controls: {
+                        quality: 'high',
+                        size: '1536x1024',
+                        background: 'transparent',
+                    },
+                },
+                style: '35mm film still',
+                lighting: 'neon rim light',
+                palette: 'cobalt + vermilion + bone',
+            },
+        });
+
+        expect(buildGenerateReplay(null, step)).toEqual({
+            draft: {
+                model: OPENAI_IMAGE_MODEL,
+                prompt: 'editorial portrait, deep blue haze, dramatic rim light',
+                style: '35mm film still',
+                lighting: 'neon rim light',
+                palette: 'cobalt + vermilion + bone',
+                gptImage2: {
+                    quality: 'high',
+                    size: '1536x1024',
+                    background: 'transparent',
+                },
+                nanoBananaPro: {
+                    aspectRatio: '1:1',
+                    imageSize: '1K',
+                },
+                isSaved: false,
+            },
+            lineageSource: {
+                archiveImageId: 'autopilot:run:iteration:3',
+                stepId: 'step-auto-typed',
+            },
+        });
+    });
+
+    it('replays sparse legacy autopilot metadata with Generate defaults', () => {
+        const step = createStep({
+            id: 'step-auto-legacy',
+            archiveImageId: 'autopilot:legacy:iteration:1',
+            stepType: 'autopilot-iteration',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                prompt: 'legacy autopilot prompt',
+            },
+        });
+
+        expect(buildGenerateReplay(null, step).draft).toMatchObject({
+            model: OPENAI_IMAGE_MODEL,
+            prompt: 'legacy autopilot prompt',
+            gptImage2: {
+                quality: 'medium',
+                size: '1024x1024',
+                background: 'auto',
+            },
+            isSaved: false,
+        });
+    });
+
     it('restores nano model controls from lineage metadata', () => {
         const step = createStep({
             id: 'step-nano',

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -3,6 +3,7 @@ import { DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft, type GenerateDraft, type
 import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug } from '../utils/openaiModels';
 import { sanitizeImageModelControls } from '../image-models/ImageModelControls';
 import type { LineageStep } from './LineageStore';
+import { readGenerateLineageImageModel } from './generateLineageMetadata';
 
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 
@@ -18,7 +19,8 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
     draft: GenerateDraft;
     lineageSource: GenerateLineageSource;
 } {
-    const model = resolveReplayModel(image, step);
+    const typedImageModel = readGenerateLineageImageModel(step.metadata);
+    const model = typedImageModel?.slug ?? resolveReplayModel(image, step);
     const replayAspectRatio = asString(step.metadata.aspectRatio) ?? image?.aspectRatio;
 
     return {
@@ -29,15 +31,12 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
             style: asString(step.metadata.style) ?? image?.style ?? 'none',
             lighting: asString(step.metadata.lighting) ?? image?.lighting ?? 'none',
             palette: asString(step.metadata.palette) ?? image?.palette ?? 'none',
-            gptImage2: model === OPENAI_IMAGE_MODEL ? sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
-                quality: step.metadata.quality ?? image?.quality,
-                size: replayAspectRatio,
-                background: step.metadata.background ?? image?.background,
-            }) : DEFAULT_GENERATE_DRAFT.gptImage2,
-            nanoBananaPro: model === NANO_BANANA_PRO_IMAGE_MODEL ? sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
-                aspectRatio: replayAspectRatio,
-                imageSize: step.metadata.imageSize ?? image?.quality,
-            }) : DEFAULT_GENERATE_DRAFT.nanoBananaPro,
+            gptImage2: model === OPENAI_IMAGE_MODEL
+                ? resolveGptImage2ReplayControls(typedImageModel, step, image, replayAspectRatio)
+                : DEFAULT_GENERATE_DRAFT.gptImage2,
+            nanoBananaPro: model === NANO_BANANA_PRO_IMAGE_MODEL
+                ? resolveNanoBananaReplayControls(typedImageModel, step, image, replayAspectRatio)
+                : DEFAULT_GENERATE_DRAFT.nanoBananaPro,
             isSaved: false,
         }),
         lineageSource: {
@@ -57,6 +56,39 @@ function resolveReplayModel(image: ArchiveImage | null, step: LineageStep) {
     }
 
     return DEFAULT_IMAGE_MODEL;
+}
+
+function resolveGptImage2ReplayControls(
+    typedImageModel: ReturnType<typeof readGenerateLineageImageModel>,
+    step: LineageStep,
+    image: ArchiveImage | null,
+    replayAspectRatio: string | undefined,
+) {
+    if (typedImageModel?.slug === OPENAI_IMAGE_MODEL) {
+        return typedImageModel.controls;
+    }
+
+    return sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+        quality: step.metadata.quality ?? image?.quality,
+        size: replayAspectRatio,
+        background: step.metadata.background ?? image?.background,
+    });
+}
+
+function resolveNanoBananaReplayControls(
+    typedImageModel: ReturnType<typeof readGenerateLineageImageModel>,
+    step: LineageStep,
+    image: ArchiveImage | null,
+    replayAspectRatio: string | undefined,
+) {
+    if (typedImageModel?.slug === NANO_BANANA_PRO_IMAGE_MODEL) {
+        return typedImageModel.controls;
+    }
+
+    return sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
+        aspectRatio: replayAspectRatio,
+        imageSize: step.metadata.imageSize ?? image?.quality,
+    });
 }
 
 function asString(value: unknown) {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -4,8 +4,23 @@ import { DEFAULT_IMAGE_MODEL, NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, i
 import { sanitizeImageModelControls } from '../image-models/ImageModelControls';
 import type { LineageStep } from './LineageStore';
 import { readGenerateLineageImageModel } from './generateLineageMetadata';
+import { readAutopilotGenerateReplayMetadata } from './autopilotLineageMetadata';
 
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
+type GenerateReplayImageModel = NonNullable<ReturnType<typeof readGenerateLineageImageModel>>;
+
+interface GenerateReplayMetadata {
+    imageModel: GenerateReplayImageModel | null;
+    model: ReturnType<typeof resolveReplayModel> | null;
+    prompt: string | null;
+    style: string | null;
+    lighting: string | null;
+    palette: string | null;
+    quality: unknown;
+    aspectRatio: string | null;
+    imageSize: unknown;
+    background: unknown;
+}
 
 export function isGenerateReplayable(step: ReplayableStep) {
     return step.stepType === 'generation' || step.stepType === 'reference-generation' || step.stepType === 'autopilot-iteration';
@@ -19,23 +34,26 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
     draft: GenerateDraft;
     lineageSource: GenerateLineageSource;
 } {
-    const typedImageModel = readGenerateLineageImageModel(step.metadata);
-    const model = typedImageModel?.slug ?? resolveReplayModel(image, step);
-    const replayAspectRatio = asString(step.metadata.aspectRatio) ?? image?.aspectRatio;
+    const replayMetadata = readGenerateReplayMetadata(step);
+    const typedImageModel = replayMetadata.imageModel;
+    const model = typedImageModel?.slug
+        ?? replayMetadata.model
+        ?? resolveReplayModel(image, step.stepType === 'autopilot-iteration' ? null : step);
+    const replayAspectRatio = replayMetadata.aspectRatio ?? image?.aspectRatio;
 
     return {
         draft: sanitizeGenerateDraft({
             ...DEFAULT_GENERATE_DRAFT,
             model,
-            prompt: asString(step.metadata.prompt) ?? image?.prompt ?? '',
-            style: asString(step.metadata.style) ?? image?.style ?? 'none',
-            lighting: asString(step.metadata.lighting) ?? image?.lighting ?? 'none',
-            palette: asString(step.metadata.palette) ?? image?.palette ?? 'none',
+            prompt: replayMetadata.prompt ?? image?.prompt ?? '',
+            style: replayMetadata.style ?? image?.style ?? 'none',
+            lighting: replayMetadata.lighting ?? image?.lighting ?? 'none',
+            palette: replayMetadata.palette ?? image?.palette ?? 'none',
             gptImage2: model === OPENAI_IMAGE_MODEL
-                ? resolveGptImage2ReplayControls(typedImageModel, step, image, replayAspectRatio)
+                ? resolveGptImage2ReplayControls(typedImageModel, replayMetadata, image, replayAspectRatio)
                 : DEFAULT_GENERATE_DRAFT.gptImage2,
             nanoBananaPro: model === NANO_BANANA_PRO_IMAGE_MODEL
-                ? resolveNanoBananaReplayControls(typedImageModel, step, image, replayAspectRatio)
+                ? resolveNanoBananaReplayControls(typedImageModel, replayMetadata, image, replayAspectRatio)
                 : DEFAULT_GENERATE_DRAFT.nanoBananaPro,
             isSaved: false,
         }),
@@ -46,8 +64,27 @@ export function buildGenerateReplay(image: ArchiveImage | null, step: LineageSte
     };
 }
 
-function resolveReplayModel(image: ArchiveImage | null, step: LineageStep) {
-    if (isImageModelSlug(step.metadata.model)) {
+function readGenerateReplayMetadata(step: LineageStep): GenerateReplayMetadata {
+    if (step.stepType === 'autopilot-iteration') {
+        return readAutopilotGenerateReplayMetadata(step.metadata);
+    }
+
+    return {
+        imageModel: readGenerateLineageImageModel(step.metadata),
+        model: isImageModelSlug(step.metadata.model) ? step.metadata.model : null,
+        prompt: asString(step.metadata.prompt),
+        style: asString(step.metadata.style),
+        lighting: asString(step.metadata.lighting),
+        palette: asString(step.metadata.palette),
+        quality: step.metadata.quality,
+        aspectRatio: asString(step.metadata.aspectRatio),
+        imageSize: step.metadata.imageSize,
+        background: step.metadata.background,
+    };
+}
+
+function resolveReplayModel(image: ArchiveImage | null, step: LineageStep | null) {
+    if (isImageModelSlug(step?.metadata.model)) {
         return step.metadata.model;
     }
 
@@ -59,8 +96,8 @@ function resolveReplayModel(image: ArchiveImage | null, step: LineageStep) {
 }
 
 function resolveGptImage2ReplayControls(
-    typedImageModel: ReturnType<typeof readGenerateLineageImageModel>,
-    step: LineageStep,
+    typedImageModel: GenerateReplayImageModel | null,
+    metadata: GenerateReplayMetadata,
     image: ArchiveImage | null,
     replayAspectRatio: string | undefined,
 ) {
@@ -69,15 +106,15 @@ function resolveGptImage2ReplayControls(
     }
 
     return sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
-        quality: step.metadata.quality ?? image?.quality,
+        quality: metadata.quality ?? image?.quality,
         size: replayAspectRatio,
-        background: step.metadata.background ?? image?.background,
+        background: metadata.background ?? image?.background,
     });
 }
 
 function resolveNanoBananaReplayControls(
-    typedImageModel: ReturnType<typeof readGenerateLineageImageModel>,
-    step: LineageStep,
+    typedImageModel: GenerateReplayImageModel | null,
+    metadata: GenerateReplayMetadata,
     image: ArchiveImage | null,
     replayAspectRatio: string | undefined,
 ) {
@@ -87,7 +124,7 @@ function resolveNanoBananaReplayControls(
 
     return sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
         aspectRatio: replayAspectRatio,
-        imageSize: step.metadata.imageSize ?? image?.quality,
+        imageSize: metadata.imageSize ?? image?.quality,
     });
 }
 

--- a/src/lineage/types.ts
+++ b/src/lineage/types.ts
@@ -1,3 +1,4 @@
+import type { AutopilotLineageMetadata } from './autopilotLineageMetadata';
 import type { GenerateLineageMetadata } from './generateLineageMetadata';
 
 export type LineageStepType =
@@ -22,6 +23,10 @@ export interface LineageStep<TMetadata extends Record<string, unknown> = Record<
 
 export type GenerateLineageStep = LineageStep<GenerateLineageMetadata> & {
     stepType: GenerateLineageStepType;
+};
+
+export type AutopilotLineageStep = LineageStep<AutopilotLineageMetadata> & {
+    stepType: 'autopilot-iteration';
 };
 
 export type SaveLineageStepInput = Omit<LineageStep, 'id'> & {

--- a/src/lineage/types.ts
+++ b/src/lineage/types.ts
@@ -1,4 +1,5 @@
 import type { AutopilotLineageMetadata } from './autopilotLineageMetadata';
+import type { EditorLineageMetadata } from './editorLineageMetadata';
 import type { GenerateLineageMetadata } from './generateLineageMetadata';
 
 export type LineageStepType =
@@ -11,6 +12,7 @@ export type LineageStepType =
     | 'autopilot-iteration';
 
 export type GenerateLineageStepType = 'generation' | 'reference-generation';
+export type EditorLineageStepType = 'ai-edit' | 'manual-edit' | 'overwrite' | 'save-as-copy';
 
 export interface LineageStep<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
     id: string;
@@ -27,6 +29,10 @@ export type GenerateLineageStep = LineageStep<GenerateLineageMetadata> & {
 
 export type AutopilotLineageStep = LineageStep<AutopilotLineageMetadata> & {
     stepType: 'autopilot-iteration';
+};
+
+export type EditorLineageStep = LineageStep<EditorLineageMetadata> & {
+    stepType: EditorLineageStepType;
 };
 
 export type SaveLineageStepInput = Omit<LineageStep, 'id'> & {

--- a/src/lineage/types.ts
+++ b/src/lineage/types.ts
@@ -1,3 +1,5 @@
+import type { GenerateLineageMetadata } from './generateLineageMetadata';
+
 export type LineageStepType =
     | 'generation'
     | 'reference-generation'
@@ -7,14 +9,20 @@ export type LineageStepType =
     | 'save-as-copy'
     | 'autopilot-iteration';
 
-export interface LineageStep {
+export type GenerateLineageStepType = 'generation' | 'reference-generation';
+
+export interface LineageStep<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
     id: string;
     archiveImageId: string;
     parentStepId: string | null;
     stepType: LineageStepType;
     timestamp: string;
-    metadata: Record<string, unknown>;
+    metadata: TMetadata;
 }
+
+export type GenerateLineageStep = LineageStep<GenerateLineageMetadata> & {
+    stepType: GenerateLineageStepType;
+};
 
 export type SaveLineageStepInput = Omit<LineageStep, 'id'> & {
     id?: string;

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -90,10 +90,6 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
             if (!canvasRef.current) throw new Error('Canvas not ready');
             return canvasRef.current.exportDataUrl();
         },
-        exportBlob: async () => {
-            if (!canvasRef.current) throw new Error('Canvas not ready');
-            return canvasRef.current.exportBlob();
-        },
         adjustments,
         onSave,
     });

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -80,8 +80,6 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         model: aiEditModel,
         isCanvasReady: isReady,
         draft,
-        layerStack,
-        selectedLayerIds,
         commitDraft,
         referenceImages,
         addReferenceFiles,

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -12,11 +12,10 @@ import { createPromptRefiner } from '../autopilot/PromptRefiner';
 import { createSatisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import { resolveReasoningClient } from '../autopilot/ReasoningClient';
 import {
+    buildImageModelGenerateReferenceRunPlan,
     coerceImageModelControlValue,
     getImageModelGenerateControls,
-    getImageModelReferenceLimitMessage,
     getImageModelUiChoices,
-    limitReferenceImagesForImageModel,
     type ImageModelControlId,
 } from '../image-models/ImageModelControls';
 import {
@@ -181,7 +180,10 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
     const promptRefiner = useMemo(() => createPromptRefiner(reasoningClient), [reasoningClient]);
     const referenceCollection = useReferenceImageCollection();
     const referenceImages = referenceCollection.files;
-    const activeReferenceImages = limitReferenceImagesForImageModel(model, referenceImages);
+    const referenceRunPlan = useMemo(
+        () => buildImageModelGenerateReferenceRunPlan(model, referenceImages),
+        [model, referenceImages],
+    );
     const referencePreviews = referenceCollection.previews;
     const addReferenceFiles = referenceCollection.addFiles;
     const removeReferenceAt = referenceCollection.removeAt;
@@ -203,7 +205,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
         reasoningModel,
         draft,
         setDraft,
-        referenceImages: activeReferenceImages,
+        referenceImages: referenceRunPlan.providerReferenceImages,
         replaceReferences: referenceCollection.replaceWithDataUrls,
         serializeReferences: referenceCollection.serialize,
         onSaveImage,
@@ -291,7 +293,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({ getProviderKey, onSaveImage
 
     const maxApiCalls = maxIterations * 3;
     const isAutopilotMode = mode === 'autopilot';
-    const imageModelReferenceWarning = getImageModelReferenceLimitMessage(model, referenceImages.length, 'generation');
+    const imageModelReferenceWarning = referenceRunPlan.referenceLimitMessage;
     const activeModelDraftKey = getImageModelDraftKey(model);
     const activeModelControls = draft[activeModelDraftKey] as Record<string, string>;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {


### PR DESCRIPTION
## Summary
- Added a shared reference-image run plan for Generate and wired it through provider requests and warnings.
- Refactored Editor AI transforms around a planned target path for rendering, insertion, and save-time provenance.
- Added typed lineage metadata for Generate, Editor, and Autopilot, plus archive manifest validation/import/recovery coverage.
- Carried used reference snapshots through Autopilot so runs stay stable even if selections change mid-flight.

## Testing
- `npm run typecheck` passed.
- `npm run test` passed with 193 tests across 29 files.