### PR TITLE
Persist transform masks in lineage

### DIFF
--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -10,6 +10,7 @@ import { initializeAuraPersistence } from '../db/AuraPersistence';
 import { saveEditedImage, type EditorSaveContext } from '../editor/saveEditedImage';
 import { lineageStore } from '../lineage/LineageStore';
 import { createLineageNavigator } from '../lineage/LineageNavigator';
+import type { EditorReplay } from '../lineage/replayLineageStep';
 import { browserCompletionNotificationPort, type CompletionNotificationReadiness } from './CompletionNotificationPort';
 
 export function useAppController() {
@@ -32,6 +33,7 @@ export function useAppController() {
         onError: handleArchiveError,
     });
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
+    const [editorReplay, setEditorReplay] = useState<EditorReplay | null>(null);
     const [completionNotificationReadiness, setCompletionNotificationReadiness] = useState<CompletionNotificationReadiness>(
         () => browserCompletionNotificationPort.getReadiness(),
     );
@@ -128,6 +130,7 @@ export function useAppController() {
 
     const editImage = useCallback((image: ArchiveImage) => {
         setEditingImage(image);
+        setEditorReplay(null);
         changeView('editor');
     }, [changeView]);
 
@@ -152,6 +155,7 @@ export function useAppController() {
 
         changeView('archive');
         setEditingImage(null);
+        setEditorReplay(null);
     }, [addImage, addToast, changeView, editingImage]);
 
     const createSimilar = useCallback(async (image: ArchiveImage) => {
@@ -192,6 +196,7 @@ export function useAppController() {
                 return;
             }
             setEditingImage(outcome.image);
+            setEditorReplay(outcome.replay);
             changeView('editor');
             addToast('Lineage step loaded into Editor', 'info');
         } catch (error) {
@@ -254,6 +259,7 @@ export function useAppController() {
         },
         editorViewProps: {
             image: editingImage,
+            replay: editorReplay,
             getProviderKey: getKey,
             onSave: handleSaveEditedImage,
         },

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -5,6 +5,7 @@ import type { ArchiveImage } from '../db/types';
 import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE, LINEAGE_MANIFEST_VERSION } from './ArchiveTransfer';
 import { createLineageStore, type LineageMetadataPort, type LineageStep, type LineageStore } from '../lineage/LineageStore';
 import { OPENAI_IMAGE_MODEL, OPENAI_RESPONSES_MODEL } from '../utils/openaiModels';
+import type { EditorLineageMetadata, EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -142,6 +143,75 @@ describe('ArchiveTransfer', () => {
             expect.objectContaining({
                 id: 'typed-autopilot-step',
                 metadata: autopilotMetadata,
+            }),
+        ]);
+    });
+
+    it('exports transform mask lineage assets as ZIP files and hydrates them on import', async () => {
+        const sourceLineage = createStore();
+        const maskedMetadata = createTypedEditorMetadata();
+        maskedMetadata.aiEdit.transformMask = {
+            assetId: 'image-1:transform-mask',
+            dataUrl: 'data:image/png;base64,bWFzaw==',
+            mimeType: 'image/png',
+        };
+        maskedMetadata.transformMaskAsset = maskedMetadata.aiEdit.transformMask;
+        await sourceLineage.save({
+            id: 'masked-editor-step',
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'ai-edit',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: maskedMetadata,
+        });
+
+        const zipBytes = await buildArchiveZip([createImages()[0]!], { lineageStore: sourceLineage });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const maskFileName = 'aura-masked-editor-step-transform-mask.png';
+        const manifest = JSON.parse(await zip.file(LINEAGE_MANIFEST_FILE)!.async('text')) as {
+            steps: LineageStep[];
+        };
+
+        expect(await zip.file(maskFileName)?.async('text')).toBe('mask');
+        expect(manifest.steps[0]?.metadata).toEqual(expect.objectContaining({
+            aiEdit: expect.objectContaining({
+                transformMask: {
+                    assetId: 'image-1:transform-mask',
+                    fileName: maskFileName,
+                    mimeType: 'image/png',
+                },
+            }),
+            transformMaskAsset: {
+                assetId: 'image-1:transform-mask',
+                fileName: maskFileName,
+                mimeType: 'image/png',
+            },
+        }));
+        expect(JSON.stringify(manifest.steps[0]?.metadata)).not.toContain('data:image/png');
+
+        const importedLineage = createStore();
+        await importArchiveZip(zipBytes, {
+            archiveStore: new InMemoryArchiveStore(),
+            lineageStore: importedLineage,
+        });
+
+        await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
+            expect.objectContaining({
+                id: 'masked-editor-step',
+                metadata: expect.objectContaining({
+                    aiEdit: expect.objectContaining({
+                        transformMask: {
+                            assetId: 'image-1:transform-mask',
+                            dataUrl: 'data:image/png;base64,bWFzaw==',
+                            mimeType: 'image/png',
+                        },
+                    }),
+                    transformMaskAsset: {
+                        assetId: 'image-1:transform-mask',
+                        dataUrl: 'data:image/png;base64,bWFzaw==',
+                        mimeType: 'image/png',
+                    },
+                }),
             }),
         ]);
     });
