### PR TITLE
Batch generation for gpt-image-2

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,18 @@ An optional input image supplied alongside the prompt to guide generation or
 editing. Distinct from the **source image** in the Editor (the canvas being
 transformed), which is always the first image sent on an edit.
 
+## Generation batch
+
+The set of result slots produced by one Generate run. A generation batch uses
+one prompt, image model, control set, and reference image snapshot, even when
+some slots succeed and others fail.
+
+## Batch result
+
+One slot in a **generation batch**. A batch result may be a generated image or a
+slot-level failure. Saving a successful batch result creates its own archive
+image and lineage step while preserving the full run inputs.
+
 ## Favorite
 
 A user-marked archive image kept easy to find with the Archive favorites filter.

--- a/docs/openAI_create_image.md
+++ b/docs/openAI_create_image.md
@@ -276,7 +276,8 @@ Reasoning text is trimmed and then used as:
 
 ## Current Limitations
 
-- The app requests one image per generation or edit operation.
+- GPT Image 2 Generate runs may request a batch of 1-4 images with the native
+  `n` parameter; edit operations and Autopilot iterations request one image.
 - The app does not use streaming responses.
 - The app does not request masks or variations.
 - The app does not expose output format or compression controls.

--- a/docs/openAI_image_generation.md
+++ b/docs/openAI_image_generation.md
@@ -122,7 +122,8 @@ Autopilot adds app-level controls that shape request cadence and reasoning:
 
 ## Current Behavior
 
-- The app requests a single image per generation or edit operation.
+- GPT Image 2 Generate runs may request a batch of 1-4 images with the native
+  `n` parameter; edit operations and Autopilot iterations request one image.
 - Image responses are expected as base64 payloads and converted into browser data URLs.
 - Prompt modifiers are concatenated into the final prompt in `ImageWorkflow`.
 - Generate and Editor previews update immediately after a successful provider response.

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -88,6 +88,7 @@ describe('AutopilotSession', () => {
                         quality: 'high',
                         size: '1024x1024',
                         background: 'transparent',
+                        batchSize: 1,
                     },
                 },
                 iteration: { number: 1 },

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -3,6 +3,7 @@ import { satisfactionEvaluator } from './SatisfactionEvaluator';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { getFirstSuccessfulGeneratedImage } from '../image-workflow/ImageWorkflow';
 import { buildAutopilotLineageMetadata } from '../lineage/autopilotLineageMetadata';
 
 export const DEFAULT_AUTOPILOT_MAX_ITERATIONS = 4;
