### PR TITLE
Batch persistence, reload survival, and save all

### DIFF
--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { StorageProvider } from '../services/StorageService';
-import { createGenerateSessionStore, DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft } from './GenerateSession';
+import { createGenerateSessionStore, DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft, type GenerateBatchSnapshot } from './GenerateSession';
 
 describe('GenerateSession draft migration', () => {
     it('migrates legacy flat controls into the gpt-image-2 block', () => {
@@ -84,6 +84,74 @@ describe('GenerateSession draft migration', () => {
 
         await expect(store.loadCurrentResult()).resolves.toBeNull();
         await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
+    });
+
+    it('round-trips the current generation batch with slot state and run context', async () => {
+        const store = createGenerateSessionStore({
+            blobStorage: new InMemoryStorageProvider(),
+        });
+        const batch: GenerateBatchSnapshot = {
+            results: [
+                {
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,result-0',
+                    isSaved: true,
+                    archiveImageId: 'archive-0',
+                },
+                {
+                    slotIndex: 1,
+                    status: 'failed',
+                    error: 'content filter',
+                },
+                {
+                    slotIndex: 2,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,result-2',
+                    isSaved: false,
+                },
+            ],
+            references: ['data:image/png;base64,used-ref'],
+            draft: {
+                ...DEFAULT_GENERATE_DRAFT,
+                prompt: 'stored run prompt',
+                gptImage2: {
+                    ...DEFAULT_GENERATE_DRAFT.gptImage2,
+                    batchSize: 3,
+                },
+            },
+            lineageSource: {
+                archiveImageId: 'source-image',
+                stepId: 'source-step',
+            },
+        };
+
+        await store.saveCurrentBatch(batch);
+
+        await expect(store.loadCurrentBatch()).resolves.toEqual(batch);
+        await expect(store.loadCurrentResult()).resolves.toBe('data:image/png;base64,result-0');
+        await expect(store.loadCurrentResultReferences()).resolves.toEqual(['data:image/png;base64,used-ref']);
+    });
+
+    it('migrates legacy single-result storage into a one-item generation batch', async () => {
+        const blobStorage = new InMemoryStorageProvider();
+        await blobStorage.save('generate_current_result', 'data:image/png;base64,legacy-result');
+        await blobStorage.save('generate_current_result_references', JSON.stringify([
+            'data:image/png;base64,legacy-ref',
+        ]));
+        const store = createGenerateSessionStore({ blobStorage });
+
+        await expect(store.loadCurrentBatch()).resolves.toEqual({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,legacy-result',
+                isSaved: false,
+            }],
+            references: ['data:image/png;base64,legacy-ref'],
+            draft: null,
+            lineageSource: null,
+        });
     });
 });
 

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -23,6 +23,7 @@ import {
 const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_CURRENT_RESULT_REFERENCES_KEY = 'generate_current_result_references';
+const GENERATE_CURRENT_BATCH_KEY = 'generate_current_batch';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
 const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 
@@ -57,6 +58,27 @@ export interface GenerateLineageSource {
     stepId?: string | null;
 }
 
+export type GenerateResultSlot =
+    | {
+        slotIndex: number;
+        status: 'success';
+        imageUrl: string;
+        isSaved: boolean;
+        archiveImageId?: string;
+    }
+    | {
+        slotIndex: number;
+        status: 'failed';
+        error: string;
+    };
+
+export interface GenerateBatchSnapshot {
+    results: GenerateResultSlot[];
+    references: string[] | null;
+    draft: GenerateDraft | null;
+    lineageSource: GenerateLineageSource | null;
+}
+
 export interface GenerateSessionStore {
     readDraft(): GenerateDraft;
     writeDraft(draft: GenerateDraft): void;
@@ -64,6 +86,8 @@ export interface GenerateSessionStore {
     loadLineageSource(): GenerateLineageSource | null;
     saveLineageSource(source: GenerateLineageSource): void;
     clearLineageSource(): void;
+    loadCurrentBatch(): Promise<GenerateBatchSnapshot | null>;
+    saveCurrentBatch(batch: GenerateBatchSnapshot): Promise<void>;
     loadCurrentResult(): Promise<string | null>;
     loadCurrentResultReferences(): Promise<string[] | null>;
     saveCurrentResult(result: string, usedReferences?: string[] | null): Promise<void>;
@@ -161,38 +185,71 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         this.localStorage.removeItem(GENERATE_LINEAGE_SOURCE_KEY);
     }
 
-    loadCurrentResult(): Promise<string | null> {
-        return this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
-    }
+    async loadCurrentBatch(): Promise<GenerateBatchSnapshot | null> {
+        const storedBatch = await this.blobStorage.load(GENERATE_CURRENT_BATCH_KEY);
+        const batch = storedBatch ? parseGenerateBatchSnapshot(storedBatch) : null;
 
-    async loadCurrentResultReferences(): Promise<string[] | null> {
-        const value = await this.blobStorage.load(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
-        if (!value) {
-            return null;
+        if (batch) {
+            return batch;
         }
 
-        try {
-            const references = JSON.parse(value) as unknown;
-            return Array.isArray(references) && references.every((reference) => typeof reference === 'string')
-                ? references
-                : null;
-        } catch {
-            return null;
-        }
+        return this.loadLegacyCurrentBatch();
     }
 
-    async saveCurrentResult(result: string, usedReferences: string[] | null = null): Promise<void> {
-        await this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
-        if (Array.isArray(usedReferences)) {
-            await this.blobStorage.save(GENERATE_CURRENT_RESULT_REFERENCES_KEY, JSON.stringify(usedReferences));
+    async saveCurrentBatch(batch: GenerateBatchSnapshot): Promise<void> {
+        const snapshot = sanitizeGenerateBatchSnapshot(batch);
+
+        if (!snapshot) {
+            await this.clearCurrentResult();
             return;
         }
 
-        await this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+        await this.blobStorage.save(GENERATE_CURRENT_BATCH_KEY, JSON.stringify(snapshot));
+        const firstSuccessfulResult = getFirstSuccessfulResultSlot(snapshot.results);
+
+        if (firstSuccessfulResult) {
+            await this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, firstSuccessfulResult.imageUrl);
+            if (Array.isArray(snapshot.references)) {
+                await this.blobStorage.save(GENERATE_CURRENT_RESULT_REFERENCES_KEY, JSON.stringify(snapshot.references));
+                return;
+            }
+
+            await this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+            return;
+        }
+
+        await Promise.all([
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY),
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY),
+        ]);
+    }
+
+    async loadCurrentResult(): Promise<string | null> {
+        const batch = await this.loadCurrentBatch();
+        return getFirstSuccessfulResultSlot(batch?.results ?? [])?.imageUrl ?? null;
+    }
+
+    async loadCurrentResultReferences(): Promise<string[] | null> {
+        return (await this.loadCurrentBatch())?.references ?? null;
+    }
+
+    async saveCurrentResult(result: string, usedReferences: string[] | null = null): Promise<void> {
+        await this.saveCurrentBatch({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: result,
+                isSaved: false,
+            }],
+            references: usedReferences,
+            draft: null,
+            lineageSource: null,
+        });
     }
 
     async clearCurrentResult(): Promise<void> {
         await Promise.all([
+            this.blobStorage.remove(GENERATE_CURRENT_BATCH_KEY),
             this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY),
             this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY),
         ]);
@@ -242,6 +299,42 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
 
     private clearLegacyDraftKeys() {
         Object.values(LEGACY_KEYS).forEach((key) => this.localStorage.removeItem(key));
+    }
+
+    private async loadLegacyCurrentBatch(): Promise<GenerateBatchSnapshot | null> {
+        const result = await this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
+
+        if (!result) {
+            return null;
+        }
+
+        return {
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: result,
+                isSaved: false,
+            }],
+            references: await this.loadLegacyCurrentResultReferences(),
+            draft: null,
+            lineageSource: this.loadLineageSource(),
+        };
+    }
+
+    private async loadLegacyCurrentResultReferences(): Promise<string[] | null> {
+        const value = await this.blobStorage.load(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+        if (!value) {
+            return null;
+        }
+
+        try {
+            const references = JSON.parse(value) as unknown;
+            return Array.isArray(references) && references.every((reference) => typeof reference === 'string')
+                ? references
+                : null;
+        } catch {
+            return null;
+        }
     }
 }
 
