### PR TITLE
Transform masks for AI editor transforms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,13 @@ The layer selection sent to an AI transform as the image content to change.
 Distinct from **reference images** and composition context, which guide the AI
 transform without defining the target layer content.
 
+## Transform mask
+
+A transient painted mask for an AI transform target. Painted areas are editable
+by the image model; unpainted areas should remain protected. A transform mask is
+drawn over the AI transform target, not the whole Editor composition, and is
+distinct from **reference images** and composition context.
+
 ## Uploaded layer
 
 A raster image layer created from an image file the user adds to the visible

--- a/docs/openAI_create_image.md
+++ b/docs/openAI_create_image.md
@@ -278,7 +278,8 @@ Reasoning text is trimmed and then used as:
 
 - The app requests one image per generation or edit operation.
 - The app does not use streaming responses.
-- The app does not request masks or variations.
+- The app requests Editor transform masks for `gpt-image-2` only; it does not
+  request variations.
 - The app does not expose output format or compression controls.
 - OpenAI editor transforms always use `quality: medium`.
 - `nano-banana-pro` uses at most the first `14` reference images.

--- a/docs/openAI_image_generation.md
+++ b/docs/openAI_image_generation.md
@@ -47,6 +47,8 @@ Reference-based `gpt-image-2` generation and editor transforms use:
 - Content type: `multipart/form-data`
 - Model: `gpt-image-2`
 - Input images: browser `File` objects appended as `image[]`
+- Optional mask: Editor transform masks are appended as the separate `mask`
+  multipart field when present
 - Output handling: base64 image payload converted to a data URL
 
 This path is used when:

