### PR TITLE
Add streaming partial previews for GPT Image 2

### DIFF
--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -7,6 +7,7 @@ import {
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
     notifyGenerateCompletion,
+    shouldStreamGeneratePartials,
     snapshotGeneratedReferenceImages,
 } from './useGenerateController';
 
@@ -94,6 +95,34 @@ describe('Generate controller batch result slots', () => {
                 error: 'content filter',
             },
         ]);
+    });
+});
+
+describe('Generate controller partial preview gating', () => {
+    it('streams partial previews only for single-slot GPT Image 2 runs', () => {
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: OPENAI_IMAGE_MODEL,
+            gptImage2: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'auto',
+                batchSize: 1,
+            },
+        }))).toBe(true);
+
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: OPENAI_IMAGE_MODEL,
+            gptImage2: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'auto',
+                batchSize: 2,
+            },
+        }))).toBe(false);
+
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+        }))).toBe(false);
     });
 });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -9,6 +9,7 @@ import {
     notifyGenerateCompletion,
     shouldStreamGeneratePartials,
     snapshotGeneratedReferenceImages,
+    startGeneratePartialPreviewRun,
 } from './useGenerateController';
 
 describe('Generate controller Image model archive metadata', () => {
@@ -123,6 +124,44 @@ describe('Generate controller partial preview gating', () => {
         expect(shouldStreamGeneratePartials(createDraft({
             model: NANO_BANANA_PRO_IMAGE_MODEL,
         }))).toBe(false);
+    });
+
+    it('updates and clears partial preview state only for the active run', () => {
+        let currentRunId = 0;
+        let currentPartialResult: string | null = 'data:image/png;base64,old';
+        const setCurrentPartialResult = vi.fn((imageUrl: string | null) => {
+            currentPartialResult = imageUrl;
+        });
+
+        const firstRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => currentRunId,
+            setCurrentRunId: (runId) => {
+                currentRunId = runId;
+            },
+            setCurrentPartialResult,
+        });
+
+        expect(currentPartialResult).toBeNull();
+
+        firstRun.update('data:image/png;base64,partial-1');
+        expect(currentPartialResult).toBe('data:image/png;base64,partial-1');
+
+        const secondRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => currentRunId,
+            setCurrentRunId: (runId) => {
+                currentRunId = runId;
+            },
+            setCurrentPartialResult,
+        });
+
+        secondRun.update('data:image/png;base64,partial-2');
+        firstRun.update('data:image/png;base64,stale-partial');
+        firstRun.clear();
+
+        expect(currentPartialResult).toBe('data:image/png;base64,partial-2');
+
+        secondRun.clear();
+        expect(currentPartialResult).toBeNull();
     });
 });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -89,6 +89,37 @@ interface BuildGeneratedArchiveImageForSaveInput {
     serializeReferences: () => Promise<string[]>;
 }
 
