### PR TITLE
Nano Banana Pro batch generation fan-out

### DIFF
--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -28,6 +28,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '3:2',
                 imageSize: '1K',
+                batchSize: 1,
             },
             isSaved: true,
         });
@@ -46,6 +47,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 9,
             },
         })).toMatchObject({
             model: 'nano-banana-pro',
@@ -58,6 +60,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 4,
             },
         });
     });

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -56,6 +56,7 @@ describe('runGenerateAutopilot', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -146,6 +147,7 @@ describe('runGenerateAutopilot', () => {
                 nanoBananaPro: {
                     aspectRatio: '16:9',
                     imageSize: '4K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -188,6 +188,7 @@ describe('saveGeneratedImage', () => {
                         controls: {
                             aspectRatio: '16:9',
                             imageSize: '2K',
+                            batchSize: 1,
                         },
                     },
                     dimensions: {

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -46,6 +46,7 @@ describe('Generate controller Image model archive metadata', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 1,
             },
         });
 

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -69,6 +69,7 @@ describe('Image model controls', () => {
         expect(getImageModelGenerateControls(NANO_BANANA_PRO_IMAGE_MODEL).map((control) => control.id)).toEqual([
             'aspectRatio',
             'imageSize',
+            'batchSize',
         ]);
     });
 
@@ -87,6 +88,7 @@ describe('Image model controls', () => {
         expect(getDefaultImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL)).toEqual({
             aspectRatio: '1:1',
             imageSize: '1K',
+            batchSize: 1,
         });
         expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
             quality: 'high',
@@ -117,11 +119,14 @@ describe('Image model controls', () => {
         expect(sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
             aspectRatio: '1536x1024',
             imageSize: '4K',
+            batchSize: 8,
         })).toEqual({
             aspectRatio: '3:2',
             imageSize: '4K',
+            batchSize: 4,
         });
         expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'aspectRatio', '1024x1536')).toBe('2:3');
+        expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'batchSize', '3')).toBe('3');
         expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'quality', 'best')).toBe('medium');
         expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'batchSize', '9')).toBe('4');
     });
@@ -172,11 +177,13 @@ describe('Image model controls', () => {
             quality: 'high',
             aspectRatio: '1024x1536',
             background: 'transparent',
+            batchSize: 4,
             imageSize: '4K',
             referenceImages: references,
         })).toEqual({
             aspectRatio: '2:3',
             imageSize: '4K',
+            batchSize: 4,
             referenceImages: references.slice(0, 14),
         });
     });

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -22,6 +22,7 @@ export type GptImage2Controls = {
 export type NanoBananaProControls = {
     aspectRatio: NanoBananaAspectRatio;
     imageSize: NanoBananaImageSize;
+    batchSize: number;
 };
 
 export type ImageModelControls = GptImage2Controls | NanoBananaProControls;
@@ -133,6 +134,7 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
         defaults: {
             aspectRatio: '1:1',
             imageSize: '1K',
+            batchSize: 1,
         },
         generateControls: [
             {
@@ -160,6 +162,17 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
                     { value: '1K', label: '1K' },
                     { value: '2K', label: '2K' },
                     { value: '4K', label: '4K' },
+                ],
+            },
+            {
+                id: 'batchSize',
+                label: 'BATCH SIZE',
+                kind: 'toggle',
+                options: [
+                    { value: '1', label: '1' },
+                    { value: '2', label: '2' },
+                    { value: '3', label: '3' },
+                    { value: '4', label: '4' },
                 ],
             },
         ],
@@ -230,6 +243,7 @@ export function sanitizeImageModelControls(
         return {
             aspectRatio: coerceNanoAspectRatio(record?.aspectRatio, fallbackControls.aspectRatio),
             imageSize: coerceNanoImageSize(record?.imageSize, fallbackControls.imageSize),
+            batchSize: coerceGptBatchSize(record?.batchSize, fallbackControls.batchSize),
         };
     }
 
@@ -270,6 +284,9 @@ export function coerceImageModelControlValue(model: ImageModelSlug, controlId: s
         if (controlId === 'imageSize') {
             return coerceNanoImageSize(value, defaults.imageSize);
         }
+        if (controlId === 'batchSize') {
+            return String(coerceGptBatchSize(value, defaults.batchSize));
+        }
         return '';
     }
 
@@ -298,7 +315,7 @@ export function getActiveImageModelGenerateControls(model: ImageModelSlug, contr
             imageSize: sanitized.imageSize,
             quality: gptDefaults.quality,
             background: gptDefaults.background,
-            batchSize: 1,
+            batchSize: sanitized.batchSize,
         };
     }
 