--- a/src/editor/transformMask.test.ts
+++ b/src/editor/transformMask.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { classifyTransformMaskCoverage } from './transformMask';
+
+describe('transform mask coverage', () => {
+    it('classifies a fully transparent mask as empty', () => {
+        expect(classifyTransformMaskCoverage({
+            width: 2,
+            height: 2,
+            data: new Uint8ClampedArray([
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+        })).toBe('empty');
+    });
+
+    it('classifies any non-transparent mask pixel as painted', () => {
+        expect(classifyTransformMaskCoverage({
+            width: 2,
+            height: 2,
+            data: new Uint8ClampedArray([
+                0, 0, 0, 0,
+                0, 0, 0, 12,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+        })).toBe('painted');
+    });
+});

--- a/src/editor/transformMask.ts
+++ b/src/editor/transformMask.ts
@@ -1,0 +1,16 @@
+export type TransformMaskCoverage = 'empty' | 'painted';
+
+export function classifyTransformMaskCoverage(
+    mask: Pick<ImageData, 'data' | 'width' | 'height'>,
+): TransformMaskCoverage {
+    const expectedLength = mask.width * mask.height * 4;
+    const length = Math.min(mask.data.length, expectedLength);
+
+    for (let alphaIndex = 3; alphaIndex < length; alphaIndex += 4) {
+        if (mask.data[alphaIndex] > 0) {
+            return 'painted';
+        }
+    }
+
+    return 'empty';
+}

--- a/src/editor/useEditorController.test.ts
+++ b/src/editor/useEditorController.test.ts
@@ -21,7 +21,11 @@ describe('Editor controller AI transform flow', () => {
             new File(['reference'], 'reference.png', { type: 'image/png' }),
         ];
         const render = createRecordingRenderer();
-        const editImage = vi.fn(async (_input: EditImageInput) => 'data:image/png;base64,ai-result');
+        const editImage = vi.fn(async (input: EditImageInput) => {
+            void input;
+            return 'data:image/png;base64,ai-result';
+        });
+        const maskImage = new File(['mask'], 'mask.png', { type: 'image/png' });
 
         const result = await runEditorAiTransform({
             apiKey: 'sk-test',
@@ -33,6 +37,7 @@ describe('Editor controller AI transform flow', () => {
             makeId: () => 'ai-layer',
             editImage,
             render,
+            maskImage,
         });
 
         expect(render).toHaveBeenCalledTimes(2);
@@ -43,6 +48,7 @@ describe('Editor controller AI transform flow', () => {
             sourceImage: expect.any(Blob),
             compositionContextImage: expect.any(File),
             referenceImages,
+            maskImage,
             quality: 'medium',
         }));
         expect(result.draft.layerStack.layers.map((layer) => [layer.id, layer.visible])).toEqual([

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -22,6 +22,7 @@ interface UseEditorControllerOptions {
     draft: EditorDraft | null;
     commitDraft: (draft: EditorDraft, recordHistory?: boolean) => void;
     referenceImages: File[];
+    maskImage?: File | Blob | null;
     addReferenceFiles: (files: File[]) => void;
     serializeReferences: () => Promise<string[]>;
     exportDataUrl: () => Promise<string>;
@@ -36,6 +37,7 @@ export function useEditorController({
     draft,
     commitDraft,
     referenceImages,
+    maskImage,
     addReferenceFiles,
     serializeReferences,
     exportDataUrl,
@@ -92,6 +94,7 @@ export function useEditorController({
                 draft,
                 adjustments,
                 referenceImages,
+                maskImage,
                 makeId: () => crypto.randomUUID(),
             });
 
@@ -103,7 +106,7 @@ export function useEditorController({
         } finally {
             setAiLoading(false);
         }
-    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, isCanvasReady, model, referenceImages]);
+    }, [adjustments, aiPrompt, apiKey, commitDraft, draft, isCanvasReady, maskImage, model, referenceImages]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
         e.preventDefault();
@@ -149,6 +152,7 @@ export interface RunEditorAiTransformOptions {
     draft: EditorDraft;
     adjustments: EditorAdjustments;
     referenceImages: File[];
+    maskImage?: File | Blob | null;
     makeId: () => string;
     editImage?: EditImage;
     render?: AiTransformRenderer;
@@ -161,6 +165,7 @@ export async function runEditorAiTransform({
     draft,
     adjustments,
     referenceImages,
+    maskImage,
     makeId,
     editImage = imageWorkflow.edit,
     render,
@@ -179,6 +184,7 @@ export async function runEditorAiTransform({
         sourceImage: editInput.sourceImage,
         compositionContextImage: editInput.compositionContextImage,
         referenceImages: editInput.referenceImages,
+        maskImage,
         quality: 'medium',
     });
 

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -8,6 +8,7 @@ import {
     getImageModelGenerateControls,
     getImageModelReferenceLimitMessage,
     getImageModelUiChoices,
+    imageModelSupportsTransformMask,
     limitReferenceImagesForImageModel,
     mapImageModelEditProviderRequest,
     mapImageModelGenerateProviderRequest,
@@ -58,6 +59,11 @@ describe('Image model controls', () => {
             'aspectRatio',
             'imageSize',
         ]);
+    });
+
+    it('exposes transform mask support per Image model', () => {
+        expect(imageModelSupportsTransformMask(OPENAI_IMAGE_MODEL)).toBe(true);
+        expect(imageModelSupportsTransformMask(NANO_BANANA_PRO_IMAGE_MODEL)).toBe(false);
     });
 
     it('validates defaults and coercion for both Image models', () => {

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -184,6 +184,10 @@ export function getImageModelUiChoices(): Array<{
     });
 }
 
+export function imageModelSupportsTransformMask(model: ImageModelSlug): boolean {
+    return IMAGE_MODEL_REGISTRY[model].capabilities.transformMask;
+}
+
 export function sanitizeImageModelControls(
     model: typeof OPENAI_IMAGE_MODEL,
     value: unknown,

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -18,6 +18,7 @@ export interface ImageProviderRequest {
     imageSize?: NanoBananaImageSize;
     preserveSourceDimensions?: boolean;
     referenceImages?: File[];
+    maskImage?: File | Blob | null;
 }
 
 export type ImageProviderResponse = OpenAiImageResponse;
@@ -39,6 +40,7 @@ export function createOpenAiImageProvider(client: OpenAiImageClient = openAiImag
         size: request.size,
         background: request.background,
         referenceImages: request.referenceImages,
+        maskImage: request.maskImage,
     });
 
     return {

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -5,7 +5,10 @@ import { createGoogleImageProvider, extractGoogleImageData } from './ImageProvid
 
 describe('ImageWorkflow', () => {
     it('routes generate requests through the configured provider for the selected model', async () => {
-        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            void input;
+            return { b64_json: 'generated' };
+        });
         const providers: ImageProviderRegistry = {
             openai: {
                 generate,
@@ -76,7 +79,10 @@ describe('ImageWorkflow', () => {
     });
 
     it('falls back to the default generation size when aspect ratio value is unsupported', async () => {
-        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (request: Parameters<ImageProvider['generate']>[0]) => {
+            void request;
+            return { b64_json: 'generated' };
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate,
@@ -250,8 +256,10 @@ describe('ImageWorkflow', () => {
 
     it('sends selected-layer edit requests with composition context before user references', async () => {
         let seenReferenceImages: File[] = [];
+        let seenMaskImage: File | Blob | null | undefined;
         const edit = vi.fn(async (input: Parameters<ImageProvider['edit']>[0]) => {
             seenReferenceImages = input.referenceImages ?? [];
+            seenMaskImage = input.maskImage;
             return { b64_json: 'edited' };
         });
         const providers: ImageProviderRegistry = {
@@ -264,6 +272,7 @@ describe('ImageWorkflow', () => {
         const sourceImage = new Blob(['selected-layer'], { type: 'image/png' });
         const compositionContext = new File(['composition'], 'composition-context.png', { type: 'image/png' });
         const userReference = new File(['reference'], 'user-reference.png', { type: 'image/png' });
+        const maskImage = new File(['mask'], 'mask.png', { type: 'image/png' });
 
         await workflow.edit({
             apiKey: 'sk-test',
@@ -271,6 +280,7 @@ describe('ImageWorkflow', () => {
             sourceImage,
             compositionContextImage: compositionContext,
             referenceImages: [userReference],
+            maskImage,
         });
 
         expect(seenReferenceImages.map((file) => file.name)).toEqual([
@@ -278,10 +288,14 @@ describe('ImageWorkflow', () => {
             'composition-context.png',
             'user-reference.png',
         ]);
+        expect(seenMaskImage).toBe(maskImage);
     });
 
     it('maps nano-banana-pro Editor AI transforms with source handling and Reference image limits', async () => {
-        const edit = vi.fn(async (_request: Parameters<ImageProvider['edit']>[0]) => ({ b64_json: 'edited-nano' }));
+        const edit = vi.fn(async (request: Parameters<ImageProvider['edit']>[0]) => {
+            void request;
+            return { b64_json: 'edited-nano' };
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -356,6 +370,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
+                capabilities: { transformMask: false },
             },
             prompt: 'a luminous teapot city',
             aspectRatio: '16:9',
@@ -385,7 +400,10 @@ describe('googleImageProvider', () => {
     });
 
     it('normalizes unsupported Nano Banana aspect ratios to 1:1', async () => {
-        const generate = vi.fn(async (_request: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (request: Parameters<ImageProvider['generate']>[0]) => {
+            void request;
+            return { b64_json: 'generated' };
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -416,7 +434,10 @@ describe('googleImageProvider', () => {
     });
 
     it('uses only the first 14 references for Nano Banana generation requests', async () => {
-        const generate = vi.fn(async (_input: Parameters<ImageProvider['generate']>[0]) => ({ b64_json: 'generated' }));
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            void input;
+            return { b64_json: 'generated' };
+        });
         const workflow = createImageWorkflow({
             openai: {
                 generate: vi.fn(),
@@ -486,6 +507,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
+                capabilities: { transformMask: false },
             },
             prompt: 'make it cinematic',
             preserveSourceDimensions: true,
@@ -540,6 +562,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
+                capabilities: { transformMask: false },
             },
             prompt: 'a luminous teapot city',
             referenceImages: [],

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -34,6 +34,7 @@ export interface EditImageInput {
     sourceImage: Blob;
     compositionContextImage?: File | null;
     referenceImages: File[];
+    maskImage?: File | Blob | null;
     quality?: ImageQuality;
     aspectRatio?: NanoBananaAspectRatio;
     imageSize?: NanoBananaImageSize;
@@ -81,6 +82,7 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
                 apiKey: input.apiKey,
                 model,
                 prompt: input.prompt,
+                maskImage: input.maskImage,
                 ...providerRequest,
             }));
         },

--- a/src/index.css
+++ b/src/index.css
@@ -1401,6 +1401,100 @@ textarea.aura-input {
     align-items: flex-start;
 }
 
+.transform-mask-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--element-gap);
+}
+
+.transform-mask-controls .btn-ghost.active {
+    color: var(--color-amber-glow);
+    border-color: var(--color-amber-glow);
+}
+
+.modal-content.transform-mask-dialog {
+    width: min(920px, calc(100vw - 48px));
+    height: min(760px, calc(100vh - 48px));
+    flex-direction: column;
+    padding: var(--spacing-24);
+    gap: var(--spacing-16);
+    border: 1px solid var(--color-steel);
+}
+
+.transform-mask-toolbar,
+.transform-mask-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-16);
+}
+
+.transform-mask-toolbar .modal-close {
+    position: static;
+    inset: auto;
+    flex: 0 0 auto;
+}
+
+.transform-mask-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-powder);
+    overflow: hidden;
+}
+
+.transform-mask-stage {
+    position: relative;
+    max-width: 100%;
+    max-height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.transform-mask-target {
+    max-width: 100%;
+    max-height: calc(100vh - 220px);
+    object-fit: contain;
+    display: block;
+}
+
+.transform-mask-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    touch-action: none;
+    cursor: crosshair;
+    mix-blend-mode: screen;
+    opacity: 0.7;
+}
+
+.transform-mask-actions {
+    flex-wrap: wrap;
+}
+
+.mask-tool-toggle {
+    min-width: 140px;
+}
+
+.mask-size-control {
+    flex: 1;
+    min-width: 220px;
+    display: flex;
+    align-items: center;
+    gap: var(--element-gap);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    color: var(--color-steel);
+}
+
+.mask-size-control input {
+    flex: 1;
+}
+
 .modal-main {
     flex: 1;
     min-width: 0;

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -23,7 +23,7 @@ export const dataURLtoFile = (dataurl: string, filename: string): File => {
 
     try {
         bstr = atob(encoded);
-    } catch (error) {
+    } catch {
         throw new Error('Invalid data URL: malformed base64 payload');
     }
 

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -52,10 +52,12 @@ describe('openAiImageClient', () => {
         vi.stubGlobal('fetch', fetchMock);
         try {
             const referenceImage = new File(['source image'], 'source.png', { type: 'image/png' });
+            const maskImage = new File(['mask image'], 'mask.png', { type: 'image/png' });
             const result = await openAiImageClient.createImage({
                 apiKey: 'sk-test',
                 prompt: 'replace the cat',
                 referenceImages: [referenceImage],
+                maskImage,
                 model: OPENAI_IMAGE_MODEL,
                 quality: 'low',
                 size: '1024x1024',
@@ -83,6 +85,7 @@ describe('openAiImageClient', () => {
             expect(form.get('quality')).toBe('low');
             expect(form.get('background')).toBe('opaque');
             expect(form.get('size')).toBe('1024x1024');
+            expect(form.get('mask')).toBe(maskImage);
             expect(fileValues).toHaveLength(1);
             expect(fileValues[0]?.[1]).toBeInstanceOf(File);
         } finally {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -17,6 +17,7 @@ export interface OpenAiImageRequest {
     size?: string;
     background?: ImageBackground;
     referenceImages?: File[];
+    maskImage?: File | Blob | null;
 }
 
 export interface OpenAiImageResponse {
@@ -63,6 +64,10 @@ export const openAiImageClient: OpenAiImageClient = {
             request.referenceImages?.forEach((file) => {
                 formData.append('image[]', file);
             });
+
+            if (request.maskImage) {
+                formData.append('mask', request.maskImage);
+            }
 
             if (request.size && request.size !== 'auto') formData.append('size', request.size);
             if (request.quality) formData.append('quality', request.quality);

--- a/src/utils/openaiModels.test.ts
+++ b/src/utils/openaiModels.test.ts
@@ -33,6 +33,9 @@ describe('openaiModels image registry', () => {
                 quality: 'quality',
                 background: 'background',
             },
+            capabilities: {
+                transformMask: true,
+            },
         });
     });
 
@@ -48,6 +51,9 @@ describe('openaiModels image registry', () => {
             parameters: {
                 aspectRatio: 'generationConfig.imageConfig.aspectRatio',
                 imageSize: 'generationConfig.imageConfig.imageSize',
+            },
+            capabilities: {
+                transformMask: false,
             },
         });
     });

--- a/src/utils/openaiModels.ts
+++ b/src/utils/openaiModels.ts
@@ -22,6 +22,9 @@ export interface ImageModelConfig {
         edit: string;
     };
     parameters: Partial<Record<'size' | 'quality' | 'background' | 'aspectRatio' | 'imageSize', string>>;
+    capabilities: {
+        transformMask: boolean;
+    };
 }
 
 export interface ReasoningModelConfig {
@@ -47,6 +50,9 @@ export const IMAGE_MODEL_REGISTRY = {
             quality: 'quality',
             background: 'background',
         },
+        capabilities: {
+            transformMask: true,
+        },
     },
     [NANO_BANANA_PRO_IMAGE_MODEL]: {
         slug: NANO_BANANA_PRO_IMAGE_MODEL,
@@ -60,6 +66,9 @@ export const IMAGE_MODEL_REGISTRY = {
         parameters: {
             aspectRatio: 'generationConfig.imageConfig.aspectRatio',
             imageSize: 'generationConfig.imageConfig.imageSize',
+        },
+        capabilities: {
+            transformMask: false,
         },
     },
 } as const satisfies Record<string, ImageModelConfig>;

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Undo2, Redo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy, Layers, RotateCcw, ChevronDown, ChevronRight } from 'lucide-react';
+import { Undo2, Redo2, Save, MoveHorizontal, Sliders, Palette, Sparkles, Loader2, X, Upload, Copy, Layers, RotateCcw, ChevronDown, ChevronRight, Paintbrush, Eraser } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { EditorCanvas, type EditorCanvasHandle } from '../editor/EditorCanvas';
 import { LayerPanel } from '../editor/LayerPanel';
@@ -8,8 +8,10 @@ import { useEditorController } from '../editor/useEditorController';
 import { useEditorSession } from '../editor/useEditorSession';
 import type { EditorSaveContext } from '../editor/saveEditedImage';
 import { OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig, type ImageModelSlug, type Provider } from '../utils/openaiModels';
-import { getImageModelReferenceLimitMessage, getImageModelUiChoices } from '../image-models/ImageModelControls';
+import { getImageModelReferenceLimitMessage, getImageModelUiChoices, imageModelSupportsTransformMask } from '../image-models/ImageModelControls';
 import { getImageFilesFromClipboard } from '../references/clipboard';
+import { renderAiTransformEditInput } from '../editor/aiTransform';
+import { classifyTransformMaskCoverage } from '../editor/transformMask';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
@@ -22,9 +24,19 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
     const [aiEditModel, setAiEditModel] = useState<ImageModelSlug>(defaultModel);
     const [adjustmentsOpen, setAdjustmentsOpen] = useState(true);
     const [filtersOpen, setFiltersOpen] = useState(true);
+    const [maskEditorOpen, setMaskEditorOpen] = useState(false);
+    const [maskTargetUrl, setMaskTargetUrl] = useState<string | null>(null);
+    const [maskLoading, setMaskLoading] = useState(false);
+    const [maskError, setMaskError] = useState<string | null>(null);
+    const [maskTool, setMaskTool] = useState<'brush' | 'eraser'>('brush');
+    const [maskBrushSize, setMaskBrushSize] = useState(32);
+    const [transformMaskFile, setTransformMaskFile] = useState<File | null>(null);
     const canvasRef = useRef<EditorCanvasHandle>(null);
+    const maskCanvasRef = useRef<HTMLCanvasElement>(null);
+    const paintingMaskRef = useRef(false);
     const activeModel = resolveImageModelConfig(aiEditModel);
     const activeApiKey = getProviderKey(activeModel.provider);
+    const supportsTransformMask = imageModelSupportsTransformMask(aiEditModel);
     const {
         brightness,
         setBrightness,
@@ -85,6 +97,7 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         model: aiEditModel,
         isCanvasReady: isReady,
         draft,
+        maskImage: supportsTransformMask ? transformMaskFile : null,
         commitDraft,
         referenceImages,
         addReferenceFiles,
@@ -97,6 +110,137 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         onSave,
     });
     const aiReferenceWarning = getImageModelReferenceLimitMessage(aiEditModel, referenceImages.length, 'AI transforms');
+
+    useEffect(() => {
+        if (!supportsTransformMask) {
+            setTransformMaskFile(null);
+            setMaskEditorOpen(false);
+        }
+    }, [supportsTransformMask]);
+
+    useEffect(() => () => {
+        if (maskTargetUrl) {
+            URL.revokeObjectURL(maskTargetUrl);
+        }
+    }, [maskTargetUrl]);
+
+    const openMaskEditor = async () => {
+        if (!draft) {
+            return;
+        }
+
+        setMaskEditorOpen(true);
+        setMaskLoading(true);
+        setMaskError(null);
+        try {
+            const input = await renderAiTransformEditInput({
+                draft,
+                adjustments,
+                referenceImages: [],
+            });
+            const url = URL.createObjectURL(input.sourceImage);
+            setMaskTargetUrl((previousUrl) => {
+                if (previousUrl) URL.revokeObjectURL(previousUrl);
+                return url;
+            });
+        } catch (error) {
+            setMaskError(error instanceof Error ? error.message : 'Failed to render transform target');
+        } finally {
+            setMaskLoading(false);
+        }
+    };
+
+    const handleMaskTargetLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+        const canvas = maskCanvasRef.current;
+        if (!canvas) return;
+
+        const imageElement = event.currentTarget;
+        canvas.width = imageElement.naturalWidth;
+        canvas.height = imageElement.naturalHeight;
+        const context = canvas.getContext('2d');
+        if (!context) return;
+
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        if (!transformMaskFile) return;
+
+        const maskUrl = URL.createObjectURL(transformMaskFile);
+        const maskImage = new Image();
+        maskImage.onload = () => {
+            context.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+            URL.revokeObjectURL(maskUrl);
+        };
+        maskImage.onerror = () => URL.revokeObjectURL(maskUrl);
+        maskImage.src = maskUrl;
+    };
+
+    const paintMaskAt = (event: React.PointerEvent<HTMLCanvasElement>) => {
+        const canvas = maskCanvasRef.current;
+        const context = canvas?.getContext('2d');
+        if (!canvas || !context) return;
+
+        const rect = canvas.getBoundingClientRect();
+        const x = (event.clientX - rect.left) * (canvas.width / rect.width);
+        const y = (event.clientY - rect.top) * (canvas.height / rect.height);
+
+        context.save();
+        context.globalCompositeOperation = maskTool === 'eraser' ? 'destination-out' : 'source-over';
+        context.fillStyle = 'rgba(255, 255, 255, 1)';
+        context.beginPath();
+        context.arc(x, y, maskBrushSize / 2, 0, Math.PI * 2);
+        context.fill();
+        context.restore();
+    };
+
+    const handleMaskPointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+        paintingMaskRef.current = true;
+        event.currentTarget.setPointerCapture(event.pointerId);
+        paintMaskAt(event);
+    };
+
+    const stopMaskPainting = () => {
+        paintingMaskRef.current = false;
+    };
+
+    const handleMaskPointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+        if (paintingMaskRef.current) {
+            paintMaskAt(event);
+        }
+    };
+
+    const clearTransformMask = () => {
+        const canvas = maskCanvasRef.current;
+        const context = canvas?.getContext('2d');
+        if (canvas && context) {
+            context.clearRect(0, 0, canvas.width, canvas.height);
+        }
+        setTransformMaskFile(null);
+        setMaskError(null);
+    };
+
+    const applyTransformMask = async () => {
+        const canvas = maskCanvasRef.current;
+        const context = canvas?.getContext('2d');
+        if (!canvas || !context) {
+            setMaskError('Mask editor is not ready.');
+            return;
+        }
+
+        const maskData = context.getImageData(0, 0, canvas.width, canvas.height);
+        if (classifyTransformMaskCoverage(maskData) === 'empty') {
+            setMaskError('Paint a mask before applying it.');
+            return;
+        }
+
+        const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+        if (!blob) {
+            setMaskError('Failed to create mask image.');
+            return;
+        }
+
+        setTransformMaskFile(new File([blob], 'transform-mask.png', { type: 'image/png' }));
+        setMaskEditorOpen(false);
+        setMaskError(null);
+    };
 
     const handleReferencePaste = (event: React.ClipboardEvent) => {
         const files = getImageFilesFromClipboard(event);
@@ -348,6 +492,28 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
                                 style={{ minHeight: '100px', resize: 'vertical' }}
                                 disabled={aiLoading || !activeApiKey || !isCanvasReady}
                             />
+                            {supportsTransformMask && (
+                                <div className="transform-mask-controls">
+                                    <button
+                                        className={`btn-ghost ${transformMaskFile ? 'active' : ''}`}
+                                        type="button"
+                                        onClick={() => { void openMaskEditor(); }}
+                                        disabled={aiLoading || !isCanvasReady || !draft}
+                                    >
+                                        <Paintbrush size={16} /> {transformMaskFile ? 'Edit Mask' : 'Mask'}
+                                    </button>
+                                    {transformMaskFile && (
+                                        <button
+                                            className="btn-ghost"
+                                            type="button"
+                                            onClick={clearTransformMask}
+                                            disabled={aiLoading}
+                                        >
+                                            <X size={16} /> Clear Mask
+                                        </button>
+                                    )}
+                                </div>
+                            )}
                             <button
                                 className="btn-amber"
                                 onClick={() => { void applyAiEdit(); }}
@@ -425,6 +591,87 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
                     </div>
                 </aside>
             </div>
+            {maskEditorOpen && (
+                <div className="modal-overlay transform-mask-modal" role="dialog" aria-modal="true">
+                    <div className="modal-content transform-mask-dialog">
+                        <div className="transform-mask-toolbar">
+                            <div className="section-title">
+                                <Paintbrush size={18} className="icon-purple" />
+                                <h3>Transform Mask</h3>
+                            </div>
+                            <button className="modal-close" onClick={() => setMaskEditorOpen(false)} aria-label="Close mask editor">
+                                <X size={20} />
+                            </button>
+                        </div>
+
+                        <div className="transform-mask-body">
+                            {maskLoading && (
+                                <div className="empty-state">
+                                    <Loader2 className="spin" size={28} />
+                                </div>
+                            )}
+                            {!maskLoading && maskTargetUrl && (
+                                <div className="transform-mask-stage">
+                                    <img
+                                        src={maskTargetUrl}
+                                        alt="AI transform target"
+                                        className="transform-mask-target"
+                                        onLoad={handleMaskTargetLoad}
+                                    />
+                                    <canvas
+                                        ref={maskCanvasRef}
+                                        className="transform-mask-canvas"
+                                        onPointerDown={handleMaskPointerDown}
+                                        onPointerMove={handleMaskPointerMove}
+                                        onPointerUp={stopMaskPainting}
+                                        onPointerCancel={stopMaskPainting}
+                                        onPointerLeave={stopMaskPainting}
+                                    />
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="transform-mask-actions">
+                            <div className="toggle-group mask-tool-toggle">
+                                <button
+                                    className={maskTool === 'brush' ? 'active' : ''}
+                                    onClick={() => setMaskTool('brush')}
+                                    type="button"
+                                    title="Brush"
+                                >
+                                    <Paintbrush size={16} />
+                                </button>
+                                <button
+                                    className={maskTool === 'eraser' ? 'active' : ''}
+                                    onClick={() => setMaskTool('eraser')}
+                                    type="button"
+                                    title="Eraser"
+                                >
+                                    <Eraser size={16} />
+                                </button>
+                            </div>
+                            <label className="mask-size-control">
+                                <span>Size</span>
+                                <input
+                                    type="range"
+                                    min={8}
+                                    max={96}
+                                    value={maskBrushSize}
+                                    onChange={(event) => setMaskBrushSize(Number(event.target.value))}
+                                />
+                                <span>{maskBrushSize}</span>
+                            </label>
+                            <button className="btn-ghost" type="button" onClick={clearTransformMask}>
+                                <RotateCcw size={16} /> Clear
+                            </button>
+                            <button className="btn-amber" type="button" onClick={() => { void applyTransformMask(); }}>
+                                <Save size={16} /> Apply Mask
+                            </button>
+                        </div>
+                        {maskError && <div className="error-message mini">{maskError}</div>}
+                    </div>
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- Add transient transform mask editor over the AI transform target
- Gate mask UI by image model capability and validate non-empty masks
- Thread mask images through editor transform, workflow/provider, and OpenAI edit requests

Closes #71