@@ -338,3 +431,103 @@ export function getActiveGenerateArchiveFields(draft: GenerateDraft): ImageModel
 }
 
 export const getImageModelDraftKey = resolveImageModelDraftKey;
+
+function parseGenerateBatchSnapshot(value: string): GenerateBatchSnapshot | null {
+    try {
+        return sanitizeGenerateBatchSnapshot(JSON.parse(value) as unknown);
+    } catch {
+        return null;
+    }
+}
+
+function sanitizeGenerateBatchSnapshot(value: unknown): GenerateBatchSnapshot | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const results = Array.isArray(record.results)
+        ? record.results.map(sanitizeGenerateResultSlot).filter((result): result is GenerateResultSlot => result !== null)
+        : [];
+
+    if (results.length === 0) {
+        return null;
+    }
+
+    return {
+        results,
+        references: sanitizeReferenceDataUrls(record.references),
+        draft: record.draft ? sanitizeGenerateDraft(record.draft as DraftLike) : null,
+        lineageSource: sanitizeGenerateLineageSource(record.lineageSource),
+    };
+}
+
+function sanitizeGenerateResultSlot(value: unknown): GenerateResultSlot | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const slotIndex = coerceSlotIndex(record.slotIndex);
+    if (slotIndex === null) {
+        return null;
+    }
+
+    if (record.status === 'success' && typeof record.imageUrl === 'string' && record.imageUrl.length > 0) {
+        return {
+            slotIndex,
+            status: 'success',
+            imageUrl: record.imageUrl,
+            isSaved: record.isSaved === true,
+            ...(typeof record.archiveImageId === 'string' && record.archiveImageId
+                ? { archiveImageId: record.archiveImageId }
+                : {}),
+        };
+    }
+
+    if (record.status === 'failed' && typeof record.error === 'string' && record.error.length > 0) {
+        return {
+            slotIndex,
+            status: 'failed',
+            error: record.error,
+        };
+    }
+
+    return null;
+}
+
+function sanitizeReferenceDataUrls(value: unknown): string[] | null {
+    return Array.isArray(value) && value.every((reference) => typeof reference === 'string')
+        ? value
+        : null;
+}
+
+function sanitizeGenerateLineageSource(value: unknown): GenerateLineageSource | null {
+    const record = asRecord(value);
+    if (!record || typeof record.archiveImageId !== 'string' || !record.archiveImageId) {
+        return null;
+    }
+
+    return {
+        archiveImageId: record.archiveImageId,
+        stepId: typeof record.stepId === 'string' ? record.stepId : null,
+    };
+}
+
+function getFirstSuccessfulResultSlot(results: GenerateResultSlot[]) {
+    return results.find((result): result is Extract<GenerateResultSlot, { status: 'success' }> =>
+        result.status === 'success',
+    ) ?? null;
+}
+
+function coerceSlotIndex(value: unknown): number | null {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        return null;
+    }
+
+    return value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -7,6 +7,7 @@ import {
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
     notifyGenerateCompletion,
+    saveGenerateResultSlots,
     snapshotGeneratedReferenceImages,
 } from './useGenerateController';
 