+interface StartGeneratePartialPreviewRunInput {
+    getCurrentRunId: () => number;
+    setCurrentRunId: (runId: number) => void;
+    setCurrentPartialResult: (imageUrl: string | null) => void;
+}
+
+export function startGeneratePartialPreviewRun({
+    getCurrentRunId,
+    setCurrentRunId,
+    setCurrentPartialResult,
+}: StartGeneratePartialPreviewRunInput) {
+    const runId = getCurrentRunId() + 1;
+    setCurrentRunId(runId);
+    setCurrentPartialResult(null);
+
+    const isCurrentRun = () => getCurrentRunId() === runId;
+
+    return {
+        update(imageUrl: string) {
+            if (isCurrentRun()) {
+                setCurrentPartialResult(imageUrl);
+            }
+        },
+        clear() {
+            if (isCurrentRun()) {
+                setCurrentPartialResult(null);
+            }
+        },
+    };
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -268,9 +299,13 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
-        const partialRunId = partialRunIdRef.current + 1;
-        partialRunIdRef.current = partialRunId;
-        setCurrentPartialResult(null);
+        const partialPreviewRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => partialRunIdRef.current,
+            setCurrentRunId: (runId) => {
+                partialRunIdRef.current = runId;
+            },
+            setCurrentPartialResult,
+        });
         setAutopilot((current) => ({
             ...current,
             running: false,
@@ -284,11 +319,7 @@ export function useGenerateController({
             const runDraft = cloneGenerateDraft(draft);
             const runLineageSource = session.loadLineageSource();
             const onPartialImage = shouldStreamGeneratePartials(draft)
-                ? (imageUrl: string) => {
-                    if (partialRunIdRef.current === partialRunId) {
-                        setCurrentPartialResult(imageUrl);
-                    }
-                }
+                ? partialPreviewRun.update
                 : undefined;
             const usedReferences = await snapshotGeneratedReferenceImages({
                 referenceImages: usedReferenceImages,
@@ -316,7 +347,7 @@ export function useGenerateController({
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
-            setCurrentPartialResult(null);
+            partialPreviewRun.clear();
 
             if (!imageUrl) {
                 setCurrentResult(null);
@@ -339,7 +370,7 @@ export function useGenerateController({
             };
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to generate image';
-            setCurrentPartialResult(null);
+            partialPreviewRun.clear();
             setError(message);
             completionNotification = {
                 title: 'Generation failed',

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -14,6 +14,7 @@ import {
     type CompletionNotificationPayload,
     type CompletionNotificationPort,
 } from '../app/CompletionNotificationPort';
+import { resolveImageModelConfig } from '../utils/openaiModels';
 
 interface AutopilotProgressState {
     running: boolean;
@@ -214,6 +215,7 @@ export function useGenerateController({
     const [currentResultReferences, setCurrentResultReferences] = useState<string[] | null>(null);
     const [currentRunDraft, setCurrentRunDraft] = useState<GenerateDraft | null>(null);
     const [currentRunLineageSource, setCurrentRunLineageSource] = useState<GenerateLineageSource | null>(null);
+    const [currentPartialResult, setCurrentPartialResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [autopilot, setAutopilot] = useState<AutopilotProgressState>({
@@ -224,6 +226,7 @@ export function useGenerateController({
         lastErrorIteration: null,
     });
     const autopilotSessionRef = useRef<AutopilotSession | null>(null);
+    const partialRunIdRef = useRef(0);
 
     const updateDraft = useCallback((patch: Partial<GenerateDraft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -265,6 +268,9 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        const partialRunId = partialRunIdRef.current + 1;
+        partialRunIdRef.current = partialRunId;
+        setCurrentPartialResult(null);
         setAutopilot((current) => ({
             ...current,
             running: false,
@@ -277,6 +283,13 @@ export function useGenerateController({
             const usedReferenceImages = referenceImages.slice();
             const runDraft = cloneGenerateDraft(draft);
             const runLineageSource = session.loadLineageSource();
+            const onPartialImage = shouldStreamGeneratePartials(draft)
+                ? (imageUrl: string) => {
+                    if (partialRunIdRef.current === partialRunId) {
+                        setCurrentPartialResult(imageUrl);
+                    }
+                }
+                : undefined;
             const usedReferences = await snapshotGeneratedReferenceImages({
                 referenceImages: usedReferenceImages,
                 serializeReferenceFiles: workflow.serializeReferences,
@@ -294,6 +307,7 @@ export function useGenerateController({
                 lighting: draft.lighting,
                 palette: draft.palette,
                 referenceImages: usedReferenceImages,
+                onPartialImage,
             });
             const imageUrl = getFirstSuccessfulGeneratedImage(results);
             const batchResults = buildGenerateResultSlots(results);
@@ -302,6 +316,7 @@ export function useGenerateController({
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
+            setCurrentPartialResult(null);
 
             if (!imageUrl) {
                 setCurrentResult(null);
@@ -324,6 +339,7 @@ export function useGenerateController({
             };
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to generate image';
+            setCurrentPartialResult(null);
             setError(message);
             completionNotification = {
                 title: 'Generation failed',
@@ -359,6 +375,7 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        setCurrentPartialResult(null);
         setCurrentResultReferences(null);
         setCurrentBatchResults([]);
         setCurrentRunDraft(null);
@@ -545,6 +562,7 @@ export function useGenerateController({
 
     const clear = useCallback(async () => {
         setCurrentResult(null);
+        setCurrentPartialResult(null);
         setCurrentBatchResults([]);
         setCurrentResultReferences(null);
         setCurrentRunDraft(null);
@@ -554,6 +572,7 @@ export function useGenerateController({
 
     return {
         currentResult,
+        currentPartialResult,
         currentBatchResults,
         loading,
         error,
@@ -568,6 +587,13 @@ export function useGenerateController({
         downloadResult,
         clear,
     };
+}
+
+export function shouldStreamGeneratePartials(draft: GenerateDraft) {
+    const model = resolveImageModelConfig(draft.model);
+    const controls = getActiveGenerateControls(draft);
+
+    return model.capabilities.partialImageStreaming && controls.batchSize === 1;
 }
 
 export function buildGenerateResultSlots(results: GenerateBatchResult[]): GenerateResultSlot[] {

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -20,6 +20,7 @@ export interface ImageProviderRequest {
     batchSize?: number;
     referenceImages?: File[];
     maskImage?: File | Blob | null;
+    onPartialImage?: (partial: ImageProviderResponse) => void;
 }
 
 export type ImageProviderResponse = OpenAiImageResponse;
@@ -43,6 +44,7 @@ export function createOpenAiImageProvider(client: OpenAiImageClient = openAiImag
         batchSize: request.batchSize,
         referenceImages: request.referenceImages,
         maskImage: request.maskImage,
+        onPartialImage: request.onPartialImage,
     });
 
     return {

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -87,6 +87,112 @@ describe('ImageWorkflow', () => {
         }));
     });
 
+    it('forwards single-slot OpenAI partial images as data URLs', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [{ b64_json: 'generated' }];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 1,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).toHaveBeenCalledWith('data:image/png;base64,partial');
+        expect(generate).toHaveBeenCalledWith(expect.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
+    it('does not forward partial image callbacks for batch generation', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+            ];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 2,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).not.toHaveBeenCalled();
+        expect(generate).toHaveBeenCalledWith(expect.not.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
+    it('does not forward partial image callbacks for Nano Banana generation', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [{ b64_json: 'generated' }];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate: vi.fn(),
+                edit: vi.fn(),
+            },
+            google: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'google-key',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            prompt: 'teapot city',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).not.toHaveBeenCalled();
+        expect(generate).toHaveBeenCalledWith(expect.not.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
     it('routes edit requests through the configured provider for the default model', async () => {
         const edit = vi.fn(async () => ({ b64_json: 'edited' }));
         const providers: ImageProviderRegistry = {
@@ -408,7 +514,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'a luminous teapot city',
             aspectRatio: '16:9',
@@ -435,6 +541,44 @@ describe('googleImageProvider', () => {
             aspectRatio: '16:9',
             imageSize: '2K',
         });
+    });
+
+    it('ignores partial image callbacks for Gemini requests', async () => {
+        const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+            candidates: [{
+                content: {
+                    parts: [{ inlineData: { data: 'gemini-image' } }],
+                },
+            }],
+        })));
+        const provider = createGoogleImageProvider(fetchImpl);
+        const onPartialImage = vi.fn();
+
+        const result = await provider.generate({
+            apiKey: 'google-key',
+            model: {
+                slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                provider: 'google',
+                apiModel: 'gemini-3-pro-image-preview',
+                label: 'Nano Banana Pro',
+                endpoints: {
+                    generate: 'https://example.test/generate',
+                    edit: 'https://example.test/generate',
+                },
+                parameters: {},
+                capabilities: { transformMask: false, partialImageStreaming: false },
+            },
+            prompt: 'a luminous teapot city',
+            onPartialImage,
+        });
+
+        expect(result).toEqual([{ b64_json: 'gemini-image' }]);
+        expect(onPartialImage).not.toHaveBeenCalled();
+
+        const requestInit = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+        const body = JSON.parse(String(requestInit.body));
+        expect(JSON.stringify(body)).not.toContain('partial');
+        expect(JSON.stringify(body)).not.toContain('stream');
     });
 
     it('normalizes unsupported Nano Banana aspect ratios to 1:1', async () => {
@@ -545,7 +689,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'make it cinematic',
             preserveSourceDimensions: true,
@@ -600,7 +744,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'a luminous teapot city',
             referenceImages: [],

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -26,6 +26,7 @@ export interface GenerateImageInput {
     lighting: string;
     palette: string;
     referenceImages: File[];
+    onPartialImage?: (imageUrl: string) => void;
 }
 
 export interface EditImageInput {
@@ -74,6 +75,9 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
             });
 
             const batchSize = providerRequest.batchSize ?? 1;
+            const onPartialImage = batchSize === 1 && model.capabilities.partialImageStreaming
+                ? createPartialImageHandler(input.onPartialImage)
+                : undefined;
 
             try {
                 const responses = await provider.generate({
@@ -81,6 +85,7 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
                     model,
                     prompt: buildGenerationPrompt(input),
                     ...providerRequest,
+                    ...(onPartialImage ? { onPartialImage } : {}),
                 });
                 const results = mapGenerateBatchResults(responses, batchSize);
 
@@ -148,6 +153,24 @@ const buildGenerationPrompt = (input: GenerateImageInput) => {
         ? `${input.prompt}, ${modifiers.join(', ')}`
         : input.prompt;
 };
+
+function createPartialImageHandler(onPartialImage: GenerateImageInput['onPartialImage']) {
+    if (!onPartialImage) {
+        return undefined;
+    }
+
+    return (partial: ImageProviderResponse) => {
+        if (!partial.b64_json) {
+            return;
+        }
+
+        try {
+            onPartialImage(`data:image/png;base64,${partial.b64_json}`);
+        } catch {
+            // Partial previews should not interrupt the final generation result.
+        }
+    };
+}
 
 const createEditSourceFile = (sourceImage: Blob) => {
     return new File([sourceImage], 'edit-input.png', {

--- a/src/index.css
+++ b/src/index.css
@@ -791,6 +791,28 @@ textarea.aura-input {
     background: var(--color-charcoal);
 }
 
+.partial-result-image {
+    opacity: 0.88;
+}
+
+.partial-result-banner {
+    position: absolute;
+    top: var(--spacing-24);
+    left: 50%;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--element-gap);
+    padding: var(--spacing-8) var(--spacing-16);
+    transform: translateX(-50%);
+    background: var(--color-snow);
+    color: var(--color-charcoal);
+    white-space: nowrap;
+}
+
+.partial-result-banner span {
+    color: var(--color-steel);
+}
+
 .result-batch-container {
     width: 100%;
     min-height: 100%;

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -77,6 +77,94 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('streams partial image events and resolves with the completed image', async () => {
+        const fetchMock = vi.fn(async () => createSseResponse([
+            'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","b64_json":"partial-0"}\n\n',
+            'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","partial_image":{"b64_json":"partial-1"}}\n\n',
+            'event: image_generation.completed\ndata: {"type":"image_generation.completed","data":[{"b64_json":"final"}]}\n\n',
+        ]));
+        const partials: Array<{ b64_json?: string }> = [];
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat appearing slowly',
+                onPartialImage: (partial) => partials.push(partial),
+            });
+
+            expect(result).toEqual({ b64_json: 'final' });
+            expect(partials).toEqual([
+                { b64_json: 'partial-0' },
+                { b64_json: 'partial-1' },
+            ]);
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body).toMatchObject({
+                stream: true,
+                partial_images: 3,
+                n: 1,
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('falls back to the normal JSON response when streaming is requested but SSE is not returned', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [{ b64_json: 'generated' }],
+        }), {
+            headers: { 'Content-Type': 'application/json' },
+        }));
+        const onPartialImage = vi.fn();
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat in a hat',
+                onPartialImage,
+            });
+
+            expect(result).toEqual({ b64_json: 'generated' });
+            expect(onPartialImage).not.toHaveBeenCalled();
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body.stream).toBe(true);
+            expect(body.partial_images).toBe(3);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('does not request streaming for batched image generation', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+            ],
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            await openAiImageClient.createImages({
+                apiKey: 'sk-test',
+                prompt: 'two cats',
+                batchSize: 2,
+                onPartialImage: vi.fn(),
+            });
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body.stream).toBeUndefined();
+            expect(body.partial_images).toBeUndefined();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts image edit requests with multipart form data to the edit endpoint', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [{ b64_json: 'edited' }],
@@ -156,6 +244,19 @@ describe('openAiImageClient', () => {
         }
     });
 });
+
+function createSseResponse(chunks: string[]) {
+    const encoder = new TextEncoder();
+
+    return new Response(new ReadableStream({
+        start(controller) {
+            chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+            controller.close();
+        },
+    }), {
+        headers: { 'Content-Type': 'text/event-stream' },
+    });
+}
 
 describe('openAiResponsesClient', () => {
     it('posts image reasoning requests to the responses endpoint', async () => {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -19,6 +19,7 @@ export interface OpenAiImageRequest {
     batchSize?: number;
     referenceImages?: File[];
     maskImage?: File | Blob | null;
+    onPartialImage?: (partial: OpenAiImageResponse) => void;
 }
 
 export interface OpenAiImageResponse {
@@ -60,12 +61,15 @@ export const openAiImageClient: OpenAiImageClient = {
     },
 };
 
+const OPENAI_PARTIAL_IMAGE_COUNT = 3;
+
 async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiImageResponse[]> {
     const isEdit = request.referenceImages && request.referenceImages.length > 0;
     const apiModel = request.apiModel ?? request.model ?? OPENAI_IMAGE_MODEL;
     const endpoints = request.endpoints ?? IMAGE_MODEL_REGISTRY[OPENAI_IMAGE_MODEL].endpoints;
     const endpoint = isEdit ? endpoints.edit : endpoints.generate;
     const batchSize = coerceOpenAiBatchSize(request.batchSize);
+    const streamPartialImages = Boolean(request.onPartialImage) && batchSize === 1 && supportsOpenAiImageStreaming(apiModel);
 
     let body: BodyInit;
     const headers: Record<string, string> = {
@@ -89,6 +93,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         if (request.size && request.size !== 'auto') formData.append('size', request.size);
         if (request.quality) formData.append('quality', request.quality);
         if (request.background && request.background !== 'auto') formData.append('background', request.background);
+        if (streamPartialImages) {
+            formData.append('stream', 'true');
+            formData.append('partial_images', String(OPENAI_PARTIAL_IMAGE_COUNT));
+        }
 
         body = formData;
     } else {
@@ -100,6 +108,8 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
             size?: string;
             quality?: ImageQuality;
             background?: 'transparent' | 'opaque';
+            stream?: boolean;
+            partial_images?: number;
         } = {
             model: apiModel,
             prompt: request.prompt,
@@ -108,6 +118,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         if (request.size && request.size !== 'auto') jsonBody.size = request.size;
         if (request.quality) jsonBody.quality = request.quality;
         if (request.background && request.background !== 'auto') jsonBody.background = request.background;
+        if (streamPartialImages) {
+            jsonBody.stream = true;
+            jsonBody.partial_images = OPENAI_PARTIAL_IMAGE_COUNT;
+        }
 
         body = JSON.stringify(jsonBody);
     }
@@ -123,6 +137,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
     }
 
+    if (streamPartialImages && isEventStreamResponse(response)) {
+        return readOpenAiImageStream(response, request.onPartialImage);
+    }
+
     const data: { data?: OpenAiImageResponse[] } = await response.json();
 
     if (!data.data || data.data.length === 0) {
@@ -130,6 +148,211 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
     }
 
     return data.data;
+}
+
+function supportsOpenAiImageStreaming(apiModel: string) {
+    return apiModel === OPENAI_IMAGE_MODEL;
+}
+
+function isEventStreamResponse(response: Response) {
+    return response.headers.get('content-type')?.toLowerCase().includes('text/event-stream') ?? false;
+}
+
+async function readOpenAiImageStream(
+    response: Response,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+): Promise<OpenAiImageResponse[]> {
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+        return parseOpenAiImageEventStream(await response.text(), onPartialImage);
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    const completed = {
+        images: null as OpenAiImageResponse[] | null,
+    };
+    const processBlock = (block: string) => {
+        const nextImages = parseOpenAiImageEventBlock(block, onPartialImage);
+        if (nextImages) {
+            completed.images = nextImages;
+        }
+    };
+
+    while (true) {
+        const { value, done } = await reader.read();
+        if (value) {
+            buffer += decoder.decode(value, { stream: !done });
+            buffer = drainEventStreamBlocks(buffer, processBlock);
+        }
+
+        if (done) {
+            buffer += decoder.decode();
+            break;
+        }
+    }
+
+    if (buffer.trim()) {
+        processBlock(buffer);
+    }
+
+    const completedImages = completed.images;
+    if (!completedImages || completedImages.length === 0) {
+        throw new Error('No image data returned from OpenAI');
+    }
+
+    return completedImages;
+}
+
+function parseOpenAiImageEventStream(
+    eventStream: string,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+) {
+    let completedImages: OpenAiImageResponse[] | null = null;
+    const buffer = drainEventStreamBlocks(eventStream, (block) => {
+        const nextImages = parseOpenAiImageEventBlock(block, onPartialImage);
+        if (nextImages) {
+            completedImages = nextImages;
+        }
+    });
+
+    if (buffer.trim()) {
+        const nextImages = parseOpenAiImageEventBlock(buffer, onPartialImage);
+        if (nextImages) {
+            completedImages = nextImages;
+        }
+    }
+
+    if (!completedImages || completedImages.length === 0) {
+        throw new Error('No image data returned from OpenAI');
+    }
+
+    return completedImages;
+}
+
+function drainEventStreamBlocks(buffer: string, onBlock: (block: string) => void) {
+    let remaining = buffer;
+
+    while (true) {
+        const separator = remaining.match(/\r?\n\r?\n/);
+        if (!separator || separator.index === undefined) {
+            return remaining;
+        }
+
+        const block = remaining.slice(0, separator.index);
+        remaining = remaining.slice(separator.index + separator[0].length);
+        if (block.trim()) {
+            onBlock(block);
+        }
+    }
+}
+
+function parseOpenAiImageEventBlock(
+    block: string,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+): OpenAiImageResponse[] | null {
+    const event = parseServerSentEvent(block);
+    if (!event.data || event.data === '[DONE]') {
+        return null;
+    }
+
+    const payload = parseJsonRecord(event.data);
+    if (!payload) {
+        return null;
+    }
+
+    const eventType = [
+        event.name,
+        typeof payload.type === 'string' ? payload.type : '',
+        typeof payload.event === 'string' ? payload.event : '',
+    ].join(' ').toLowerCase();
+
+    if (eventType.includes('partial_image')) {
+        const b64Json = extractImageB64Json(payload);
+        if (b64Json && onPartialImage) {
+            try {
+                onPartialImage({ b64_json: b64Json });
+            } catch {
+                // Partial previews are opportunistic; the final generation should still resolve.
+            }
+        }
+        return null;
+    }
+
+    const images = extractImageResponses(payload);
+    if (images.length > 0 && (eventType.includes('completed') || eventType.includes('complete') || !event.name)) {
+        return images;
+    }
+
+    return null;
+}
+
+function parseServerSentEvent(block: string) {
+    const dataLines: string[] = [];
+    let name = '';
+
+    block.split(/\r?\n/).forEach((line) => {
+        if (line.startsWith('event:')) {
+            name = line.slice('event:'.length).trim();
+            return;
+        }
+
+        if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).trimStart());
+        }
+    });
+
+    return {
+        name,
+        data: dataLines.join('\n').trim(),
+    };
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+    try {
+        const parsed: unknown = JSON.parse(value);
+        return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? parsed as Record<string, unknown>
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function extractImageResponses(value: unknown): OpenAiImageResponse[] {
+    if (typeof value !== 'object' || value === null) {
+        return [];
+    }
+
+    const record = value as Record<string, unknown>;
+    if (Array.isArray(record.data)) {
+        return record.data.flatMap(extractImageResponses);
+    }
+
+    const b64Json = extractImageB64Json(record);
+    return b64Json ? [{ b64_json: b64Json }] : [];
+}
+
+function extractImageB64Json(value: unknown): string | null {
+    if (Array.isArray(value)) {
+        return value.map(extractImageB64Json).find((item): item is string => Boolean(item)) ?? null;
+    }
+
+    if (typeof value !== 'object' || value === null) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const key of ['b64_json', 'partial_image_b64', 'image_b64', 'b64']) {
+        if (typeof record[key] === 'string') {
+            return record[key] as string;
+        }
+    }
+
+    return extractImageB64Json(record.partial_image)
+        ?? extractImageB64Json(record.image)
+        ?? extractImageB64Json(record.data);
 }
 
 function coerceOpenAiBatchSize(value: unknown): number {

--- a/src/utils/openaiModels.ts
+++ b/src/utils/openaiModels.ts
@@ -24,6 +24,7 @@ export interface ImageModelConfig {
     parameters: Partial<Record<'size' | 'quality' | 'background' | 'aspectRatio' | 'imageSize', string>>;
     capabilities: {
         transformMask: boolean;
+        partialImageStreaming: boolean;
     };
 }
 
@@ -52,6 +53,7 @@ export const IMAGE_MODEL_REGISTRY = {
         },
         capabilities: {
             transformMask: true,
+            partialImageStreaming: true,
         },
     },
     [NANO_BANANA_PRO_IMAGE_MODEL]: {
@@ -69,6 +71,7 @@ export const IMAGE_MODEL_REGISTRY = {
         },
         capabilities: {
             transformMask: false,
+            partialImageStreaming: false,
         },
     },
 } as const satisfies Record<string, ImageModelConfig>;

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -200,6 +200,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const removeReferenceAt = referenceCollection.removeAt;
     const {
         currentResult,
+        currentPartialResult,
         currentBatchResults,
         loading,
         error,
@@ -651,8 +652,17 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
 
-                <section className={`preview-panel glass-panel${showBatchGrid ? ' batch-preview-panel' : ''}`}>
-                    {showBatchGrid ? (
+                <section className={`preview-panel glass-panel${showBatchGrid && !currentPartialResult ? ' batch-preview-panel' : ''}`}>
+                    {currentPartialResult ? (
+                        <div className="result-container partial-result-container">
+                            <img src={currentPartialResult} alt="In-progress generation preview" className="result-image partial-result-image" />
+                            <div className="partial-result-banner glass-panel">
+                                <Loader2 className="spin" size={18} />
+                                <strong>Generating preview</strong>
+                                <span>Final result is still rendering.</span>
+                            </div>
+                        </div>
+                    ) : showBatchGrid ? (
                         <div className="result-batch-container">
                             <div className="result-batch-grid">
                                 {currentBatchResults.map((result) => (


### PR DESCRIPTION
## Summary

- Adds OpenAI Images API SSE streaming with partial image callbacks and final response resolution
- Falls back silently for non-SSE responses and disables streaming for multi-slot batches or Google requests
- Shows in-progress partial previews in the Generate view
- Adds controller partial-preview state coverage and stale-run guard

Closes #77.

## Validation

- pnpm vitest run src/generate-session/useGenerateController.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- npm run build
- playwright screenshot http://127.0.0.1:5173/ /tmp/aura-issue77-generate.png