### PR TITLE
Add generated-result reference iteration

### DIFF
--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -3,6 +3,7 @@ import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageMo
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
 import {
+    addGeneratedResultAsReference,
     buildGenerateResultSlots,
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
@@ -94,6 +95,69 @@ describe('Generate controller batch result slots', () => {
                 error: 'content filter',
             },
         ]);
+    });
+});
+
+describe('Generate controller result Reference iteration', () => {
+    it('adds a saved generated result as a Reference image and keeps its lineage source', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+
+        const added = addGeneratedResultAsReference({
+            slot: {
+                slotIndex: 2,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,c2F2ZWQtcmVzdWx0',
+                isSaved: true,
+                archiveImageId: 'archive-image-123',
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+        });
+
+        expect(added).toBe(true);
+        expect(addReferenceFiles).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'generated-result-3.png',
+                type: 'image/png',
+            }),
+        ]);
+        expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'archive-image-123' });
+        expect(clearLineageSource).not.toHaveBeenCalled();
+    });
+
+    it('adds an unsaved generated result as a Reference image without carrying a lineage source', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+
+        const added = addGeneratedResultAsReference({
+            slot: {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,dW5zYXZlZC1yZXN1bHQ=',
+                isSaved: false,
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+        });
+
+        expect(added).toBe(true);
+        expect(addReferenceFiles).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'generated-result-1.png',
+                type: 'image/png',
+            }),
+        ]);
+        expect(saveLineageSource).not.toHaveBeenCalled();
+        expect(clearLineageSource).toHaveBeenCalled();
     });
 });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -4,6 +4,7 @@ import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openai
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
 import {
     addGeneratedResultAsReference,
+    addGeneratedResultAsReferenceFromAction,
     buildGenerateResultSlots,
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
@@ -158,6 +159,77 @@ describe('Generate controller result Reference iteration', () => {
         ]);
         expect(saveLineageSource).not.toHaveBeenCalled();
         expect(clearLineageSource).toHaveBeenCalled();
+    });
+
+    it('blocks result Reference iteration at model capacity without changing session lineage', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+        const setNotice = vi.fn();
+
+        const added = addGeneratedResultAsReferenceFromAction({
+            slot: {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,Y2FwYWNpdHk=',
+                isSaved: true,
+                archiveImageId: 'archive-at-capacity',
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+            capacityMessage: 'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+            setNotice,
+        });
+
+        expect(added).toBe(false);
+        expect(addReferenceFiles).not.toHaveBeenCalled();
+        expect(saveLineageSource).not.toHaveBeenCalled();
+        expect(clearLineageSource).not.toHaveBeenCalled();
+        expect(setNotice).toHaveBeenCalledWith(
+            'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+        );
+    });
+
+    it('runs the result Reference action without mutating the draft prompt or controls', () => {
+        const draft = createDraft({
+            prompt: 'keep this prompt',
+            gptImage2: {
+                quality: 'high',
+                size: '1536x1024',
+                background: 'transparent',
+                batchSize: 4,
+            },
+        });
+        const draftBeforeAction = structuredClone(draft);
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+        const setNotice = vi.fn();
+
+        const added = addGeneratedResultAsReferenceFromAction({
+            slot: {
+                slotIndex: 1,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,aXRlcmF0ZQ==',
+                isSaved: false,
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+            capacityMessage: null,
+            setNotice,
+        });
+
+        expect(added).toBe(true);
+        expect(draft).toEqual(draftBeforeAction);
+        expect(addReferenceFiles).toHaveBeenCalledTimes(1);
+        expect(clearLineageSource).toHaveBeenCalled();
+        expect(setNotice).toHaveBeenCalledWith(null);
     });
 });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -95,6 +95,11 @@ interface AddGeneratedResultAsReferenceInput {
     session: Pick<GenerateSessionStore, 'saveLineageSource' | 'clearLineageSource'>;
 }
 