@@ -92,6 +93,96 @@ describe('Generate controller batch result slots', () => {
                 slotIndex: 1,
                 status: 'failed',
                 error: 'content filter',
+            },
+        ]);
+    });
+
+    it('save-all archives each unsaved successful slot without duplicating saved or failed slots', async () => {
+        const savedImages: string[] = [];
+        const nextResults = await saveGenerateResultSlots({
+            results: [
+                {
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,one',
+                    isSaved: false,
+                },
+                {
+                    slotIndex: 1,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,two',
+                    isSaved: true,
+                    archiveImageId: 'already-saved',
+                },
+                {
+                    slotIndex: 2,
+                    status: 'failed',
+                    error: 'content filter',
+                },
+                {
+                    slotIndex: 3,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,four',
+                    isSaved: false,
+                },
+            ],
+            draft: createDraft({ prompt: 'batch prompt' }),
+            runDraft: null,
+            usedReferences: [],
+            runLineageSource: null,
+            serializeReferences: vi.fn(async () => []),
+            saveImage: vi.fn(async (image) => {
+                savedImages.push(image.id);
+                return image;
+            }),
+            lineageStore: {
+                getByArchiveImageId: vi.fn(async () => []),
+                save: vi.fn(async (input) => ({
+                    id: input.id ?? 'lineage-step',
+                    archiveImageId: input.archiveImageId,
+                    parentStepId: input.parentStepId ?? null,
+                    stepType: input.stepType,
+                    timestamp: input.timestamp ?? '2026-06-05T12:00:00.000Z',
+                    metadata: input.metadata,
+                })),
+            },
+            sessionStore: {
+                loadLineageSource: vi.fn(() => null),
+                clearLineageSource: vi.fn(),
+            },
+            createArchiveImageId: vi.fn()
+                .mockReturnValueOnce('archive-0')
+                .mockReturnValueOnce('archive-3'),
+            now: vi.fn(() => new Date('2026-06-05T12:00:00.000Z')),
+        });
+
+        expect(savedImages).toEqual(['archive-0', 'archive-3']);
+        expect(nextResults).toEqual([
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,one',
+                isSaved: true,
+                archiveImageId: 'archive-0',
+            },
+            {
+                slotIndex: 1,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,two',
+                isSaved: true,
+                archiveImageId: 'already-saved',
+            },
+            {
+                slotIndex: 2,
+                status: 'failed',
+                error: 'content filter',
+            },
+            {
+                slotIndex: 3,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,four',
+                isSaved: true,
+                archiveImageId: 'archive-3',
             },
         ]);
     });

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateLineageSource, type GenerateSessionStore } from './GenerateSession';
+import {
+    generateSessionStore,
+    getActiveGenerateArchiveFields,
+    getActiveGenerateControls,
+    type GenerateBatchSnapshot,
+    type GenerateDraft,
+    type GenerateLineageSource,
+    type GenerateResultSlot,
+    type GenerateSessionStore,
+} from './GenerateSession';
 import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResult, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