@@ -355,10 +372,12 @@ export function mapImageModelGenerateProviderRequest(
         const controls = sanitizeImageModelControls(model, {
             aspectRatio: input.aspectRatio,
             imageSize: input.imageSize,
+            batchSize: input.batchSize,
         }) as NanoBananaProControls;
         return {
             aspectRatio: controls.aspectRatio,
             imageSize: controls.imageSize,
+            batchSize: controls.batchSize,
             referenceImages: referenceRunPlan.providerReferenceImages,
         };
     }

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -80,7 +80,26 @@ export function createGoogleImageProvider(fetchImpl: typeof fetch = fetch): Imag
     };
 
     return {
-        generate: async (request) => [await createImage(request)],
+        async generate(request) {
+            const batchSize = coerceProviderBatchSize(request.batchSize);
+
+            if (batchSize === 1) {
+                return [await createImage(request)];
+            }
+
+            return Promise.all(Array.from({ length: batchSize }, async () => {
+                try {
+                    return await createImage({
+                        ...request,
+                        batchSize: 1,
+                    });
+                } catch (error) {
+                    return {
+                        error: error instanceof Error ? error.message : 'Google Gemini image generation failed',
+                    };
+                }
+            }));
+        },
         edit: createImage,
     };
 }
@@ -129,6 +148,20 @@ async function fileToBase64(file: File) {
         binary += String.fromCharCode(byte);
     });
     return btoa(binary);
+}
+
+function coerceProviderBatchSize(value: unknown): number {
+    const parsed = typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+            ? Number(value.trim())
+            : NaN;
+
+    if (!Number.isFinite(parsed)) {
+        return 1;
+    }
+
+    return Math.min(4, Math.max(1, Math.trunc(parsed)));
 }
 
 export function extractGoogleImageData(data: unknown): string | null {

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -87,6 +87,38 @@ describe('ImageWorkflow', () => {
         }));
     });
 
+    it('uses provider slot errors when batch generation partially fails', async () => {
+        const generate = vi.fn(async () => [
+            { b64_json: 'generated-0' },
+            { error: 'Google Gemini API Error: overloaded' },
+            { b64_json: 'generated-2' },
+        ]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await expect(workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 3,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        })).resolves.toEqual([
+            { slotIndex: 0, status: 'success', imageUrl: 'data:image/png;base64,generated-0' },
+            { slotIndex: 1, status: 'failed', error: 'Google Gemini API Error: overloaded' },
+            { slotIndex: 2, status: 'success', imageUrl: 'data:image/png;base64,generated-2' },
+        ]);
+    });
+
+
     it('routes edit requests through the configured provider for the default model', async () => {
         const edit = vi.fn(async () => ({ b64_json: 'edited' }));
         const providers: ImageProviderRegistry = {
@@ -612,5 +644,53 @@ describe('googleImageProvider', () => {
             aspectRatio: '1:1',
             imageSize: '1K',
         });
+    });
+
+    it('fans out Nano Banana batch generation and keeps failed slots isolated', async () => {
+        const pendingResponses: Array<(response: Response) => void> = [];
+        const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>((resolve) => {
+            pendingResponses.push(resolve);
+        }));
+        const provider = createGoogleImageProvider(fetchImpl);
+
+        const resultPromise = provider.generate({
+            apiKey: 'google-key',
+            model: {
+                slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                provider: 'google',
+                apiModel: 'gemini-3-pro-image-preview',
+                label: 'Nano Banana Pro',
+                endpoints: {
+                    generate: 'https://example.test/generate',
+                    edit: 'https://example.test/generate',
+                },
+                parameters: {},
+                capabilities: { transformMask: false },
+            },
+            prompt: 'a luminous teapot city',
+            aspectRatio: '16:9',
+            imageSize: '2K',
+            batchSize: 3,
+            referenceImages: [],
+        });
+
+        await Promise.resolve();
+        expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+        pendingResponses[0]?.(new Response(JSON.stringify({
+            candidates: [{ content: { parts: [{ inlineData: { data: 'gemini-image-0' } }] } }],
+        })));
+        pendingResponses[1]?.(new Response(JSON.stringify({
+            error: { message: 'quota exceeded' },
+        }), { status: 429 }));
+        pendingResponses[2]?.(new Response(JSON.stringify({
+            candidates: [{ content: { parts: [{ inlineData: { data: 'gemini-image-2' } }] } }],
+        })));
+
+        await expect(resultPromise).resolves.toEqual([
+            { b64_json: 'gemini-image-0' },
+            { error: 'quota exceeded' },
+            { b64_json: 'gemini-image-2' },
+        ]);
     });
 });

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -203,7 +203,7 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
         return {
             slotIndex,
             status: 'failed',
-            error: 'No image data returned from image provider',
+            error: response?.error ?? 'No image data returned from image provider',
         };
     });
 }

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -39,6 +39,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -90,6 +91,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -138,6 +140,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -23,6 +23,7 @@ export interface OpenAiImageRequest {
 
 export interface OpenAiImageResponse {
     b64_json?: string;
+    error?: string;
 }
 
 export interface OpenAiResponsesRequest {


### PR DESCRIPTION
## Summary

- Enables 1-4 batch size controls for Nano Banana Pro generation
- Fans out Google image generation into concurrent single-image requests for batch runs
- Preserves slot order and maps per-slot provider errors into failed batch results

Closes #76.

## Validation

- pnpm vitest src/image-models/ImageModelControls.test.ts src/generate-session/GenerateSession.test.ts src/image-workflow/ImageWorkflow.test.ts
- pnpm run test
- pnpm run typecheck
- pnpm run lint
- npm run build