@@ -465,7 +535,11 @@ function createTypedGenerateMetadata() {
     };
 }
 
-function createTypedEditorMetadata() {
+function createTypedEditorMetadata(): EditorLineageMetadata & {
+    aiEdit: NonNullable<EditorLineageMetadata['aiEdit']> & {
+        transformMask?: EditorLineageTransformMaskAsset;
+    };
+} {
     return {
         sourceImage: {
             archiveImageId: 'image-1',

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -79,7 +79,8 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
 
     zip.file(ARCHIVE_MANIFEST_FILE, JSON.stringify(createArchiveManifest(archiveManifestImages), null, 2));
 
-    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify(createLineageManifest(dedupeLineageSteps(lineageCollections)), null, 2));
+    const lineageSteps = await addLineageAssetsToZip(zip, dedupeLineageSteps(lineageCollections));
+    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify(createLineageManifest(lineageSteps), null, 2));
 
     return zip.generateAsync({ type: 'uint8array' });
 }
@@ -142,8 +143,9 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
 
     const importedStepIds: string[] = [];
     for (const step of lineageManifest.steps) {
-        await deps.lineageStore.save(step);
-        importedStepIds.push(step.id);
+        const hydratedStep = await hydrateLineageAssetsFromZip(zip, step, missingAssetFiles);
+        await deps.lineageStore.save(hydratedStep);
+        importedStepIds.push(hydratedStep.id);
     }
 
     return {
@@ -200,12 +202,60 @@ function getLayerFileName(imageId: string, layerId: string) {
     return `aura-${imageId}-layer-${layerId}.png`;
 }
 
+function getTransformMaskFileName(stepId: string, mimeType: string) {
+    return `aura-${stepId}-transform-mask.${mimeType === 'image/png' ? 'png' : 'bin'}`;
+}
+
 async function addLayerStackToZip(zip: JSZip, imageId: string, layerStack: ArchiveLayerStack): Promise<ArchiveManifestLayerStack> {
     await Promise.all(layerStack.layers.map(async (layer) => {
         zip.file(getLayerFileName(imageId, layer.id), await imageUrlToBytes(layer.assetUrl));
     }));
 
     return createArchiveManifestLayerStack(imageId, layerStack, getLayerFileName);
+}
+
+async function addLineageAssetsToZip(zip: JSZip, steps: LineageStep[]): Promise<LineageStep[]> {
+    return Promise.all(steps.map(async (step) => {
+        const nextStep = cloneLineageStep(step);
+        const transformMask = getTransformMaskAsset(nextStep.metadata);
+
+        if (!transformMask?.dataUrl) {
+            return nextStep;
+        }
+
+        const fileName = getTransformMaskFileName(step.id, transformMask.mimeType);
+        zip.file(fileName, await imageUrlToBytes(transformMask.dataUrl));
+        setTransformMaskAsset(nextStep.metadata, {
+            assetId: transformMask.assetId,
+            fileName,
+            mimeType: transformMask.mimeType,
+        });
+
+        return nextStep;
+    }));
+}
+
+async function hydrateLineageAssetsFromZip(zip: JSZip, step: LineageStep, missingAssetFiles: string[]): Promise<LineageStep> {
+    const nextStep = cloneLineageStep(step);
+    const transformMask = getTransformMaskAsset(nextStep.metadata);
+
+    if (!transformMask?.fileName || transformMask.dataUrl) {
+        return nextStep;
+    }
+
+    const file = zip.file(transformMask.fileName);
+    if (!file) {
+        missingAssetFiles.push(transformMask.fileName);
+        return nextStep;
+    }
+
+    setTransformMaskAsset(nextStep.metadata, {
+        assetId: transformMask.assetId,
+        dataUrl: bytesToDataUrl(await file.async('uint8array'), transformMask.mimeType),
+        mimeType: transformMask.mimeType,
+    });
+
+    return nextStep;
 }
 
 async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStack | undefined, missingAssetFiles: string[]): Promise<ArchiveLayerStack | undefined> {
@@ -236,8 +286,11 @@ async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStac
 }
 
 async function blobToDataUrl(blob: Blob) {
-    const mimeType = blob.type || 'image/png';
     const bytes = new Uint8Array(await blob.arrayBuffer());
+    return bytesToDataUrl(bytes, blob.type || 'image/png');
+}
+
+function bytesToDataUrl(bytes: Uint8Array, mimeType: string) {
     let binary = '';
 
     for (const byte of bytes) {
@@ -260,4 +313,57 @@ async function imageUrlToBytes(url: string) {
 
     const binary = atob(base64Data);
     return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+interface TransferTransformMaskAsset {
+    assetId: string | null;
+    dataUrl?: string;
+    fileName?: string;
+    mimeType: string;
+}
+
+function cloneLineageStep(step: LineageStep): LineageStep {
+    return {
+        ...step,
+        metadata: JSON.parse(JSON.stringify(step.metadata)) as Record<string, unknown>,
+    };
+}
+
+function getTransformMaskAsset(metadata: Record<string, unknown>): TransferTransformMaskAsset | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+    return readTransformMaskAsset(aiEdit?.transformMask) ?? readTransformMaskAsset(metadata.transformMaskAsset);
+}
+
+function setTransformMaskAsset(metadata: Record<string, unknown>, asset: TransferTransformMaskAsset) {
+    const aiEdit = asRecord(metadata.aiEdit);
+    if (aiEdit) {
+        aiEdit.transformMask = asset;
+    }
+    metadata.transformMaskAsset = asset;
+}
+
+function readTransformMaskAsset(value: unknown): TransferTransformMaskAsset | null {
+    const asset = asRecord(value);
+    if (!asset) {
+        return null;
+    }
+
+    const dataUrl = typeof asset.dataUrl === 'string' ? asset.dataUrl : undefined;
+    const fileName = typeof asset.fileName === 'string' ? asset.fileName : undefined;
+    if (!dataUrl && !fileName) {
+        return null;
+    }
+
+    return {
+        assetId: typeof asset.assetId === 'string' ? asset.assetId : null,
+        ...(dataUrl ? { dataUrl } : {}),
+        ...(fileName ? { fileName } : {}),
+        mimeType: typeof asset.mimeType === 'string' ? asset.mimeType : 'image/png',
+    };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
 }

--- a/src/editor/aiTransform.ts
+++ b/src/editor/aiTransform.ts
@@ -1,5 +1,7 @@
 import type { ArchiveLayerStack } from '../db/types';
+import type { EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { ImageModelSlug } from '../utils/openaiModels';
+import { fileToDataURL } from '../utils/file';
 import {
     insertAiResultLayer,
     planAiTransformTarget,
@@ -43,11 +45,13 @@ export interface AiTransformSaveProvenance extends AiTransformTargetMetadata {
     aiEditModel: ImageModelSlug;
     aiResultLayerId: string;
     aiResultLayerName: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export interface AiTransformProvenanceInput {
     prompt: string;
     model: ImageModelSlug;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export async function renderAiTransformEditInput({
@@ -98,6 +102,7 @@ export function applyAiTransformResultToDraft(
             ? {
                 aiEditPrompt: provenanceInput.prompt,
                 aiEditModel: provenanceInput.model,
+                ...(provenanceInput.transformMask ? { transformMask: provenanceInput.transformMask } : {}),
                 targetMode: targetPlan.metadata.targetMode,
                 targetLayerCount: targetPlan.metadata.targetLayerCount,
                 targetIncludesBaseLayer: targetPlan.metadata.targetIncludesBaseLayer,
@@ -153,4 +158,12 @@ function getWholeCompositionBounds(layerStack: ArchiveLayerStack): LayerBounds {
 
 function blobToFile(blob: Blob, name: string) {
     return new File([blob], name, { type: blob.type || 'image/png' });
+}
+
+export async function blobToTransformMaskAsset(maskImage: File | Blob): Promise<EditorLineageTransformMaskAsset> {
+    return {
+        assetId: null,
+        dataUrl: await fileToDataURL(maskImage),
+        mimeType: maskImage.type || 'image/png',
+    };
 }

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -246,6 +246,46 @@ describe('saveEditedImage', () => {
         }));
     });
 
+    it('stores masked AI edit lineage as a transform mask asset without adding mask layers', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        const savedImage = await saveEditedImage(createArchiveImage(), 'data:image/png;base64,masked-edit', {
+            ...createSaveContext(),
+            isCopy: true,
+            layerStack: createLayerStack(),
+            aiEditPrompt: 'replace only the painted area',
+            targetMode: 'selected-layers',
+            transformMask: {
+                assetId: null,
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            makeId: () => 'masked-copy',
+        });
+
+        const steps = await lineage.getByArchiveImageId(savedImage.id);
+        expect(steps.at(-1)?.metadata).toEqual(expect.objectContaining({
+            aiEdit: expect.objectContaining({
+                transformMask: {
+                    assetId: 'masked-copy:transform-mask',
+                    dataUrl: 'data:image/png;base64,bWFzaw==',
+                    mimeType: 'image/png',
+                },
+            }),
+            transformMaskAsset: {
+                assetId: 'masked-copy:transform-mask',
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
+        }));
+        expect(savedImage.layerStack?.layers.map((layer) => layer.id)).toEqual(['base', 'upload', 'ai-layer']);
+        expect(savedImage.layerStack?.layers.some((layer) => layer.id.includes('mask'))).toBe(false);
+    });
+
     it('persists layered save metadata without putting the full stack in lineage', async () => {
         const lineage = createStore();
         await seedSourceLineage(lineage);

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -1,5 +1,5 @@
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
-import { buildEditorLineageMetadata } from '../lineage/editorLineageMetadata';
+import { buildEditorLineageMetadata, type EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { EditorAdjustments } from './layers';
 
@@ -15,6 +15,7 @@ export interface EditorSaveContext {
     aiResultLayerName?: string | null;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export interface SaveEditedImageDeps {
@@ -104,5 +105,6 @@ function buildMetadata(sourceImage: ArchiveImage, savedImage: ArchiveImage, cont
         aiResultLayerName: context.aiResultLayerName,
         aiEditPrompt: context.aiEditPrompt,
         aiEditModel: context.aiEditModel,
+        transformMask: context.transformMask,
     });
 }

--- a/src/editor/useEditorController.test.ts
+++ b/src/editor/useEditorController.test.ts
@@ -70,6 +70,11 @@ describe('Editor controller AI transform flow', () => {
             isCopy: false,
             aiEditPrompt: 'replace the jacket',
             aiEditModel: OPENAI_IMAGE_MODEL,
+            transformMask: {
+                assetId: null,
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
             targetMode: 'selected-layers',
             targetLayerCount: 1,
             targetIncludesBaseLayer: false,

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -3,6 +3,7 @@ import { imageWorkflow, type EditImageInput } from '../image-workflow/ImageWorkf
 import type { ImageModelSlug } from '../utils/openaiModels';
 import {
     applyAiTransformResultToDraft,
+    blobToTransformMaskAsset,
     getAiTransformSaveProvenance,
     renderAiTransformEditInput,
     type AiTransformRenderer,
@@ -187,6 +188,9 @@ export async function runEditorAiTransform({
         maskImage,
         quality: 'medium',
     });
+    const transformMask = maskImage
+        ? await blobToTransformMaskAsset(maskImage)
+        : null;
 
     return applyAiTransformResultToDraft(
         draft,
@@ -196,6 +200,7 @@ export async function runEditorAiTransform({
         {
             prompt: trimmedPrompt,
             model,
+            transformMask,
         },
     );
 }
@@ -224,6 +229,7 @@ export function buildEditorSaveContext({
         layerStack: draft && hasDurableLayerStack(draft.layerStack) ? draft.layerStack : null,
         aiEditPrompt: saveProvenance?.aiEditPrompt,
         aiEditModel: saveProvenance?.aiEditModel,
+        transformMask: saveProvenance?.transformMask ?? undefined,
         targetMode: saveProvenance?.targetMode,
         targetLayerCount: saveProvenance?.targetLayerCount,
         targetIncludesBaseLayer: saveProvenance?.targetIncludesBaseLayer,

--- a/src/lineage/LineageNavigator.test.ts
+++ b/src/lineage/LineageNavigator.test.ts
@@ -72,11 +72,45 @@ describe('LineageNavigator', () => {
 
             const outcome = await navigator.replayIntoEditor('step-4');
 
-            expect(outcome).toEqual({ status: 'replayed', image });
+            expect(outcome).toEqual({ status: 'replayed', image, replay: { prompt: null, model: null } });
             expect(sessionStore.saveLineageSource).toHaveBeenCalledWith({
                 archiveImageId: 'image-4',
                 stepId: 'step-4',
             });
+        });
+
+        it('returns masked editor replay metadata for the Editor to send on the next AI transform', async () => {
+            const step = createStep({
+                id: 'masked-step',
+                archiveImageId: 'masked-image',
+                stepType: 'ai-edit',
+                metadata: {
+                    aiEdit: {
+                        prompt: 'replace the masked area',
+                        imageModel: { slug: 'gpt-image-2' },
+                        transformMask: {
+                            dataUrl: 'data:image/png;base64,bWFzaw==',
+                            mimeType: 'image/png',
+                        },
+                    },
+                },
+            });
+            const image = createImage({ id: 'masked-image' });
+            const { navigator } = setup({ steps: [step], images: [image] });
+
+            const outcome = await navigator.replayIntoEditor('masked-step');
+
+            expect(outcome.status).toBe('replayed');
+            if (outcome.status !== 'replayed') {
+                return;
+            }
+            expect(outcome.image).toBe(image);
+            expect(outcome.replay).toMatchObject({
+                prompt: 'replace the masked area',
+                model: 'gpt-image-2',
+            });
+            expect(outcome.replay.maskImage).toBeInstanceOf(File);
+            await expect(outcome.replay.maskImage?.text()).resolves.toBe('mask');
         });
 
         it('reports unavailable when the image is missing from the archive', async () => {

--- a/src/lineage/LineageNavigator.ts
+++ b/src/lineage/LineageNavigator.ts
@@ -1,14 +1,14 @@
 import type { ArchiveImage } from '../db/types';
 import type { GenerateSessionStore } from '../generate-session/GenerateSession';
 import type { LineageStore } from './LineageStore';
-import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+import { buildEditorReplay, buildGenerateReplay, isEditorReplayable, isGenerateReplayable, type EditorReplay } from './replayLineageStep';
 
 export type ReplayIntoGenerateOutcome =
     | { status: 'replayed' }
     | { status: 'unavailable'; reason: string };
 
 export type ReplayIntoEditorOutcome =
-    | { status: 'replayed'; image: ArchiveImage }
+    | { status: 'replayed'; image: ArchiveImage; replay: EditorReplay }
     | { status: 'unavailable'; reason: string };
 
 export type ForkOutcome =
@@ -60,9 +60,14 @@ export function createLineageNavigator(deps: LineageNavigatorDeps): LineageNavig
                 return { status: 'unavailable', reason: 'Selected step image is missing from the local archive' };
             }
 
+            const replay = buildEditorReplay(step);
+            if (!replay) {
+                return { status: 'unavailable', reason: 'This step cannot be replayed into Editor' };
+            }
+
             sessionStore.saveLineageSource({ archiveImageId: step.archiveImageId, stepId: step.id });
 
-            return { status: 'replayed', image };
+            return { status: 'replayed', image, replay };
         },
 
         async fork(stepId) {

--- a/src/lineage/editorLineageMetadata.ts
+++ b/src/lineage/editorLineageMetadata.ts
@@ -34,11 +34,19 @@ export interface EditorLineageAiTransformTarget {
     includesBaseLayer: boolean | null;
 }
 
+export interface EditorLineageTransformMaskAsset {
+    assetId: string | null;
+    dataUrl?: string;
+    fileName?: string;
+    mimeType: string;
+}
+
 export interface EditorLineageAiEdit {
     prompt: string;
     imageModel: EditorLineageImageModel | null;
     referenceImages: EditorLineageReferenceImages;
     transformTarget: EditorLineageAiTransformTarget;
+    transformMask?: EditorLineageTransformMaskAsset;
 }
 
 export interface EditorLineageAiResultLayerFact {
@@ -75,6 +83,7 @@ export interface EditorLineageMetadata extends Record<string, unknown> {
     targetIncludesBaseLayer: boolean | null;
     aiResultLayerId: string | null;
     aiResultLayerName: string | null;
+    transformMaskAsset?: EditorLineageTransformMaskAsset;
 }
 
 export interface EditorTimelineMetadata {
@@ -97,6 +106,7 @@ export function buildEditorLineageMetadata(input: {
     aiResultLayerName?: string | null;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }): EditorLineageMetadata {
     const layerStack = input.layerStack ?? input.savedImage.layerStack;
     const editPrompt = normalizeString(input.aiEditPrompt);
@@ -113,6 +123,7 @@ export function buildEditorLineageMetadata(input: {
         aiResultLayerId: input.aiResultLayerId ?? null,
         aiResultLayerName: input.aiResultLayerName ?? null,
     });
+    const transformMask = buildEditorTransformMaskAsset(input.transformMask, input.savedImage.id);
 
     return {
         sourceImage: {
@@ -134,6 +145,7 @@ export function buildEditorLineageMetadata(input: {
                     count: referenceCount,
                 },
                 transformTarget: aiTransformTarget,
+                ...(transformMask ? { transformMask } : {}),
             }
             : null,
         layers,
@@ -152,6 +164,7 @@ export function buildEditorLineageMetadata(input: {
         targetIncludesBaseLayer: aiTransformTarget.includesBaseLayer,
         aiResultLayerId: layers.aiResultLayer?.id ?? null,
         aiResultLayerName: layers.aiResultLayer?.name ?? null,
+        ...(transformMask ? { transformMaskAsset: transformMask } : {}),
     };
 }
 
@@ -214,6 +227,11 @@ export function readEditorLineageAiTransformTarget(metadata: Record<string, unkn
     };
 }
 
+export function readEditorLineageTransformMask(metadata: Record<string, unknown>): EditorLineageTransformMaskAsset | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+    return readTransformMaskAsset(aiEdit?.transformMask) ?? readTransformMaskAsset(metadata.transformMaskAsset);
+}
+
 function buildEditorAdjustment(adjustments: EditorAdjustments): EditorLineageAdjustment {
     return {
         brightness: adjustments.brightness,
@@ -247,6 +265,45 @@ function buildEditorLineageImageModel(model: string | null): EditorLineageImageM
     return isImageModelSlug(model)
         ? { slug: model }
         : null;
+}
+
+function buildEditorTransformMaskAsset(
+    transformMask: EditorLineageTransformMaskAsset | null | undefined,
+    savedImageId: string,
+): EditorLineageTransformMaskAsset | null {
+    if (!transformMask?.dataUrl && !transformMask?.fileName) {
+        return null;
+    }
+
+    return {
+        assetId: transformMask.assetId || `${savedImageId}:transform-mask`,
+        ...(transformMask.dataUrl ? { dataUrl: transformMask.dataUrl } : {}),
+        ...(transformMask.fileName ? { fileName: transformMask.fileName } : {}),
+        mimeType: transformMask.mimeType || 'image/png',
+    };
+}
+
+function readTransformMaskAsset(value: unknown): EditorLineageTransformMaskAsset | null {
+    const asset = asRecord(value);
+    if (!asset) {
+        return null;
+    }
+
+    const dataUrl = typeof asset.dataUrl === 'string' ? asset.dataUrl : undefined;
+    const fileName = typeof asset.fileName === 'string' ? asset.fileName : undefined;
+    const mimeType = typeof asset.mimeType === 'string' ? asset.mimeType : 'image/png';
+    const assetId = typeof asset.assetId === 'string' ? asset.assetId : null;
+
+    if (!dataUrl && !fileName) {
+        return null;
+    }
+
+    return {
+        assetId,
+        ...(dataUrl ? { dataUrl } : {}),
+        ...(fileName ? { fileName } : {}),
+        mimeType,
+    };
 }
 
 function readAdjustment(value: unknown): EditorLineageAdjustment | null {

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -35,6 +35,7 @@ function validateEditorMetadata(metadata: Record<string, unknown>) {
     validateEditorAdjustment(metadata.editorAdjustment);
     validateEditorAiEdit(metadata.aiEdit);
     validateEditorLayers(metadata.layers);
+    validateTransformMaskAsset(metadata.transformMaskAsset);
 }
 
 function validateAutopilotMetadata(metadata: Record<string, unknown>) {
@@ -133,6 +134,7 @@ function validateEditorAiEdit(value: unknown) {
         requireFiniteNumber(referenceImages.count, 'lineage aiEdit referenceImages count');
     }
     validateEditorTransformTarget(aiEdit.transformTarget);
+    validateTransformMaskAsset(aiEdit.transformMask);
 }
 
 function validateEditorTransformTarget(value: unknown) {
@@ -154,6 +156,24 @@ function validateEditorTransformTarget(value: unknown) {
     if (transformTarget.includesBaseLayer !== null) {
         requireBoolean(transformTarget.includesBaseLayer, 'lineage transformTarget includesBaseLayer');
     }
+}
+
+function validateTransformMaskAsset(value: unknown) {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    const asset = requireRecord(value, 'lineage transformMask');
+    if (asset.assetId !== null) {
+        requireString(asset.assetId, 'lineage transformMask assetId');
+    }
+    if (asset.dataUrl !== undefined) {
+        requireString(asset.dataUrl, 'lineage transformMask dataUrl');
+    }
+    if (asset.fileName !== undefined) {
+        requireString(asset.fileName, 'lineage transformMask fileName');
+    }
+    requireString(asset.mimeType, 'lineage transformMask mimeType');
 }
 
 function validateEditorLayers(value: unknown) {

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ArchiveImage } from '../db/types';
 import type { LineageStep } from './LineageStore';
-import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+import { buildEditorReplay, buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
 describe('replayLineageStep', () => {
@@ -55,6 +55,45 @@ describe('replayLineageStep', () => {
         expect(isGenerateReplayable(createStep({ id: 'b', archiveImageId: 'image-b', stepType: 'ai-edit', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
         expect(isEditorReplayable(createStep({ id: 'c', archiveImageId: 'image-c', stepType: 'save-as-copy', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
         expect(isEditorReplayable(createStep({ id: 'd', archiveImageId: 'image-d', stepType: 'reference-generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
+    });
+
+    it('hydrates masked editor replay metadata into an edit request mask image', async () => {
+        const step = createStep({
+            id: 'masked-step',
+            archiveImageId: 'masked-image',
+            stepType: 'ai-edit',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                aiEdit: {
+                    prompt: 'replace only the painted area',
+                    imageModel: {
+                        slug: OPENAI_IMAGE_MODEL,
+                    },
+                    referenceImages: {
+                        count: 0,
+                    },
+                    transformTarget: {
+                        mode: 'selected-layers',
+                        layerCount: 1,
+                        includesBaseLayer: false,
+                    },
+                    transformMask: {
+                        assetId: 'masked-copy:transform-mask',
+                        dataUrl: 'data:image/png;base64,bWFzaw==',
+                        mimeType: 'image/png',
+                    },
+                },
+            },
+        });
+
+        const replay = buildEditorReplay(step);
+
+        expect(replay).toEqual(expect.objectContaining({
+            prompt: 'replace only the painted area',
+            model: OPENAI_IMAGE_MODEL,
+        }));
+        expect(replay?.maskImage).toBeInstanceOf(File);
+        await expect(replay?.maskImage?.text()).resolves.toBe('mask');
     });
 
     it('hydrates a generate draft from an autopilot step without an archive image fallback', () => {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -5,6 +5,12 @@ import { sanitizeImageModelControls } from '../image-models/ImageModelControls';
 import type { LineageStep } from './LineageStore';
 import { readGenerateLineageImageModel } from './generateLineageMetadata';
 import { readAutopilotGenerateReplayMetadata } from './autopilotLineageMetadata';
+import {
+    readEditorLineageEditPrompt,
+    readEditorLineageImageModel,
+    readEditorLineageTransformMask,
+} from './editorLineageMetadata';
+import { dataURLtoFile } from '../utils/file';
 
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 type GenerateReplayImageModel = NonNullable<ReturnType<typeof readGenerateLineageImageModel>>;
@@ -28,6 +34,25 @@ export function isGenerateReplayable(step: ReplayableStep) {
 
 export function isEditorReplayable(step: ReplayableStep) {
     return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
+}
+
+export function buildEditorReplay(step: LineageStep): {
+    prompt: string | null;
+    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
+    maskImage?: File;
+} | null {
+    if (!isEditorReplayable(step)) {
+        return null;
+    }
+
+    const transformMask = readEditorLineageTransformMask(step.metadata);
+    const dataUrl = transformMask?.dataUrl;
+
+    return {
+        prompt: readEditorLineageEditPrompt(step.metadata),
+        model: readEditorLineageImageModel(step.metadata)?.slug ?? null,
+        ...(dataUrl ? { maskImage: dataURLtoFile(dataUrl, 'transform-mask.png') } : {}),
+    };
 }
 
 export function buildGenerateReplay(image: ArchiveImage | null, step: LineageStep): {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -15,6 +15,12 @@ import { dataURLtoFile } from '../utils/file';
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 type GenerateReplayImageModel = NonNullable<ReturnType<typeof readGenerateLineageImageModel>>;
 
+export interface EditorReplay {
+    prompt: string | null;
+    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
+    maskImage?: File;
+}
+
 interface GenerateReplayMetadata {
     imageModel: GenerateReplayImageModel | null;
     model: ReturnType<typeof resolveReplayModel> | null;
@@ -36,11 +42,7 @@ export function isEditorReplayable(step: ReplayableStep) {
     return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
 }
 
-export function buildEditorReplay(step: LineageStep): {
-    prompt: string | null;
-    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
-    maskImage?: File;
-} | null {
+export function buildEditorReplay(step: LineageStep): EditorReplay | null {
     if (!isEditorReplayable(step)) {
         return null;
     }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -12,14 +12,16 @@ import { getImageModelReferenceLimitMessage, getImageModelUiChoices, imageModelS
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { renderAiTransformEditInput } from '../editor/aiTransform';
 import { classifyTransformMaskCoverage } from '../editor/transformMask';
+import type { EditorReplay } from '../lineage/replayLineageStep';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
+    replay?: EditorReplay | null;
     getProviderKey: (provider: Provider) => string | null;
     onSave: (updatedUrl: string, context: EditorSaveContext) => void;
 }
 
-const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }) => {
+const EditorView: React.FC<EditorViewProps> = ({ image, replay, getProviderKey, onSave }) => {
     const defaultModel = image && isImageModelSlug(image.model) ? image.model : OPENAI_IMAGE_MODEL;
     const [aiEditModel, setAiEditModel] = useState<ImageModelSlug>(defaultModel);
     const [adjustmentsOpen, setAdjustmentsOpen] = useState(true);
@@ -110,6 +112,20 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         onSave,
     });
     const aiReferenceWarning = getImageModelReferenceLimitMessage(aiEditModel, referenceImages.length, 'AI transforms');
+
+    useEffect(() => {
+        if (!replay) {
+            return;
+        }
+
+        if (replay.model) {
+            setAiEditModel(replay.model);
+        }
+        if (replay.prompt) {
+            setAiPrompt(replay.prompt);
+        }
+        setTransformMaskFile(replay.maskImage ?? null);
+    }, [replay, setAiPrompt]);
 
     useEffect(() => {
         if (!supportsTransformMask) {


### PR DESCRIPTION
## Summary

- Persists transform mask assets in editor lineage metadata without adding mask layers
- Includes mask assets in archive export/import and recovered metadata
- Hydrates masked editor replay metadata back into Editor, seeding prompt/model/mask for the next AI transform
- Adds replay/navigator coverage proving the mask file is available to Editor replay

Closes #80.

## Validation

- pnpm vitest run src/lineage/LineageNavigator.test.ts src/lineage/replayLineageStep.test.ts src/editor/useEditorController.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- npm run build