@@ -31,20 +40,6 @@ interface AutopilotProgressState {
     lastErrorIteration: number | null;
 }
 
-export type GenerateResultSlot =
-    | {
-        slotIndex: number;
-        status: 'success';
-        imageUrl: string;
-        isSaved: boolean;
-        archiveImageId?: string;
-    }
-    | {
-        slotIndex: number;
-        status: 'failed';
-        error: string;
-    };
-
 interface UseGenerateControllerOptions {
     apiKey: string | null;
     reasoningApiKey?: string | null;
@@ -56,7 +51,7 @@ interface UseGenerateControllerOptions {
     serializeReferences: () => Promise<string[]>;
     onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
     lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
-    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'loadCurrentResultReferences' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentBatch' | 'saveCurrentBatch' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
     workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     createAutopilot?: typeof createAutopilotSession;
     evaluate?: typeof satisfactionEvaluator.evaluate;
@@ -86,6 +81,21 @@ interface BuildGeneratedArchiveImageForSaveInput {
     draft: GenerateDraft;
     usedReferences: string[] | null;
     serializeReferences: () => Promise<string[]>;
+}
+
+interface SaveGenerateResultSlotsInput {
+    results: GenerateResultSlot[];
+    slotIndexes?: number[];
+    draft: GenerateDraft;
+    runDraft: GenerateDraft | null;
+    usedReferences: string[] | null;
+    runLineageSource: GenerateLineageSource | null;
+    serializeReferences: () => Promise<string[]>;
+    saveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'clearLineageSource'>;
+    createArchiveImageId?: () => string;
+    now?: () => Date;
 }
 
 export function buildGeneratedArchiveImage({
@@ -139,6 +149,50 @@ export async function buildGeneratedArchiveImageForSave({
         draft,
         references,
     });
+}
+
+export async function saveGenerateResultSlots({
+    results,
+    slotIndexes,
+    draft,
+    runDraft,
+    usedReferences,
+    runLineageSource,
+    serializeReferences,
+    saveImage,
+    lineageStore,
+    sessionStore,
+    createArchiveImageId = () => crypto.randomUUID(),
+    now = () => new Date(),
+}: SaveGenerateResultSlotsInput): Promise<GenerateResultSlot[]> {
+    const selectedSlotIndexes = new Set(slotIndexes);
+    const shouldSaveSlot = (slot: GenerateResultSlot): slot is Extract<GenerateResultSlot, { status: 'success' }> => (
+        slot.status === 'success' &&
+        !slot.isSaved &&
+        (!slotIndexes || selectedSlotIndexes.has(slot.slotIndex))
+    );
+    let nextResults = results;
+
+    for (const slot of results.filter(shouldSaveSlot)) {
+        const archiveImageId = createArchiveImageId();
+        const image = await buildGeneratedArchiveImageForSave({
+            id: archiveImageId,
+            url: slot.imageUrl,
+            timestamp: now().toISOString(),
+            draft: runDraft ?? draft,
+            usedReferences,
+            serializeReferences,
+        });
+        await saveGeneratedImage(image, {
+            saveImage: async (image) => Promise.resolve(saveImage(image)),
+            lineageStore,
+            sessionStore,
+            lineageSource: runLineageSource,
+        });
+        nextResults = markGenerateResultSlotSaved(nextResults, slot.slotIndex, archiveImageId);
+    }
+
+    return nextResults;
 }
 
 export function notifyGenerateCompletion({
@@ -230,20 +284,16 @@ export function useGenerateController({
     }, [setDraft]);
 
     useEffect(() => {
-        Promise.all([
-            session.loadCurrentResult(),
-            session.loadCurrentResultReferences(),
-        ]).then(([value, references]) => {
-            if (value) {
-                setCurrentResult(value);
-                setCurrentBatchResults([{
-                    slotIndex: 0,
-                    status: 'success',
-                    imageUrl: value,
-                    isSaved: false,
-                }]);
-                setCurrentResultReferences(references);
+        session.loadCurrentBatch().then((batch) => {
+            if (!batch) {
+                return;
             }
+
+            setCurrentResult(getFirstSuccessfulResultSlot(batch.results)?.imageUrl ?? null);
+            setCurrentBatchResults(batch.results);
+            setCurrentResultReferences(batch.references);
+            setCurrentRunDraft(batch.draft);
+            setCurrentRunLineageSource(batch.lineageSource);
         });
 
         session.consumeTransferredReferences().then((references) => {
@@ -297,17 +347,23 @@ export function useGenerateController({
             });
             const imageUrl = getFirstSuccessfulGeneratedImage(results);
             const batchResults = buildGenerateResultSlots(results);
+            const batchSnapshot: GenerateBatchSnapshot = {
+                results: batchResults,
+                references: usedReferences,
+                draft: runDraft,
+                lineageSource: runLineageSource,
+            };
 
             setCurrentBatchResults(batchResults);
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
+            await session.saveCurrentBatch(batchSnapshot);
 
             if (!imageUrl) {
                 setCurrentResult(null);
                 updateDraft({ isSaved: false });
                 setError('Generation failed for every batch result.');
-                await session.clearCurrentResult();
                 completionNotification = {
                     title: 'Generation failed',
                     body: 'Every batch result failed.',
@@ -317,7 +373,6 @@ export function useGenerateController({
 
             setCurrentResult(imageUrl);
             updateDraft({ isSaved: false });
-            await session.saveCurrentResult(imageUrl, usedReferences);
             completionNotification = {
                 title: 'Generation complete',
                 body: 'Your image is ready in AURA.',
@@ -488,6 +543,13 @@ export function useGenerateController({
         autopilotSessionRef.current?.cancel();
     }, []);
 
+    const persistCurrentBatch = useCallback((results: GenerateResultSlot[]) => session.saveCurrentBatch({
+        results,
+        references: currentResultReferences,
+        draft: currentRunDraft ?? draft,
+        lineageSource: currentRunLineageSource,
+    }), [currentResultReferences, currentRunDraft, currentRunLineageSource, draft, session]);
+
     const saveResult = useCallback(async (slotIndex: number) => {
         const slot = currentBatchResults.find((result) => result.slotIndex === slotIndex);
         if (!slot || slot.status !== 'success' || slot.isSaved) {
@@ -495,34 +557,50 @@ export function useGenerateController({
         }
 
         try {
-            const archiveImageId = crypto.randomUUID();
-            const image = await buildGeneratedArchiveImageForSave({
-                id: archiveImageId,
-                url: slot.imageUrl,
-                timestamp: new Date().toISOString(),
-                draft: currentRunDraft ?? draft,
+            const nextResults = await saveGenerateResultSlots({
+                results: currentBatchResults,
+                slotIndexes: [slot.slotIndex],
+                draft,
+                runDraft: currentRunDraft,
                 usedReferences: currentResultReferences,
+                runLineageSource: currentRunLineageSource,
                 serializeReferences,
-            });
-            await saveGeneratedImage(image, {
-                saveImage: async (image) => Promise.resolve(onSaveImage(image)),
+                saveImage: onSaveImage,
                 lineageStore: lineage,
                 sessionStore: session,
-                lineageSource: currentRunLineageSource,
             });
-            const nextResults = currentBatchResults.map((result) => result.slotIndex === slotIndex && result.status === 'success'
-                ? {
-                    ...result,
-                    isSaved: true,
-                    archiveImageId,
-                }
-                : result);
             setCurrentBatchResults(nextResults);
+            await persistCurrentBatch(nextResults);
             updateDraft({ isSaved: areAllSuccessfulResultsSaved(nextResults) });
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
+    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, persistCurrentBatch, serializeReferences, session, updateDraft]);
+
+    const saveAllResults = useCallback(async () => {
+        if (!hasUnsavedSuccessfulResults(currentBatchResults)) {
+            return;
+        }
+
+        try {
+            const nextResults = await saveGenerateResultSlots({
+                results: currentBatchResults,
+                draft,
+                runDraft: currentRunDraft,
+                usedReferences: currentResultReferences,
+                runLineageSource: currentRunLineageSource,
+                serializeReferences,
+                saveImage: onSaveImage,
+                lineageStore: lineage,
+                sessionStore: session,
+            });
+            setCurrentBatchResults(nextResults);
+            await persistCurrentBatch(nextResults);
+            updateDraft({ isSaved: areAllSuccessfulResultsSaved(nextResults) });
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Failed to save batch');
+        }
+    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, persistCurrentBatch, serializeReferences, session, updateDraft]);
 
     const save = useCallback(async () => {
         await saveResult(0);
@@ -564,6 +642,7 @@ export function useGenerateController({
         cancelAutopilot,
         save,
         saveResult,
+        saveAllResults,
         download,
         downloadResult,
         clear,
@@ -587,6 +666,30 @@ function areAllSuccessfulResultsSaved(results: GenerateResultSlot[]) {
     );
 
     return successfulResults.length > 0 && successfulResults.every((result) => result.isSaved);
+}
+
+function hasUnsavedSuccessfulResults(results: GenerateResultSlot[]) {
+    return results.some((result) => result.status === 'success' && !result.isSaved);
+}
+
+function getFirstSuccessfulResultSlot(results: GenerateResultSlot[]) {
+    return results.find((result): result is Extract<GenerateResultSlot, { status: 'success' }> =>
+        result.status === 'success',
+    ) ?? null;
+}
+
+function markGenerateResultSlotSaved(
+    results: GenerateResultSlot[],
+    slotIndex: number,
+    archiveImageId: string,
+): GenerateResultSlot[] {
+    return results.map((result) => result.slotIndex === slotIndex && result.status === 'success'
+        ? {
+            ...result,
+            isSaved: true,
+            archiveImageId,
+        }
+        : result);
 }
 
 function cloneGenerateDraft(draft: GenerateDraft): GenerateDraft {

--- a/src/index.css
+++ b/src/index.css
@@ -857,6 +857,13 @@ textarea.aura-input {
     text-align: center;
 }
 
+.result-batch-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--element-gap);
+    flex-wrap: wrap;
+}
+
 .result-batch-clear {
     align-self: flex-end;
 }

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -210,6 +210,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
         cancelAutopilot,
         save,
         saveResult,
+        saveAllResults,
         download,
         downloadResult,
         clear,
@@ -324,6 +325,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const activeModelDraftKey = getImageModelDraftKey(model);
     const activeModelControls = draft[activeModelDraftKey] as Record<string, string | number>;
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
+    const hasUnsavedSuccessfulBatchResults = successfulBatchResults.some((result) => !result.isSaved);
     const showBatchGrid = currentBatchResults.length > 1 || currentBatchResults.some((result) => result.status === 'failed');
     const singleResultSlot = !showBatchGrid ? successfulBatchResults[0] : null;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
@@ -687,9 +689,18 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                     </div>
                                 ))}
                             </div>
-                            <button onClick={() => { void clear(); }} className="btn-ghost result-batch-clear">
-                                <Trash2 size={18} /> Clear Results
-                            </button>
+                            <div className="result-batch-actions">
+                                <button
+                                    onClick={() => { void saveAllResults(); }}
+                                    className="btn-amber"
+                                    disabled={!hasUnsavedSuccessfulBatchResults}
+                                >
+                                    <Archive size={18} /> Save All
+                                </button>
+                                <button onClick={() => { void clear(); }} className="btn-ghost result-batch-clear">
+                                    <Trash2 size={18} /> Clear Results
+                                </button>
+                            </div>
                         </div>
                     ) : currentResult ? (
                         <div className="result-container">


### PR DESCRIPTION
## Summary

- Persists the full generation batch snapshot, including per-slot success/failure state, saved state, run draft, references, and lineage source
- Migrates legacy single-result storage into a one-item batch for reload compatibility
- Adds Save All for batch results while skipping failed and already-saved slots

Closes #75.

## Validation

- pnpm vitest src/generate-session/GenerateSession.test.ts src/generate-session/useGenerateController.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- npm run build