@@ -67,7 +68,7 @@ class DefaultAutopilotSession implements AutopilotSession {
     }
 
     async run(): Promise<AutopilotSessionResult> {
-        const generate = this.input.generate ?? ((input) => imageWorkflow.generate(input));
+        const generate = this.input.generate ?? generateSingleImage;
         const evaluate = this.input.evaluate ?? ((input) => satisfactionEvaluator.evaluate(input));
         const refine = this.input.refine ?? ((input) => promptRefiner.refine(input));
         const maxIterations = Math.max(1, Math.min(MAX_AUTOPILOT_ITERATIONS, this.input.maxIterations ?? DEFAULT_AUTOPILOT_MAX_ITERATIONS));
@@ -188,6 +189,20 @@ function pickBetterIteration(best: AutopilotIteration | null, candidate: Autopil
 
 export function createAutopilotSession(input: CreateAutopilotSessionInput): AutopilotSession {
     return new DefaultAutopilotSession(input);
+}
+
+async function generateSingleImage(input: GenerateImageInput): Promise<string> {
+    const results = await imageWorkflow.generate({
+        ...input,
+        batchSize: 1,
+    });
+    const imageDataUrl = getFirstSuccessfulGeneratedImage(results);
+
+    if (!imageDataUrl) {
+        throw new Error('No image data returned from image provider');
+    }
+
+    return imageDataUrl;
 }
 
 function snapshotAutopilotSettings(

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -23,6 +23,7 @@ describe('GenerateSession draft migration', () => {
                 quality: 'high',
                 size: '1536x1024',
                 background: 'transparent',
+                batchSize: 1,
             },
             nanoBananaPro: {
                 aspectRatio: '3:2',
@@ -40,6 +41,7 @@ describe('GenerateSession draft migration', () => {
                 quality: 'low',
                 size: '1024x1536',
                 background: 'opaque',
+                batchSize: 7,
             },
             nanoBananaPro: {
                 aspectRatio: '16:9',
@@ -51,6 +53,7 @@ describe('GenerateSession draft migration', () => {
                 quality: 'low',
                 size: '1024x1536',
                 background: 'opaque',
+                batchSize: 4,
             },
             nanoBananaPro: {
                 aspectRatio: '16:9',

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -51,6 +51,7 @@ describe('runGenerateAutopilot', () => {
                     quality: 'high',
                     size: '1024x1024',
                     background: 'transparent',
+                    batchSize: 1,
                 },
                 nanoBananaPro: {
                     aspectRatio: '1:1',
@@ -103,7 +104,11 @@ describe('runGenerateAutopilot', () => {
             input.referenceImages.push(new File(['request-mutation'], `request-mutated-${seenReferenceNames.length}.png`, { type: 'image/png' }));
             selectedReferenceFiles.unshift(new File(['new-reference'], `new-ref-${seenReferenceNames.length}.png`, { type: 'image/png' }));
 
-            return `data:image/png;base64,iteration-${seenReferenceNames.length}`;
+            return [{
+                slotIndex: 0,
+                status: 'success' as const,
+                imageUrl: `data:image/png;base64,iteration-${seenReferenceNames.length}`,
+            }];
         });
         const saveCurrentResult = vi.fn(async () => undefined);
         const serializeReferences = vi.fn(async (files: File[]) =>
@@ -136,6 +141,7 @@ describe('runGenerateAutopilot', () => {
                     quality: 'high',
                     size: '1024x1024',
                     background: 'transparent',
+                    batchSize: 1,
                 },
                 nanoBananaPro: {
                     aspectRatio: '16:9',

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -1,8 +1,9 @@
 import { createAutopilotSession, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
 import { getActiveGenerateControls, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
 import type { LineageStore } from '../lineage/LineageStore';
-import type { ImageWorkflow } from '../image-workflow/ImageWorkflow';
+import type { GenerateImageInput, ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
+import { getFirstSuccessfulGeneratedImage } from '../image-workflow/ImageWorkflow';
 import { promptRefiner } from '../autopilot/PromptRefiner';
 import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageModelControls';
@@ -48,6 +49,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
             quality: controls.quality,
             aspectRatio: controls.aspectRatio,
             background: controls.background,
+            batchSize: 1,
             imageSize: controls.imageSize,
             style: input.draft.style,
             lighting: input.draft.lighting,
@@ -60,7 +62,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
         initialParentStepId: input.sessionStore.loadLineageSource()?.stepId ?? null,
         maxIterations: input.maxIterations,
         satisfactionThreshold: input.satisfactionThreshold,
-        generate: (request) => workflow.generate(request),
+        generate: (request) => generateSingleImage(workflow, request),
         evaluate: input.evaluate,
         refine: input.refine,
         lineageStore: input.lineageStore,
@@ -88,4 +90,21 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
         usedReferenceImages: usedReferenceImages.slice(),
         usedReferences,
     };
+}
+
+async function generateSingleImage(
+    workflow: Pick<ImageWorkflow, 'generate'>,
+    request: GenerateImageInput,
+): Promise<string> {
+    const results = await workflow.generate({
+        ...request,
+        batchSize: 1,
+    });
+    const imageDataUrl = getFirstSuccessfulGeneratedImage(results);
+
+    if (!imageDataUrl) {
+        throw new Error('No image data returned from image provider');
+    }
+
+    return imageDataUrl;
 }

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -66,6 +66,7 @@ describe('saveGeneratedImage', () => {
                             quality: savedImage.quality,
                             size: savedImage.aspectRatio,
                             background: savedImage.background,
+                            batchSize: 1,
                         },
                     },
                     dimensions: {
@@ -266,6 +267,39 @@ describe('saveGeneratedImage', () => {
         expect(steps.at(-1)).toEqual(expect.objectContaining({
             parentStepId: 'step-1',
         }));
+    });
+
+    it('can reuse a captured lineage source for multiple batch result saves', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore(null);
+        await lineage.save({
+            archiveImageId: 'source-image',
+            parentStepId: null,
+            stepType: 'generation',
+            timestamp: '2026-04-04T09:00:00.000Z',
+            metadata: { prompt: 'source prompt' },
+        });
+        const lineageSource = { archiveImageId: 'source-image' };
+
+        await saveGeneratedImage(createArchiveImage({ id: 'batch-result-1' }), {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+            lineageSource,
+        });
+        await saveGeneratedImage(createArchiveImage({ id: 'batch-result-2' }), {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+            lineageSource,
+        });
+
+        await expect(lineage.getByArchiveImageId('batch-result-1')).resolves.toEqual([
+            expect.objectContaining({ parentStepId: 'step-1' }),
+        ]);
+        await expect(lineage.getByArchiveImageId('batch-result-2')).resolves.toEqual([
+            expect.objectContaining({ parentStepId: 'step-1' }),
+        ]);
     });
 
     it('does not write provenance when archive save fails', async () => {

--- a/src/generate-session/saveGeneratedImage.ts
+++ b/src/generate-session/saveGeneratedImage.ts
@@ -7,10 +7,13 @@ export interface SaveGeneratedImageDeps {
     saveImage: (image: ArchiveImage) => Promise<ArchiveImage>;
     lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
     sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'clearLineageSource'>;
+    lineageSource?: GenerateLineageSource | null;
 }
 
 export async function saveGeneratedImage(image: ArchiveImage, deps: SaveGeneratedImageDeps): Promise<ArchiveImage> {
-    const lineageSource = deps.sessionStore.loadLineageSource();
+    const lineageSource = deps.lineageSource !== undefined
+        ? deps.lineageSource
+        : deps.sessionStore.loadLineageSource();
     const savedImage = await deps.saveImage(image);
 
     await deps.lineageStore.save({

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -3,6 +3,7 @@ import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageMo
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
 import {
+    buildGenerateResultSlots,
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
     notifyGenerateCompletion,
@@ -17,6 +18,7 @@ describe('Generate controller Image model archive metadata', () => {
                 quality: 'high',
                 size: '1536x1024',
                 background: 'transparent',
+                batchSize: 1,
             },
         });
 
@@ -63,6 +65,35 @@ describe('Generate controller Image model archive metadata', () => {
             height: 2304,
             references: [],
         });
+    });
+});
+
+describe('Generate controller batch result slots', () => {
+    it('keeps successful and failed batch slots independent', () => {
+        expect(buildGenerateResultSlots([
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,one',
+            },
+            {
+                slotIndex: 1,
+                status: 'failed',
+                error: 'content filter',
+            },
+        ])).toEqual([
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,one',
+                isSaved: false,
+            },
+            {
+                slotIndex: 1,
+                status: 'failed',
+                error: 'content filter',
+            },
+        ]);
     });
 });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
-import { imageWorkflow, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
+import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateLineageSource, type GenerateSessionStore } from './GenerateSession';
+import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResult, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
 import { runGenerateAutopilot } from './runGenerateAutopilot';
@@ -30,6 +30,20 @@ interface AutopilotProgressState {
     bestIterationNumber: number | null;
     lastErrorIteration: number | null;
 }
+
+export type GenerateResultSlot =
+    | {
+        slotIndex: number;
+        status: 'success';
+        imageUrl: string;
+        isSaved: boolean;
+        archiveImageId?: string;
+    }
+    | {
+        slotIndex: number;
+        status: 'failed';
+        error: string;
+    };
 
 interface UseGenerateControllerOptions {
     apiKey: string | null;
@@ -196,7 +210,10 @@ export function useGenerateController({
     isDocumentHidden = () => typeof document !== 'undefined' && document.hidden,
 }: UseGenerateControllerOptions) {
     const [currentResult, setCurrentResult] = useState<string | null>(null);
+    const [currentBatchResults, setCurrentBatchResults] = useState<GenerateResultSlot[]>([]);
     const [currentResultReferences, setCurrentResultReferences] = useState<string[] | null>(null);
+    const [currentRunDraft, setCurrentRunDraft] = useState<GenerateDraft | null>(null);
+    const [currentRunLineageSource, setCurrentRunLineageSource] = useState<GenerateLineageSource | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [autopilot, setAutopilot] = useState<AutopilotProgressState>({
@@ -219,6 +236,12 @@ export function useGenerateController({
         ]).then(([value, references]) => {
             if (value) {
                 setCurrentResult(value);
+                setCurrentBatchResults([{
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: value,
+                    isSaved: false,
+                }]);
                 setCurrentResultReferences(references);
             }
         });
@@ -252,26 +275,47 @@ export function useGenerateController({
         try {
             const controls = getActiveGenerateControls(draft);
             const usedReferenceImages = referenceImages.slice();
+            const runDraft = cloneGenerateDraft(draft);
+            const runLineageSource = session.loadLineageSource();
             const usedReferences = await snapshotGeneratedReferenceImages({
                 referenceImages: usedReferenceImages,
                 serializeReferenceFiles: workflow.serializeReferences,
             });
-            const imageUrl = await workflow.generate({
+            const results = await workflow.generate({
                 apiKey,
                 model: draft.model,
                 prompt: draft.prompt,
                 quality: controls.quality,
                 aspectRatio: controls.aspectRatio,
                 background: controls.background,
+                batchSize: controls.batchSize,
                 imageSize: controls.imageSize,
                 style: draft.style,
                 lighting: draft.lighting,
                 palette: draft.palette,
                 referenceImages: usedReferenceImages,
             });
+            const imageUrl = getFirstSuccessfulGeneratedImage(results);
+            const batchResults = buildGenerateResultSlots(results);
+
+            setCurrentBatchResults(batchResults);
+            setCurrentRunDraft(runDraft);
+            setCurrentRunLineageSource(runLineageSource);
+            setCurrentResultReferences(usedReferences);
+
+            if (!imageUrl) {
+                setCurrentResult(null);
+                updateDraft({ isSaved: false });
+                setError('Generation failed for every batch result.');
+                await session.clearCurrentResult();
+                completionNotification = {
+                    title: 'Generation failed',
+                    body: 'Every batch result failed.',
+                };
+                return;
+            }
 
             setCurrentResult(imageUrl);
-            setCurrentResultReferences(usedReferences);
             updateDraft({ isSaved: false });
             await session.saveCurrentResult(imageUrl, usedReferences);
             completionNotification = {
@@ -316,6 +360,9 @@ export function useGenerateController({
         setLoading(true);
         setError(null);
         setCurrentResultReferences(null);
+        setCurrentBatchResults([]);
+        setCurrentRunDraft(null);
+        setCurrentRunLineageSource(session.loadLineageSource());
         setAutopilot({
             running: true,
             iterations: [],
@@ -353,6 +400,13 @@ export function useGenerateController({
                         bestIterationNumber: runningBest.iterationNumber,
                     }));
                     setCurrentResult(iteration.imageDataUrl);
+                    setCurrentBatchResults([{
+                        slotIndex: 0,
+                        status: 'success',
+                        imageUrl: iteration.imageDataUrl,
+                        isSaved: false,
+                        archiveImageId: iteration.archiveImageId,
+                    }]);
                 },
                 onError: (error, iterationNumber) => {
                     setError(error.message);
@@ -369,7 +423,19 @@ export function useGenerateController({
                     serializeReferenceFiles: workflow.serializeReferences,
                 });
                 setCurrentResult(outcome.result.bestIteration.imageDataUrl);
+                setCurrentBatchResults([{
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: outcome.result.bestIteration.imageDataUrl,
+                    isSaved: false,
+                    archiveImageId: outcome.result.bestIteration.archiveImageId,
+                }]);
                 setCurrentResultReferences(usedReferences);
+                setCurrentRunDraft(null);
+                setCurrentRunLineageSource({
+                    archiveImageId: outcome.result.bestIteration.archiveImageId,
+                    stepId: outcome.result.bestIteration.stepId,
+                });
                 updateDraft({
                     prompt: outcome.result.bestIteration.prompt,
                     isSaved: false,
@@ -422,17 +488,19 @@ export function useGenerateController({
         autopilotSessionRef.current?.cancel();
     }, []);
 
-    const save = useCallback(async () => {
-        if (!currentResult || draft.isSaved) {
+    const saveResult = useCallback(async (slotIndex: number) => {
+        const slot = currentBatchResults.find((result) => result.slotIndex === slotIndex);
+        if (!slot || slot.status !== 'success' || slot.isSaved) {
             return;
         }
 
         try {
+            const archiveImageId = crypto.randomUUID();
             const image = await buildGeneratedArchiveImageForSave({
-                id: crypto.randomUUID(),
-                url: currentResult,
+                id: archiveImageId,
+                url: slot.imageUrl,
                 timestamp: new Date().toISOString(),
-                draft,
+                draft: currentRunDraft ?? draft,
                 usedReferences: currentResultReferences,
                 serializeReferences,
             });
@@ -440,12 +508,25 @@ export function useGenerateController({
                 saveImage: async (image) => Promise.resolve(onSaveImage(image)),
                 lineageStore: lineage,
                 sessionStore: session,
+                lineageSource: currentRunLineageSource,
             });
-            updateDraft({ isSaved: true });
+            const nextResults = currentBatchResults.map((result) => result.slotIndex === slotIndex && result.status === 'success'
+                ? {
+                    ...result,
+                    isSaved: true,
+                    archiveImageId,
+                }
+                : result);
+            setCurrentBatchResults(nextResults);
+            updateDraft({ isSaved: areAllSuccessfulResultsSaved(nextResults) });
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [currentResult, currentResultReferences, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
+    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
+
+    const save = useCallback(async () => {
+        await saveResult(0);
+    }, [saveResult]);
 
     const download = useCallback(() => {
         if (!currentResult) {
@@ -455,14 +536,25 @@ export function useGenerateController({
         downloadGeneratedImage(currentResult);
     }, [currentResult]);
 
+    const downloadResult = useCallback((slotIndex: number) => {
+        const slot = currentBatchResults.find((result) => result.slotIndex === slotIndex);
+        if (slot?.status === 'success') {
+            downloadGeneratedImage(slot.imageUrl);
+        }
+    }, [currentBatchResults]);
+
     const clear = useCallback(async () => {
         setCurrentResult(null);
+        setCurrentBatchResults([]);
         setCurrentResultReferences(null);
+        setCurrentRunDraft(null);
+        setCurrentRunLineageSource(null);
         await session.clearCurrentResult();
     }, [session]);
 
     return {
         currentResult,
+        currentBatchResults,
         loading,
         error,
         autopilot,
@@ -471,7 +563,36 @@ export function useGenerateController({
         runAutopilot,
         cancelAutopilot,
         save,
+        saveResult,
         download,
+        downloadResult,
         clear,
+    };
+}
+
+export function buildGenerateResultSlots(results: GenerateBatchResult[]): GenerateResultSlot[] {
+    return results.map((result) => result.status === 'success'
+        ? {
+            slotIndex: result.slotIndex,
+            status: 'success',
+            imageUrl: result.imageUrl,
+            isSaved: false,
+        }
+        : result);
+}
+
+function areAllSuccessfulResultsSaved(results: GenerateResultSlot[]) {
+    const successfulResults = results.filter((result): result is Extract<GenerateResultSlot, { status: 'success' }> =>
+        result.status === 'success',
+    );
+
+    return successfulResults.length > 0 && successfulResults.every((result) => result.isSaved);
+}
+
+function cloneGenerateDraft(draft: GenerateDraft): GenerateDraft {
+    return {
+        ...draft,
+        gptImage2: { ...draft.gptImage2 },
+        nanoBananaPro: { ...draft.nanoBananaPro },
     };
 }

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -53,6 +53,17 @@ describe('Image model controls', () => {
                     { value: 'transparent', label: 'Transparent' },
                 ],
             },
+            {
+                id: 'batchSize',
+                label: 'BATCH SIZE',
+                kind: 'toggle',
+                options: [
+                    { value: '1', label: '1' },
+                    { value: '2', label: '2' },
+                    { value: '3', label: '3' },
+                    { value: '4', label: '4' },
+                ],
+            },
         ]);
         expect(getImageModelGenerateControls(NANO_BANANA_PRO_IMAGE_MODEL).map((control) => control.id)).toEqual([
             'aspectRatio',
@@ -65,6 +76,7 @@ describe('Image model controls', () => {
             quality: 'medium',
             size: '1024x1024',
             background: 'auto',
+            batchSize: 1,
         });
         expect(getDefaultImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL)).toEqual({
             aspectRatio: '1:1',
@@ -74,16 +86,28 @@ describe('Image model controls', () => {
             quality: 'high',
             size: '1536x1024',
             background: 'transparent',
+            batchSize: 3,
         })).toEqual({
             quality: 'high',
             size: '1536x1024',
             background: 'transparent',
+            batchSize: 3,
         });
         expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
             quality: 'best',
             size: '1600x900',
             background: 'clear',
-        })).toEqual(getDefaultImageModelControls(OPENAI_IMAGE_MODEL));
+            batchSize: 99,
+        })).toEqual({
+            ...getDefaultImageModelControls(OPENAI_IMAGE_MODEL),
+            batchSize: 4,
+        });
+        expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
+            batchSize: '4',
+        })).toEqual({
+            ...getDefaultImageModelControls(OPENAI_IMAGE_MODEL),
+            batchSize: 4,
+        });
         expect(sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
             aspectRatio: '1536x1024',
             imageSize: '4K',
@@ -93,6 +117,7 @@ describe('Image model controls', () => {
         });
         expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'aspectRatio', '1024x1536')).toBe('2:3');
         expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'quality', 'best')).toBe('medium');
+        expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'batchSize', '9')).toBe('4');
     });
 
     it('builds archive metadata dimensions for Generate saves through shared Image model controls', () => {
@@ -128,11 +153,13 @@ describe('Image model controls', () => {
             quality: 'high',
             aspectRatio: ' 1536x1024 ',
             background: 'transparent',
+            batchSize: 3,
             referenceImages: references,
         })).toEqual({
             quality: 'high',
             size: '1536x1024',
             background: 'transparent',
+            batchSize: 3,
             referenceImages: references,
         });
         expect(mapImageModelGenerateProviderRequest(NANO_BANANA_PRO_IMAGE_MODEL, {

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -16,6 +16,7 @@ export type GptImage2Controls = {
     quality: ImageQuality;
     size: string;
     background: ImageBackground;
+    batchSize: number;
 };
 
 export type NanoBananaProControls = {
@@ -25,12 +26,13 @@ export type NanoBananaProControls = {
 
 export type ImageModelControls = GptImage2Controls | NanoBananaProControls;
 
-export type ImageModelControlId = 'quality' | 'size' | 'background' | 'aspectRatio' | 'imageSize';
+export type ImageModelControlId = 'quality' | 'size' | 'background' | 'batchSize' | 'aspectRatio' | 'imageSize';
 
 export interface ActiveImageModelControls {
     quality: ImageQuality;
     aspectRatio: string;
     background: ImageBackground;
+    batchSize: number;
     imageSize?: NanoBananaImageSize;
 }
 
@@ -66,6 +68,8 @@ interface ImageModelControlFacts {
 }
 
 const GPT_IMAGE_2_SIZES = ['1024x1024', '1536x1024', '1024x1536', 'auto'] as const;
+const GPT_IMAGE_2_BATCH_SIZE_MIN = 1;
+const GPT_IMAGE_2_BATCH_SIZE_MAX = 4;
 const IMAGE_QUALITIES = ['low', 'medium', 'high'] as const;
 const IMAGE_BACKGROUNDS = ['auto', 'opaque', 'transparent'] as const;
 const NANO_ASPECT_RATIOS = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'] as const;
@@ -77,6 +81,7 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
             quality: 'medium',
             size: '1024x1024',
             background: 'auto',
+            batchSize: 1,
         },
         generateControls: [
             {
@@ -108,6 +113,17 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
                     { value: 'auto', label: 'Auto' },
                     { value: 'opaque', label: 'Opaque' },
                     { value: 'transparent', label: 'Transparent' },
+                ],
+            },
+            {
+                id: 'batchSize',
+                label: 'BATCH SIZE',
+                kind: 'toggle',
+                options: [
+                    { value: '1', label: '1' },
+                    { value: '2', label: '2' },
+                    { value: '3', label: '3' },
+                    { value: '4', label: '4' },
                 ],
             },
         ],
@@ -219,6 +235,7 @@ export function sanitizeImageModelControls(
         quality: coerceImageQuality(record?.quality, fallbackControls.quality),
         size: coerceGptImageSize(record?.size, fallbackControls.size),
         background: coerceImageBackground(record?.background, fallbackControls.background),
+        batchSize: coerceGptBatchSize(record?.batchSize, fallbackControls.batchSize),
     };
 }
 
@@ -262,6 +279,9 @@ export function coerceImageModelControlValue(model: ImageModelSlug, controlId: s
     if (controlId === 'background') {
         return coerceImageBackground(value, defaults.background);
     }
+    if (controlId === 'batchSize') {
+        return String(coerceGptBatchSize(value, defaults.batchSize));
+    }
     return '';
 }
 
@@ -274,6 +294,7 @@ export function getActiveImageModelGenerateControls(model: ImageModelSlug, contr
             imageSize: sanitized.imageSize,
             quality: gptDefaults.quality,
             background: gptDefaults.background,
+            batchSize: 1,
         };
     }
 
@@ -283,6 +304,7 @@ export function getActiveImageModelGenerateControls(model: ImageModelSlug, contr
         imageSize: undefined,
         quality: sanitized.quality,
         background: sanitized.background,
+        batchSize: sanitized.batchSize,
     };
 }
 
@@ -318,6 +340,7 @@ export function mapImageModelGenerateProviderRequest(
         quality: ImageQuality;
         aspectRatio: string;
         background: ImageBackground;
+        batchSize?: number;
         imageSize?: NanoBananaImageSize;
         referenceImages: File[];
     },
@@ -340,6 +363,7 @@ export function mapImageModelGenerateProviderRequest(
         quality: coerceImageQuality(input.quality, 'medium'),
         size: coerceGptImageSize(input.aspectRatio, '1024x1024'),
         background: coerceImageBackground(input.background, 'auto'),
+        batchSize: coerceGptBatchSize(input.batchSize, 1),
         referenceImages: referenceRunPlan.providerReferenceImages,
     };
 }
@@ -442,6 +466,23 @@ function coerceGptImageSize(value: unknown, fallback: string): string {
 
     const normalized = value.trim();
     return (GPT_IMAGE_2_SIZES as readonly string[]).includes(normalized) ? normalized : fallback;
+}
+
+function coerceGptBatchSize(value: unknown, fallback: number): number {
+    const parsed = typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+            ? Number(value.trim())
+            : NaN;
+
+    if (!Number.isFinite(parsed)) {
+        return fallback;
+    }
+
+    return Math.min(
+        GPT_IMAGE_2_BATCH_SIZE_MAX,
+        Math.max(GPT_IMAGE_2_BATCH_SIZE_MIN, Math.trunc(parsed)),
+    );
 }
 
 function coerceNanoAspectRatio(value: unknown, fallback: NanoBananaAspectRatio): NanoBananaAspectRatio {

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -17,20 +17,21 @@ export interface ImageProviderRequest {
     aspectRatio?: NanoBananaAspectRatio;
     imageSize?: NanoBananaImageSize;
     preserveSourceDimensions?: boolean;
+    batchSize?: number;
     referenceImages?: File[];
 }
 
 export type ImageProviderResponse = OpenAiImageResponse;
 
 export interface ImageProvider {
-    generate(request: ImageProviderRequest): Promise<ImageProviderResponse>;
+    generate(request: ImageProviderRequest): Promise<ImageProviderResponse[]>;
     edit(request: ImageProviderRequest): Promise<ImageProviderResponse>;
 }
 
 export type ImageProviderRegistry = Partial<Record<Provider, ImageProvider>>;
 
 export function createOpenAiImageProvider(client: OpenAiImageClient = openAiImageClient): ImageProvider {
-    const createImage = (request: ImageProviderRequest) => client.createImage({
+    const toOpenAiRequest = (request: ImageProviderRequest) => ({
         apiKey: request.apiKey,
         apiModel: request.model.apiModel,
         endpoints: request.model.endpoints,
@@ -38,12 +39,13 @@ export function createOpenAiImageProvider(client: OpenAiImageClient = openAiImag
         quality: request.quality,
         size: request.size,
         background: request.background,
+        batchSize: request.batchSize,
         referenceImages: request.referenceImages,
     });
 
     return {
-        generate: createImage,
-        edit: createImage,
+        generate: (request) => client.createImages(toOpenAiRequest(request)),
+        edit: (request) => client.createImage(toOpenAiRequest(request)),
     };
 }
 
@@ -76,7 +78,7 @@ export function createGoogleImageProvider(fetchImpl: typeof fetch = fetch): Imag
     };
 
     return {
-        generate: createImage,
+        generate: async (request) => [await createImage(request)],
         edit: createImage,
     };
 }

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -5,7 +5,10 @@ import { createGoogleImageProvider, extractGoogleImageData } from './ImageProvid
 
 describe('ImageWorkflow', () => {
     it('routes generate requests through the configured provider for the selected model', async () => {
-        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            void input;
+            return [{ b64_json: 'generated' }];
+        });
         const providers: ImageProviderRegistry = {
             openai: {
                 generate,
@@ -15,7 +18,7 @@ describe('ImageWorkflow', () => {
 
         const workflow = createImageWorkflow(providers);
 
-        const dataUrl = await workflow.generate({
+        const results = await workflow.generate({
             apiKey: 'sk-test',
             prompt: 'blue hour mountain',
             quality: 'high',
@@ -27,7 +30,11 @@ describe('ImageWorkflow', () => {
             referenceImages: [],
         });
 
-        expect(dataUrl).toBe('data:image/png;base64,generated');
+        expect(results).toEqual([{
+            slotIndex: 0,
+            status: 'success',
+            imageUrl: 'data:image/png;base64,generated',
+        }]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             apiKey: 'sk-test',
             model: expect.objectContaining({
@@ -39,7 +46,44 @@ describe('ImageWorkflow', () => {
             quality: 'high',
             size: '1024x1024',
             background: 'transparent',
+            batchSize: 1,
             referenceImages: [],
+        }));
+    });
+
+    it('returns per-slot batch results and keeps failed slots in place', async () => {
+        const generate = vi.fn(async () => [
+            { b64_json: 'generated-0' },
+            {},
+            { b64_json: 'generated-2' },
+        ]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        const results = await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 3,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        });
+
+        expect(results).toEqual([
+            { slotIndex: 0, status: 'success', imageUrl: 'data:image/png;base64,generated-0' },
+            { slotIndex: 1, status: 'failed', error: 'No image data returned from image provider' },
+            { slotIndex: 2, status: 'success', imageUrl: 'data:image/png;base64,generated-2' },
+        ]);
+        expect(generate).toHaveBeenCalledWith(expect.objectContaining({
+            batchSize: 3,
         }));
     });
 
@@ -76,7 +120,7 @@ describe('ImageWorkflow', () => {
     });
 
     it('falls back to the default generation size when aspect ratio value is unsupported', async () => {
-        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async () => [{ b64_json: 'generated' }]);
         const workflow = createImageWorkflow({
             openai: {
                 generate,
@@ -106,7 +150,7 @@ describe('ImageWorkflow', () => {
     });
 
     it('trims generation dimensions before validating size', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async () => [{ b64_json: 'generated' }]);
         const workflow = createImageWorkflow({
             openai: {
                 generate,
@@ -136,7 +180,7 @@ describe('ImageWorkflow', () => {
     });
 
     it('maps landscape generation dimensions to supported Nano Banana aspect ratio', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async () => [{ b64_json: 'generated' }]);
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -167,7 +211,7 @@ describe('ImageWorkflow', () => {
     });
 
     it('trims Nano Banana generation dimensions before mapping aspect ratio', async () => {
-        const generate = vi.fn(async () => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async () => [{ b64_json: 'generated' }]);
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -198,7 +242,7 @@ describe('ImageWorkflow', () => {
     });
 
     it('surfaces a provider-agnostic error when generation returns no image data', async () => {
-        const generate = vi.fn(async () => ({}));
+        const generate = vi.fn(async () => [{}]);
         const workflow = createImageWorkflow({
             openai: {
                 generate,
@@ -281,7 +325,10 @@ describe('ImageWorkflow', () => {
     });
 
     it('maps nano-banana-pro Editor AI transforms with source handling and Reference image limits', async () => {
-        const edit = vi.fn(async (_request: Parameters<ImageProvider['edit']>[0]) => ({ b64_json: 'edited-nano' }));
+        const edit = vi.fn(async (request: Parameters<ImageProvider['edit']>[0]) => {
+            void request;
+            return { b64_json: 'edited-nano' };
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -363,7 +410,7 @@ describe('googleImageProvider', () => {
             referenceImages: [reference],
         });
 
-        expect(result).toEqual({ b64_json: 'gemini-image' });
+        expect(result).toEqual([{ b64_json: 'gemini-image' }]);
         expect(fetchImpl).toHaveBeenCalledWith('https://example.test/generate', expect.objectContaining({
             method: 'POST',
             headers: {
@@ -385,7 +432,10 @@ describe('googleImageProvider', () => {
     });
 
     it('normalizes unsupported Nano Banana aspect ratios to 1:1', async () => {
-        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            void input;
+            return [{ b64_json: 'generated' }];
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -416,7 +466,10 @@ describe('googleImageProvider', () => {
     });
 
     it('uses only the first 14 references for Nano Banana generation requests', async () => {
-        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            void input;
+            return [{ b64_json: 'generated' }];
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -20,6 +20,7 @@ export interface GenerateImageInput {
     quality: ImageQuality;
     aspectRatio: string;
     background: ImageBackground;
+    batchSize?: number;
     imageSize?: NanoBananaImageSize;
     style: string;
     lighting: string;
@@ -39,8 +40,20 @@ export interface EditImageInput {
     imageSize?: NanoBananaImageSize;
 }
 
+export type GenerateBatchResult =
+    | {
+        slotIndex: number;
+        status: 'success';
+        imageUrl: string;
+    }
+    | {
+        slotIndex: number;
+        status: 'failed';
+        error: string;
+    };
+
 export interface ImageWorkflow {
-    generate(input: GenerateImageInput): Promise<string>;
+    generate(input: GenerateImageInput): Promise<GenerateBatchResult[]>;
     edit(input: EditImageInput): Promise<string>;
     serializeReferences(files: File[]): Promise<string[]>;
     hydrateReferences(dataUrls: string[]): File[];
@@ -54,16 +67,41 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
                 quality: input.quality,
                 aspectRatio: input.aspectRatio,
                 background: input.background,
+                batchSize: input.batchSize,
                 imageSize: input.imageSize,
                 referenceImages: input.referenceImages,
             });
 
-            return requestImageDataUrl(provider.generate({
-                apiKey: input.apiKey,
-                model,
-                prompt: buildGenerationPrompt(input),
-                ...providerRequest,
-            }));
+            const batchSize = providerRequest.batchSize ?? 1;
+
+            try {
+                const responses = await provider.generate({
+                    apiKey: input.apiKey,
+                    model,
+                    prompt: buildGenerationPrompt(input),
+                    ...providerRequest,
+                });
+                const results = mapGenerateBatchResults(responses, batchSize);
+
+                if (!hasSuccessfulGeneratedImage(results) && batchSize === 1) {
+                    const [result] = results;
+                    throw new Error(result?.status === 'failed'
+                        ? result.error
+                        : 'No image data returned from image provider');
+                }
+
+                return results;
+            } catch (error) {
+                if (batchSize === 1) {
+                    throw error;
+                }
+
+                return Array.from({ length: batchSize }, (_, slotIndex) => ({
+                    slotIndex,
+                    status: 'failed' as const,
+                    error: error instanceof Error ? error.message : 'Image generation failed',
+                }));
+            }
         },
 
         async edit(input) {
@@ -139,3 +177,31 @@ const requestImageDataUrl = async (request: Promise<ImageProviderResponse>) => {
 
     return `data:image/png;base64,${result.b64_json}`;
 };
+
+export function getFirstSuccessfulGeneratedImage(results: GenerateBatchResult[]): string | null {
+    return results.find((result) => result.status === 'success')?.imageUrl ?? null;
+}
+
+function hasSuccessfulGeneratedImage(results: GenerateBatchResult[]): boolean {
+    return getFirstSuccessfulGeneratedImage(results) !== null;
+}
+
+function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: number): GenerateBatchResult[] {
+    return Array.from({ length: batchSize }, (_, slotIndex) => {
+        const response = responses[slotIndex];
+
+        if (response?.b64_json) {
+            return {
+                slotIndex,
+                status: 'success',
+                imageUrl: `data:image/png;base64,${response.b64_json}`,
+            };
+        }
+
+        return {
+            slotIndex,
+            status: 'failed',
+            error: 'No image data returned from image provider',
+        };
+    });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -728,6 +728,12 @@ textarea.aura-input {
     overflow: hidden;
 }
 
+.batch-preview-panel {
+    align-items: stretch;
+    justify-content: flex-start;
+    overflow: auto;
+}
+
 .empty-preview,
 .empty-archive,
 .empty-state {
@@ -783,6 +789,76 @@ textarea.aura-input {
     min-height: 600px;
     object-fit: contain;
     background: var(--color-charcoal);
+}
+
+.result-batch-container {
+    width: 100%;
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-16);
+    padding: var(--spacing-16);
+}
+
+.result-batch-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-16);
+    width: 100%;
+}
+
+.result-slot-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    min-height: 280px;
+    padding: var(--spacing-12);
+    border: 1px solid var(--color-steel);
+    background: rgba(246, 244, 239, 0.92);
+}
+
+.result-slot-header,
+.result-slot-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--element-gap);
+}
+
+.result-slot-header {
+    color: var(--color-charcoal);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.result-slot-image {
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: contain;
+    background: var(--color-charcoal);
+}
+
+.result-slot-actions {
+    flex-wrap: wrap;
+}
+
+.result-slot-error {
+    flex: 1;
+    min-height: 190px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--element-gap);
+    padding: var(--spacing-16);
+    border: 1px dashed var(--color-steel);
+    color: var(--color-steel);
+    text-align: center;
+}
+
+.result-batch-clear {
+    align-self: flex-end;
 }
 
 .result-actions,

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -34,6 +34,7 @@ describe('replayLineageStep', () => {
                     quality: 'high',
                     size: '1536x1024',
                     background: 'transparent',
+                    batchSize: 1,
                 },
                 nanoBananaPro: {
                     aspectRatio: '1:1',
@@ -84,6 +85,7 @@ describe('replayLineageStep', () => {
                     quality: 'high',
                     size: '1536x1024',
                     background: 'transparent',
+                    batchSize: 1,
                 },
                 nanoBananaPro: {
                     aspectRatio: '1:1',
@@ -131,6 +133,7 @@ describe('replayLineageStep', () => {
                     quality: 'high',
                     size: '1536x1024',
                     background: 'transparent',
+                    batchSize: 1,
                 },
                 nanoBananaPro: {
                     aspectRatio: '1:1',

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -44,6 +44,39 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('posts batched image generation requests with native n and returns every image payload', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+                { b64_json: 'generated-2' },
+            ],
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImages({
+                apiKey: 'sk-test',
+                prompt: 'three cats',
+                batchSize: 3,
+            });
+
+            expect(result).toEqual([
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+                { b64_json: 'generated-2' },
+            ]);
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body).toMatchObject({
+                n: 3,
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts image edit requests with multipart form data to the edit endpoint', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [{ b64_json: 'edited' }],

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -16,6 +16,7 @@ export interface OpenAiImageRequest {
     quality?: ImageQuality;
     size?: string;
     background?: ImageBackground;
+    batchSize?: number;
     referenceImages?: File[];
 }
 
@@ -36,6 +37,7 @@ export interface OpenAiResponsesResponse {
 
 export interface OpenAiImageClient {
     createImage(request: OpenAiImageRequest): Promise<OpenAiImageResponse>;
+    createImages(request: OpenAiImageRequest): Promise<OpenAiImageResponse[]>;
 }
 
 export interface OpenAiResponsesClient {
@@ -44,10 +46,25 @@ export interface OpenAiResponsesClient {
 
 export const openAiImageClient: OpenAiImageClient = {
     async createImage(request) {
+        const images = await requestOpenAiImages({
+            ...request,
+            batchSize: 1,
+        });
+
+        return images[0];
+    },
+
+    createImages(request) {
+        return requestOpenAiImages(request);
+    },
+};
+
+async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiImageResponse[]> {
         const isEdit = request.referenceImages && request.referenceImages.length > 0;
         const apiModel = request.apiModel ?? request.model ?? OPENAI_IMAGE_MODEL;
         const endpoints = request.endpoints ?? IMAGE_MODEL_REGISTRY[OPENAI_IMAGE_MODEL].endpoints;
         const endpoint = isEdit ? endpoints.edit : endpoints.generate;
+        const batchSize = coerceOpenAiBatchSize(request.batchSize);
 
         let body: BodyInit;
         const headers: Record<string, string> = {
@@ -58,7 +75,7 @@ export const openAiImageClient: OpenAiImageClient = {
             const formData = new FormData();
             formData.append('model', apiModel);
             formData.append('prompt', request.prompt);
-            formData.append('n', '1');
+            formData.append('n', String(batchSize));
 
             request.referenceImages?.forEach((file) => {
                 formData.append('image[]', file);
@@ -81,7 +98,7 @@ export const openAiImageClient: OpenAiImageClient = {
             } = {
                 model: apiModel,
                 prompt: request.prompt,
-                n: 1,
+                n: batchSize,
             };
             if (request.size && request.size !== 'auto') jsonBody.size = request.size;
             if (request.quality) jsonBody.quality = request.quality;
@@ -107,9 +124,22 @@ export const openAiImageClient: OpenAiImageClient = {
             throw new Error('No image data returned from OpenAI');
         }
 
-        return data.data[0];
-    },
-};
+        return data.data;
+}
+
+function coerceOpenAiBatchSize(value: unknown): number {
+    const parsed = typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+            ? Number(value.trim())
+            : NaN;
+
+    if (!Number.isFinite(parsed)) {
+        return 1;
+    }
+
+    return Math.min(4, Math.max(1, Math.trunc(parsed)));
+}
 
 export const openAiResponsesClient: OpenAiResponsesClient = {
     async createResponse(request) {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -200,6 +200,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const removeReferenceAt = referenceCollection.removeAt;
     const {
         currentResult,
+        currentBatchResults,
         loading,
         error,
         autopilot,
@@ -208,7 +209,9 @@ const GenerateView: React.FC<GenerateViewProps> = ({
         runAutopilot,
         cancelAutopilot,
         save,
+        saveResult,
         download,
+        downloadResult,
         clear,
     } = useGenerateController({
         apiKey: activeImageApiKey,
@@ -319,7 +322,10 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const isAutopilotMode = mode === 'autopilot';
     const imageModelReferenceWarning = referenceRunPlan.referenceLimitMessage;
     const activeModelDraftKey = getImageModelDraftKey(model);
-    const activeModelControls = draft[activeModelDraftKey] as Record<string, string>;
+    const activeModelControls = draft[activeModelDraftKey] as Record<string, string | number>;
+    const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
+    const showBatchGrid = currentBatchResults.length > 1 || currentBatchResults.some((result) => result.status === 'failed');
+    const singleResultSlot = !showBatchGrid ? successfulBatchResults[0] : null;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
         updateDraft({
             [activeModelDraftKey]: {
@@ -493,7 +499,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                 <label>{control.label}</label>
                                 {control.kind === 'select' ? (
                                     <CustomSelect
-                                        value={activeModelControls[control.id] ?? ''}
+                                        value={String(activeModelControls[control.id] ?? '')}
                                         onChange={(value) => updateImageModelControl(control.id, value)}
                                         options={control.options}
                                     />
@@ -502,7 +508,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                         {control.options.map((option) => (
                                             <button
                                                 key={option.value}
-                                                className={activeModelControls[control.id] === option.value ? 'active' : ''}
+                                                className={String(activeModelControls[control.id] ?? '') === option.value ? 'active' : ''}
                                                 onClick={() => updateImageModelControl(control.id, option.value)}
                                             >{option.label}</button>
                                         ))}
@@ -645,8 +651,47 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
 
-                <section className="preview-panel glass-panel">
-                    {currentResult ? (
+                <section className={`preview-panel glass-panel${showBatchGrid ? ' batch-preview-panel' : ''}`}>
+                    {showBatchGrid ? (
+                        <div className="result-batch-container">
+                            <div className="result-batch-grid">
+                                {currentBatchResults.map((result) => (
+                                    <div key={result.slotIndex} className={`result-slot-card ${result.status}`}>
+                                        <div className="result-slot-header">
+                                            <span>Result {result.slotIndex + 1}</span>
+                                            {result.status === 'success' && result.isSaved && <span>Saved</span>}
+                                            {result.status === 'failed' && <span>Failed</span>}
+                                        </div>
+                                        {result.status === 'success' ? (
+                                            <>
+                                                <img src={result.imageUrl} alt={`Generated result ${result.slotIndex + 1}`} className="result-slot-image" />
+                                                <div className="result-slot-actions">
+                                                    <button
+                                                        onClick={() => { void saveResult(result.slotIndex); }}
+                                                        className="btn-amber"
+                                                        disabled={result.isSaved}
+                                                    >
+                                                        <Archive size={16} /> {result.isSaved ? 'Saved' : 'Save'}
+                                                    </button>
+                                                    <button className="btn-ghost" onClick={() => downloadResult(result.slotIndex)}>
+                                                        <Download size={16} /> Download
+                                                    </button>
+                                                </div>
+                                            </>
+                                        ) : (
+                                            <div className="result-slot-error">
+                                                <Sparkles size={28} className="dim-icon" />
+                                                <p>{result.error}</p>
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                            <button onClick={() => { void clear(); }} className="btn-ghost result-batch-clear">
+                                <Trash2 size={18} /> Clear Results
+                            </button>
+                        </div>
+                    ) : currentResult ? (
                         <div className="result-container">
                             <img src={currentResult} alt="Generated result" className="result-image" />
                             {isAutopilotMode && autopilot.iterations.length > 0 && (
@@ -667,9 +712,9 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                 <button
                                     onClick={() => { void save(); }}
                                     className="btn-amber"
-                                    disabled={isSaved}
+                                    disabled={singleResultSlot?.isSaved ?? isSaved}
                                 >
-                                    <Archive size={18} /> {isSaved ? 'Saved to Archive' : 'Save to Archive'}
+                                    <Archive size={18} /> {(singleResultSlot?.isSaved ?? isSaved) ? 'Saved to Archive' : 'Save to Archive'}
                                 </button>
                                 <button className="btn-ghost" onClick={download}>
                                     <Download size={18} /> Download


### PR DESCRIPTION
## Summary
- Add GPT Image 2 batch size control and per-slot batch results
- Send native OpenAI Images API n and render/save individual batch slots
- Preserve single-result behavior for batch size 1 and Autopilot

Closes #70