+interface AddGeneratedResultAsReferenceActionInput extends AddGeneratedResultAsReferenceInput {
+    capacityMessage: string | null;
+    setNotice: (message: string | null) => void;
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -168,6 +173,28 @@ export function addGeneratedResultAsReference({
     }
 
     return true;
+}
+
+export function addGeneratedResultAsReferenceFromAction({
+    capacityMessage,
+    setNotice,
+    ...input
+}: AddGeneratedResultAsReferenceActionInput) {
+    if (capacityMessage) {
+        setNotice(capacityMessage);
+        return false;
+    }
+
+    try {
+        const added = addGeneratedResultAsReference(input);
+        if (added) {
+            setNotice(null);
+        }
+        return added;
+    } catch (referenceError) {
+        setNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
+        return false;
+    }
 }
 
 export function notifyGenerateCompletion({

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -14,6 +14,7 @@ import {
     type CompletionNotificationPayload,
     type CompletionNotificationPort,
 } from '../app/CompletionNotificationPort';
+import { dataURLtoFile } from '../utils/file';
 
 interface AutopilotProgressState {
     running: boolean;
@@ -88,6 +89,12 @@ interface BuildGeneratedArchiveImageForSaveInput {
     serializeReferences: () => Promise<string[]>;
 }
 
+interface AddGeneratedResultAsReferenceInput {
+    slot: GenerateResultSlot;
+    addReferenceFiles: (files: File[]) => void;
+    session: Pick<GenerateSessionStore, 'saveLineageSource' | 'clearLineageSource'>;
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -139,6 +146,28 @@ export async function buildGeneratedArchiveImageForSave({
         draft,
         references,
     });
+}
+
+export function addGeneratedResultAsReference({
+    slot,
+    addReferenceFiles,
+    session,
+}: AddGeneratedResultAsReferenceInput) {
+    if (slot.status !== 'success') {
+        return false;
+    }
+
+    addReferenceFiles([
+        dataURLtoFile(slot.imageUrl, `generated-result-${slot.slotIndex + 1}.png`),
+    ]);
+
+    if (slot.isSaved && slot.archiveImageId) {
+        session.saveLineageSource({ archiveImageId: slot.archiveImageId });
+    } else {
+        session.clearLineageSource();
+    }
+
+    return true;
 }
 
 export function notifyGenerateCompletion({

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -6,6 +6,7 @@ import {
     coerceImageModelControlValue,
     getDefaultImageModelControls,
     getImageModelGenerateControls,
+    getImageModelReferenceCapacityMessage,
     getImageModelReferenceLimitMessage,
     getImageModelUiChoices,
     imageModelSupportsTransformMask,
@@ -227,6 +228,14 @@ describe('Image model controls', () => {
             'ref-12.png',
             'ref-13.png',
         ]);
+    });
+
+    it('reports when a Generate result cannot be appended as another Reference image', () => {
+        expect(getImageModelReferenceCapacityMessage(OPENAI_IMAGE_MODEL, 50, 'generation')).toBeNull();
+        expect(getImageModelReferenceCapacityMessage(NANO_BANANA_PRO_IMAGE_MODEL, 13, 'generation')).toBeNull();
+        expect(getImageModelReferenceCapacityMessage(NANO_BANANA_PRO_IMAGE_MODEL, 14, 'generation')).toBe(
+            'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+        );
     });
 
     it('applies future gpt-image-2 Reference limits from Image model facts consistently', () => {

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -437,6 +437,19 @@ export function getImageModelReferenceLimitMessage(
     return `${IMAGE_MODEL_REGISTRY[model].label} uses the first ${limit} reference images for ${context}.`;
 }
 
+export function getImageModelReferenceCapacityMessage(
+    model: ImageModelSlug,
+    referenceCount: number,
+    context: string,
+): string | null {
+    const limit = IMAGE_MODEL_CONTROL_FACTS[model].referenceLimit;
+    if (limit === null || referenceCount < limit) {
+        return null;
+    }
+
+    return `${IMAGE_MODEL_REGISTRY[model].label} already has ${limit} reference images for ${context}. Remove one before adding another.`;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
         ? value as Record<string, unknown>

--- a/src/index.css
+++ b/src/index.css
@@ -867,7 +867,10 @@ textarea.aura-input {
     left: 50%;
     bottom: var(--spacing-24);
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: var(--spacing-16);
+    max-width: calc(100% - 48px);
     padding: var(--card-padding);
     transform: translateX(-50%);
     background: rgba(0, 0, 0, 0.55);

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
-import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
+import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X, ImagePlus } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
-import { getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
-import { useGenerateController } from '../generate-session/useGenerateController';
+import { generateSessionStore, getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
+import { addGeneratedResultAsReference, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
@@ -17,6 +17,7 @@ import {
     buildImageModelGenerateReferenceRunPlan,
     coerceImageModelControlValue,
     getImageModelGenerateControls,
+    getImageModelReferenceCapacityMessage,
     getImageModelUiChoices,
     type ImageModelControlId,
 } from '../image-models/ImageModelControls';
@@ -321,6 +322,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const maxApiCalls = maxIterations * 3;
     const isAutopilotMode = mode === 'autopilot';
     const imageModelReferenceWarning = referenceRunPlan.referenceLimitMessage;
+    const resultReferenceCapacityMessage = getImageModelReferenceCapacityMessage(model, referenceImages.length, 'generation');
     const activeModelDraftKey = getImageModelDraftKey(model);
     const activeModelControls = draft[activeModelDraftKey] as Record<string, string | number>;
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
@@ -333,6 +335,23 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                 [controlId]: coerceImageModelControlValue(model, controlId, value),
             },
         } as Partial<GenerateDraft>);
+    };
+
+    const handleUseResultAsReference = (result: Extract<GenerateResultSlot, { status: 'success' }>) => {
+        if (resultReferenceCapacityMessage) {
+            return;
+        }
+
+        try {
+            addGeneratedResultAsReference({
+                slot: result,
+                addReferenceFiles,
+                session: generateSessionStore,
+            });
+            setAutopilotNotice(null);
+        } catch (referenceError) {
+            setAutopilotNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
+        }
     };
 
 
@@ -647,6 +666,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                         <div className="error-message">{activeReasoningModel.label} API key missing. Go to Settings to configure.</div>
                     )}
                     {imageModelReferenceWarning && <div className="info-message">{imageModelReferenceWarning}</div>}
+                    {resultReferenceCapacityMessage && successfulBatchResults.length > 0 && <div className="info-message">{resultReferenceCapacityMessage}</div>}
                     {error && <div className="error-message">{error}</div>}
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
@@ -675,6 +695,14 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                                     </button>
                                                     <button className="btn-ghost" onClick={() => downloadResult(result.slotIndex)}>
                                                         <Download size={16} /> Download
+                                                    </button>
+                                                    <button
+                                                        className="btn-ghost"
+                                                        onClick={() => handleUseResultAsReference(result)}
+                                                        disabled={!!resultReferenceCapacityMessage}
+                                                        title={resultReferenceCapacityMessage ?? 'Use this result as a reference image'}
+                                                    >
+                                                        <ImagePlus size={16} /> Use as Reference
                                                     </button>
                                                 </div>
                                             </>
@@ -719,6 +747,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                 <button className="btn-ghost" onClick={download}>
                                     <Download size={18} /> Download
                                 </button>
+                                {singleResultSlot && (
+                                    <button
+                                        className="btn-ghost"
+                                        onClick={() => handleUseResultAsReference(singleResultSlot)}
+                                        disabled={!!resultReferenceCapacityMessage}
+                                        title={resultReferenceCapacityMessage ?? 'Use this result as a reference image'}
+                                    >
+                                        <ImagePlus size={18} /> Use as Reference
+                                    </button>
+                                )}
                                 <button onClick={() => { void clear(); }} className="btn-ghost">
                                     <Trash2 size={18} />
                                 </button>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useRef, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X, ImagePlus } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
-import { addGeneratedResultAsReference, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
+import { addGeneratedResultAsReferenceFromAction, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
@@ -338,20 +338,13 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     };
 
     const handleUseResultAsReference = (result: Extract<GenerateResultSlot, { status: 'success' }>) => {
-        if (resultReferenceCapacityMessage) {
-            return;
-        }
-
-        try {
-            addGeneratedResultAsReference({
-                slot: result,
-                addReferenceFiles,
-                session: generateSessionStore,
-            });
-            setAutopilotNotice(null);
-        } catch (referenceError) {
-            setAutopilotNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
-        }
+        addGeneratedResultAsReferenceFromAction({
+            slot: result,
+            addReferenceFiles,
+            session: generateSessionStore,
+            capacityMessage: resultReferenceCapacityMessage,
+            setNotice: setAutopilotNotice,
+        });
     };
 
 


### PR DESCRIPTION
## Summary

- Adds a result-level Use as Reference action for successful Generate outputs
- Converts generated result data URLs into reference image files without changing prompt or controls
- Preserves saved-result lineage source and clears lineage source for unsaved results
- Blocks the action at model reference capacity and surfaces the capacity message
- Adds action-level coverage for capacity, draft preservation, and lineage state

Closes #79.

## Validation

- pnpm vitest run src/generate-session/useGenerateController.test.ts src/image-models/ImageModelControls.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- npm run build
- playwright screenshot http://127.0.0.1:5173/ /tmp/aura-issue79-generate.png