### PR TITLE
Track actual generation parameters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ One slot in a **generation batch**. A batch result may be a generated image or a
 slot-level failure. Saving a successful batch result creates its own archive
 image and lineage step while preserving the full run inputs.
 
+## Actual parameters
+
+Provider- or workflow-reported facts about a completed generated image, such as
+the provider-rewritten prompt, applied size or quality, and elapsed generation
+time. Distinct from requested generation settings, which are what the user asked
+for before the provider processed the run. Actual parameters are recorded only
+when reported or measured; do not infer missing provider values.
+
 ## Favorite
 
 A user-marked archive image kept easy to find with the Archive favorites filter.

--- a/src/archive/ArchiveManifest.test.ts
+++ b/src/archive/ArchiveManifest.test.ts
@@ -50,6 +50,27 @@ describe('ArchiveManifest', () => {
         ]);
     });
 
+    it('preserves actual parameters while keeping legacy images compatible by omission', () => {
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const manifest = parseArchiveManifest({
+            version: ARCHIVE_MANIFEST_VERSION,
+            images: [
+                createManifestImage({ id: 'actual-image', actualParameters }),
+                createManifestImage({ id: 'legacy-image' }),
+            ],
+        });
+
+        expect(manifest.images).toEqual([
+            expect.objectContaining({ id: 'actual-image', actualParameters }),
+            expect.not.objectContaining({ id: 'legacy-image', actualParameters: expect.anything() }),
+        ]);
+    });
+
     it('rejects malformed layer stack entries', () => {
         expect(() => parseArchiveManifest({
             version: ARCHIVE_MANIFEST_VERSION,

--- a/src/archive/ArchiveManifest.ts
+++ b/src/archive/ArchiveManifest.ts
@@ -1,4 +1,4 @@
-import { isLayerBlendMode, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
+import { isLayerBlendMode, type ActualImageParameters, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
 import { parseLineageMetadata } from '../lineage/lineageMetadata';
 import type { LineageStep } from '../lineage/types';
 
@@ -25,6 +25,7 @@ export interface ArchiveManifestImage {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     imageFileName?: string;
     references: ArchiveManifestReference[];
     layerStack?: ArchiveManifestLayerStack;
@@ -160,6 +161,7 @@ function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
         style: optionalString(value.style),
         lighting: optionalString(value.lighting),
         palette: optionalString(value.palette),
+        actualParameters: optionalActualParameters(value.actualParameters),
         imageFileName: optionalString(value.imageFileName),
         references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
         layerStack: parseOptionalLayerStack(value.layerStack),
@@ -308,6 +310,21 @@ function optionalNumber(value: unknown) {
 
 function optionalBoolean(value: unknown) {
     return typeof value === 'boolean' ? value : undefined;
+}
+
+function optionalActualParameters(value: unknown): ActualImageParameters | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+
+    const actualParameters: ActualImageParameters = {
+        ...(typeof value.revisedPrompt === 'string' ? { revisedPrompt: value.revisedPrompt } : {}),
+        ...(typeof value.size === 'string' ? { size: value.size } : {}),
+        ...(typeof value.quality === 'string' ? { quality: value.quality } : {}),
+        ...(typeof value.elapsedMs === 'number' && Number.isFinite(value.elapsedMs) ? { elapsedMs: value.elapsedMs } : {}),
+    };
+
+    return Object.keys(actualParameters).length > 0 ? actualParameters : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/archive/ArchiveStore.test.ts
+++ b/src/archive/ArchiveStore.test.ts
@@ -232,6 +232,45 @@ describe('ArchiveStore layer asset ownership', () => {
         ]));
     });
 
+    it('persists actual parameter metadata and treats legacy metadata as absent', async () => {
+        const { store, metadata } = createStore();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+
+        await store.save(createImageInput({
+            id: 'actual-image',
+            actualParameters,
+        }));
+        metadata.records.set('legacy-image', {
+            id: 'legacy-image',
+            storedUrl: 'data:image/png;base64,legacy',
+            prompt: 'legacy prompt',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-06-05T08:00:00.000Z',
+            width: 1024,
+            height: 1024,
+            referenceIds: [],
+        });
+
+        expect(metadata.records.get('actual-image')?.actualParameters).toEqual(actualParameters);
+        await expect(store.list()).resolves.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'actual-image',
+                actualParameters,
+            }),
+            expect.not.objectContaining({
+                id: 'legacy-image',
+                actualParameters: expect.anything(),
+            }),
+        ]));
+    });
+
     it('recovers orphaned image blobs when metadata is missing', async () => {
         const { store, metadata, blobs } = createStore();
         blobs.blobs.set('img_orphaned-image', 'data:image/png;base64,orphaned');
@@ -283,6 +322,7 @@ function createImageInput(overrides: Partial<ArchiveImage> = {}) {
         height: 1024,
         favorite: overrides.favorite,
         references: overrides.references,
+        actualParameters: overrides.actualParameters,
         layerStack: overrides.layerStack,
     };
 }

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -134,6 +134,7 @@ class LocalArchiveStore implements ArchiveStore {
                 style: input.style,
                 lighting: input.lighting,
                 palette: input.palette,
+                actualParameters: input.actualParameters,
                 referenceIds,
                 layerStack: durableLayerStack,
             });
@@ -159,6 +160,7 @@ class LocalArchiveStore implements ArchiveStore {
             style: input.style,
             lighting: input.lighting,
             palette: input.palette,
+            actualParameters: input.actualParameters,
             layerStack: input.layerStack,
         };
     }
@@ -215,6 +217,7 @@ class LocalArchiveStore implements ArchiveStore {
             style: record.style,
             lighting: record.lighting,
             palette: record.palette,
+            actualParameters: record.actualParameters,
             layerStack,
         };
     }

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -208,6 +208,41 @@ describe('ArchiveTransfer', () => {
         expect(archiveStore.images.get('image-2')?.favorite).toBeUndefined();
     });
 
+    it('round-trips actual parameters through the archive manifest', async () => {
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const sourceImages = createImages();
+        sourceImages[0] = {
+            ...sourceImages[0]!,
+            actualParameters,
+        };
+
+        const zipBytes = await buildArchiveZip(sourceImages, { lineageStore: createStore() });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const manifest = JSON.parse(await zip.file('archive-manifest.json')!.async('text')) as {
+            images: Array<{ id: string; actualParameters?: unknown }>;
+        };
+
+        expect(manifest.images).toEqual([
+            expect.objectContaining({ id: 'image-1', actualParameters }),
+            expect.not.objectContaining({ id: 'image-2', actualParameters: expect.anything() }),
+            expect.not.objectContaining({ id: 'image-3', actualParameters: expect.anything() }),
+        ]);
+
+        const archiveStore = new InMemoryArchiveStore();
+        await importArchiveZip(zipBytes, {
+            archiveStore,
+            lineageStore: createStore(),
+        });
+
+        expect(archiveStore.images.get('image-1')?.actualParameters).toEqual(actualParameters);
+        expect(archiveStore.images.get('image-2')?.actualParameters).toBeUndefined();
+    });
+
     it('round-trips layered image assets and stable layer ids', async () => {
         const sourceLineage = createStore();
         const sourceImages = [createLayeredImage()];

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -71,6 +71,7 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             imageFileName,
             references,
             layerStack,
@@ -129,6 +130,7 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             references,
             layerStack,
         });

--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -3,7 +3,12 @@ import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { createDurableLayerStackMetadata } from './ArchiveAssets';
 
-type ArchiveImageRow = ArchiveImage & { favorite?: number | null; ref_ids?: string; layer_stack?: string };
+type ArchiveImageRow = ArchiveImage & {
+    favorite?: number | null;
+    ref_ids?: string;
+    layer_stack?: string;
+    actual_parameters?: string | null;
+};
 
 type ArchiveMetadataRecord = Omit<ArchiveImage, 'url' | 'references'> & {
     storedUrl: string;
@@ -46,6 +51,7 @@ export class SQLiteArchiveMetadataPort {
         await this.sql.sql`ALTER TABLE images ADD COLUMN palette TEXT`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN layer_stack TEXT`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN favorite INTEGER`.catch(() => null);
+        await this.sql.sql`ALTER TABLE images ADD COLUMN actual_parameters TEXT`.catch(() => null);
 
         this.initialized = true;
     }
@@ -54,7 +60,7 @@ export class SQLiteArchiveMetadataPort {
         await this.init();
 
         await this.sql.sql`
-            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack)
+            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack, actual_parameters)
             VALUES (
                 ${record.id},
                 ${record.storedUrl},
@@ -71,7 +77,8 @@ export class SQLiteArchiveMetadataPort {
                 ${record.style || null},
                 ${record.lighting || null},
                 ${record.palette || null},
-                ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null}
+                ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null},
+                ${record.actualParameters ? JSON.stringify(record.actualParameters) : null}
             )
         `;
     }
@@ -96,6 +103,7 @@ export class SQLiteArchiveMetadataPort {
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: parseActualParameters(image.actual_parameters),
             referenceIds: parseReferenceIds(image.ref_ids),
             layerStack: parseLayerStack(image.layer_stack),
         }));
@@ -125,6 +133,7 @@ export class SQLiteArchiveMetadataPort {
             style: row.style,
             lighting: row.lighting,
             palette: row.palette,
+            actualParameters: parseActualParameters(row.actual_parameters),
             referenceIds: parseReferenceIds(row.ref_ids),
             layerStack: parseLayerStack(row.layer_stack),
         };
@@ -154,6 +163,31 @@ const optionalNumber = (value: unknown): number | undefined => {
 
 const parseFavorite = (value: unknown): boolean | undefined => {
     return value === 1 || value === true ? true : undefined;
+};
+
+const parseActualParameters = (value?: string | null): ArchiveImage['actualParameters'] | undefined => {
+    if (!value) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return undefined;
+        }
+
+        const record = parsed as Record<string, unknown>;
+        const actualParameters: ArchiveImage['actualParameters'] = {
+            ...(typeof record.revisedPrompt === 'string' ? { revisedPrompt: record.revisedPrompt } : {}),
+            ...(typeof record.size === 'string' ? { size: record.size } : {}),
+            ...(typeof record.quality === 'string' ? { quality: record.quality } : {}),
+            ...(typeof record.elapsedMs === 'number' && Number.isFinite(record.elapsedMs) ? { elapsedMs: record.elapsedMs } : {}),
+        };
+
+        return Object.keys(actualParameters).length > 0 ? actualParameters : undefined;
+    } catch {
+        return undefined;
+    }
 };
 
 const parseLayerStack = (value?: string): ArchiveLayerStack | undefined => {

--- a/src/archive/recoverArchiveMetadata.test.ts
+++ b/src/archive/recoverArchiveMetadata.test.ts
@@ -14,6 +14,12 @@ describe('recoverArchiveMetadataFromManifests', () => {
         const generateMetadata = createTypedGenerateMetadata();
         const editorMetadata = createTypedEditorMetadata();
         const autopilotMetadata = createTypedAutopilotMetadata();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
 
         const summary = await recoverArchiveMetadataFromManifests({
             version: 1,
@@ -31,6 +37,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     style: 'none',
                     lighting: 'none',
                     palette: 'none',
+                    actualParameters,
                     imageFileName: 'aura-image-1.png',
                     references: [{ fileName: 'aura-image-1-reference-0.png' }],
                     layerStack: {
@@ -122,6 +129,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
             aspectRatio: '1536x1024',
             referenceIds: [0],
             model: 'gpt-image-2',
+            actualParameters,
             layerStack: expect.objectContaining({
                 layers: [
                     expect.objectContaining({ id: 'base', assetUrl: '' }),

--- a/src/archive/recoverArchiveMetadata.ts
+++ b/src/archive/recoverArchiveMetadata.ts
@@ -1,5 +1,5 @@
 import { archiveMetadataPort } from '../db/AuraPersistence';
-import type { ArchiveLayerStack } from '../db/types';
+import type { ActualImageParameters, ArchiveLayerStack } from '../db/types';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { storage, type StorageProvider } from '../services/StorageService';
 import { getArchiveImageBlobKey } from './ArchiveAssets';
@@ -25,6 +25,7 @@ interface ArchiveMetadataRecord {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     referenceIds: number[];
     layerStack?: ArchiveLayerStack;
 }
@@ -80,6 +81,7 @@ export async function recoverArchiveMetadataFromManifests(
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             referenceIds: image.references.map((_, index) => index),
             layerStack: image.layerStack ? createLayerStackMetadata(image.layerStack) : undefined,
         });

--- a/src/components/ActualParametersPanel.tsx
+++ b/src/components/ActualParametersPanel.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+    hasActualParameterDetails,
+    type ActualParameterDetails,
+} from '../generate-session/actualParameters';
+
+interface ActualParametersPanelProps {
+    details: ActualParameterDetails;
+    compact?: boolean;
+}
+
+const ActualParametersPanel: React.FC<ActualParametersPanelProps> = ({ details, compact = false }) => {
+    if (!hasActualParameterDetails(details)) {
+        return null;
+    }
+
+    return (
+        <div className={`actual-parameters-panel${compact ? ' compact' : ''}`}>
+            <label className="section-label">Actual Parameters</label>
+
+            {details.rows.length > 0 && (
+                <dl className="actual-parameter-list">
+                    {details.rows.map((row) => (
+                        <div key={row.label} className={`actual-parameter-row${row.changed ? ' changed' : ''}`}>
+                            <dt>{row.label}</dt>
+                            <dd>
+                                <span>
+                                    <small>Requested</small>
+                                    <strong>{row.requested ?? 'Not set'}</strong>
+                                </span>
+                                <span>
+                                    <small>Actual</small>
+                                    <strong>{row.actual}</strong>
+                                </span>
+                                {row.changed && <em>Changed</em>}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            )}
+
+            {details.elapsedLabel && (
+                <div className="actual-parameter-elapsed">
+                    <span>Elapsed</span>
+                    <strong>{details.elapsedLabel}</strong>
+                </div>
+            )}
+
+            {details.revisedPrompt && (
+                <div className="actual-parameter-prompt">
+                    <span>Rewritten Prompt</span>
+                    <p>{details.revisedPrompt}</p>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ActualParametersPanel;

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -7,6 +7,11 @@ import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLi
 import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig } from '../utils/openaiModels';
+import ActualParametersPanel from './ActualParametersPanel';
+import {
+    buildActualParameterDetails,
+    getRequestedArchiveParameters,
+} from '../generate-session/actualParameters';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -37,6 +42,10 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     const imageModel = isImageModelSlug(image.model) ? image.model : OPENAI_IMAGE_MODEL;
     const modelLabel = resolveImageModelConfig(imageModel).label;
     const isNanoImage = imageModel === NANO_BANANA_PRO_IMAGE_MODEL;
+    const actualParameterDetails = buildActualParameterDetails({
+        actualParameters: image.actualParameters,
+        requestedParameters: getRequestedArchiveParameters(image),
+    });
 
     const copyPrompt = () => {
         navigator.clipboard.writeText(image.prompt);
@@ -193,6 +202,8 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                 </div>
                             )}
                         </div>
+
+                        <ActualParametersPanel details={actualParameterDetails} />
 
                         {image.references && image.references.length > 0 && (
                             <div className="sidebar-section">

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,3 +1,10 @@
+export interface ActualImageParameters {
+    revisedPrompt?: string;
+    size?: string;
+    quality?: string;
+    elapsedMs?: number;
+}
+
 export interface ArchiveImage {
     id: string;
     url: string;
@@ -14,6 +21,7 @@ export interface ArchiveImage {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     layerStack?: ArchiveLayerStack;
 }
 

--- a/src/generate-session/actualParameters.test.ts
+++ b/src/generate-session/actualParameters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildActualParameterDetails, hasActualParameterDetails } from './actualParameters';
+
+describe('actual parameter details', () => {
+    it('omits details for legacy images without actual parameters', () => {
+        const details = buildActualParameterDetails({});
+
+        expect(details).toEqual({ rows: [] });
+        expect(hasActualParameterDetails(details)).toBe(false);
+    });
+
+    it('compares requested and actual size and quality values', () => {
+        const details = buildActualParameterDetails({
+            requestedParameters: {
+                size: '1024x1024',
+                quality: 'high',
+            },
+            actualParameters: {
+                size: '1536x1024',
+                quality: 'high',
+            },
+        });
+
+        expect(details.rows).toEqual([
+            {
+                label: 'Size',
+                requested: '1024x1024',
+                actual: '1536x1024',
+                changed: true,
+            },
+            {
+                label: 'Quality',
+                requested: 'high',
+                actual: 'high',
+                changed: false,
+            },
+        ]);
+        expect(hasActualParameterDetails(details)).toBe(true);
+    });
+
+    it('formats revised prompt and elapsed time when present', () => {
+        expect(buildActualParameterDetails({
+            actualParameters: {
+                revisedPrompt: 'A more detailed prompt',
+                elapsedMs: 930,
+            },
+        })).toEqual({
+            rows: [],
+            revisedPrompt: 'A more detailed prompt',
+            elapsedLabel: '930 ms',
+        });
+
+        expect(buildActualParameterDetails({
+            actualParameters: {
+                elapsedMs: 1234,
+            },
+        }).elapsedLabel).toBe('1.2 s');
+    });
+});

--- a/src/generate-session/actualParameters.ts
+++ b/src/generate-session/actualParameters.ts
@@ -1,0 +1,83 @@
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
+import { getActiveGenerateArchiveFields, type GenerateDraft } from './GenerateSession';
+
+export interface RequestedImageParameters {
+    size?: string;
+    quality?: string;
+}
+
+export interface ActualParameterRow {
+    label: string;
+    requested?: string;
+    actual: string;
+    changed: boolean;
+}
+
+export interface ActualParameterDetails {
+    rows: ActualParameterRow[];
+    revisedPrompt?: string;
+    elapsedLabel?: string;
+}
+
+export function getRequestedGenerateParameters(draft: GenerateDraft): RequestedImageParameters {
+    const fields = getActiveGenerateArchiveFields(draft);
+
+    return {
+        size: fields.aspectRatio,
+        quality: fields.quality,
+    };
+}
+
+export function getRequestedArchiveParameters(image: ArchiveImage): RequestedImageParameters {
+    return {
+        size: image.aspectRatio,
+        quality: image.quality,
+    };
+}
+
+export function buildActualParameterDetails(input: {
+    actualParameters?: ActualImageParameters;
+    requestedParameters?: RequestedImageParameters;
+}): ActualParameterDetails {
+    const actualParameters = input.actualParameters;
+    if (!actualParameters) {
+        return { rows: [] };
+    }
+
+    const rows: ActualParameterRow[] = [];
+    if (actualParameters.size) {
+        rows.push(buildRow('Size', input.requestedParameters?.size, actualParameters.size));
+    }
+    if (actualParameters.quality) {
+        rows.push(buildRow('Quality', input.requestedParameters?.quality, actualParameters.quality));
+    }
+
+    return {
+        rows,
+        ...(actualParameters.revisedPrompt ? { revisedPrompt: actualParameters.revisedPrompt } : {}),
+        ...(typeof actualParameters.elapsedMs === 'number' && Number.isFinite(actualParameters.elapsedMs)
+            ? { elapsedLabel: formatElapsedMs(actualParameters.elapsedMs) }
+            : {}),
+    };
+}
+
+export function hasActualParameterDetails(details: ActualParameterDetails) {
+    return details.rows.length > 0 || Boolean(details.revisedPrompt) || Boolean(details.elapsedLabel);
+}
+
+function buildRow(label: string, requested: string | undefined, actual: string): ActualParameterRow {
+    return {
+        label,
+        requested,
+        actual,
+        changed: Boolean(requested && requested !== actual),
+    };
+}
+
+function formatElapsedMs(elapsedMs: number) {
+    if (elapsedMs < 1000) {
+        return `${Math.round(elapsedMs)} ms`;
+    }
+
+    return `${(elapsedMs / 1000).toFixed(1)} s`;
+}

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -127,6 +127,36 @@ describe('saveGeneratedImage', () => {
         ]);
     });
 
+    it('writes actual parameters into generation lineage metadata', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const image = createArchiveImage({
+            id: 'generated-with-actuals',
+            actualParameters,
+        });
+
+        await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        await expect(lineage.getByArchiveImageId('generated-with-actuals')).resolves.toEqual([
+            expect.objectContaining({
+                stepType: 'generation',
+                metadata: expect.objectContaining({
+                    actualParameters,
+                }),
+            }),
+        ]);
+    });
+
     it('records Nano Banana Pro reference-generation lineage from the saved used Reference images', async () => {
         const lineage = createStore();
         const sessionStore = createSessionStore();

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -28,6 +28,12 @@ describe('Generate controller Image model archive metadata', () => {
             timestamp: '2026-06-05T12:00:00.000Z',
             draft,
             references: ['data:image/png;base64,ref'],
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 420,
+            },
         })).toMatchObject({
             id: 'generated-openai',
             model: OPENAI_IMAGE_MODEL,
@@ -37,6 +43,12 @@ describe('Generate controller Image model archive metadata', () => {
             width: 1536,
             height: 1024,
             references: ['data:image/png;base64,ref'],
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 420,
+            },
         });
     });
 
@@ -75,6 +87,10 @@ describe('Generate controller batch result slots', () => {
                 slotIndex: 0,
                 status: 'success',
                 imageUrl: 'data:image/png;base64,one',
+                actualParameters: {
+                    elapsedMs: 350,
+                    size: '1536x1024',
+                },
             },
             {
                 slotIndex: 1,
@@ -87,6 +103,10 @@ describe('Generate controller batch result slots', () => {
                 status: 'success',
                 imageUrl: 'data:image/png;base64,one',
                 isSaved: false,
+                actualParameters: {
+                    elapsedMs: 350,
+                    size: '1536x1024',
+                },
             },
             {
                 slotIndex: 1,

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import type { ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
 import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateLineageSource, type GenerateSessionStore } from './GenerateSession';
 import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResult, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
@@ -37,6 +37,7 @@ export type GenerateResultSlot =
         status: 'success';
         imageUrl: string;
         isSaved: boolean;
+        actualParameters?: ActualImageParameters;
         archiveImageId?: string;
     }
     | {
@@ -72,6 +73,7 @@ interface BuildGeneratedArchiveImageInput {
     timestamp: string;
     draft: GenerateDraft;
     references: string[];
+    actualParameters?: ActualImageParameters;
 }
 
 interface SnapshotGeneratedReferenceImagesInput {
@@ -85,6 +87,7 @@ interface BuildGeneratedArchiveImageForSaveInput {
     timestamp: string;
     draft: GenerateDraft;
     usedReferences: string[] | null;
+    actualParameters?: ActualImageParameters;
     serializeReferences: () => Promise<string[]>;
 }
 
@@ -94,6 +97,7 @@ export function buildGeneratedArchiveImage({
     timestamp,
     draft,
     references,
+    actualParameters,
 }: BuildGeneratedArchiveImageInput): ArchiveImage {
     const archiveFields = getActiveGenerateArchiveFields(draft);
 
@@ -111,6 +115,7 @@ export function buildGeneratedArchiveImage({
         style: draft.style,
         lighting: draft.lighting,
         palette: draft.palette,
+        actualParameters,
         references,
     };
 }
@@ -128,6 +133,7 @@ export async function buildGeneratedArchiveImageForSave({
     timestamp,
     draft,
     usedReferences,
+    actualParameters,
     serializeReferences,
 }: BuildGeneratedArchiveImageForSaveInput): Promise<ArchiveImage> {
     const references = usedReferences ?? await serializeReferences();
@@ -137,6 +143,7 @@ export async function buildGeneratedArchiveImageForSave({
         url,
         timestamp,
         draft,
+        actualParameters,
         references,
     });
 }
@@ -502,6 +509,7 @@ export function useGenerateController({
                 timestamp: new Date().toISOString(),
                 draft: currentRunDraft ?? draft,
                 usedReferences: currentResultReferences,
+                actualParameters: slot.actualParameters,
                 serializeReferences,
             });
             await saveGeneratedImage(image, {
@@ -555,6 +563,7 @@ export function useGenerateController({
     return {
         currentResult,
         currentBatchResults,
+        currentRunDraft,
         loading,
         error,
         autopilot,
@@ -577,6 +586,7 @@ export function buildGenerateResultSlots(results: GenerateBatchResult[]): Genera
             status: 'success',
             imageUrl: result.imageUrl,
             isSaved: false,
+            actualParameters: result.actualParameters,
         }
         : result);
 }

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -34,6 +34,9 @@ describe('ImageWorkflow', () => {
             slotIndex: 0,
             status: 'success',
             imageUrl: 'data:image/png;base64,generated',
+            actualParameters: {
+                elapsedMs: expect.any(Number),
+            },
         }]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             apiKey: 'sk-test',
@@ -78,13 +81,68 @@ describe('ImageWorkflow', () => {
         });
 
         expect(results).toEqual([
-            { slotIndex: 0, status: 'success', imageUrl: 'data:image/png;base64,generated-0' },
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,generated-0',
+                actualParameters: {
+                    elapsedMs: expect.any(Number),
+                },
+            },
             { slotIndex: 1, status: 'failed', error: 'No image data returned from image provider' },
-            { slotIndex: 2, status: 'success', imageUrl: 'data:image/png;base64,generated-2' },
+            {
+                slotIndex: 2,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,generated-2',
+                actualParameters: {
+                    elapsedMs: expect.any(Number),
+                },
+            },
         ]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             batchSize: 3,
         }));
+    });
+
+    it('attaches actual parameters and elapsed time to successful generated results', async () => {
+        const generate = vi.fn(async () => [{
+            b64_json: 'generated',
+            revised_prompt: 'refined mountain prompt',
+            size: '1536x1024',
+            quality: 'high',
+        }]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        }, {
+            now: createNowSequence([1000, 1275]),
+        });
+
+        const results = await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'medium',
+            aspectRatio: 'auto',
+            background: 'transparent',
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        });
+
+        expect(results).toEqual([{
+            slotIndex: 0,
+            status: 'success',
+            imageUrl: 'data:image/png;base64,generated',
+            actualParameters: {
+                revisedPrompt: 'refined mountain prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 275,
+            },
+        }]);
     });
 
     it('routes edit requests through the configured provider for the default model', async () => {
@@ -417,6 +475,9 @@ describe('googleImageProvider', () => {
         });
 
         expect(result).toEqual([{ b64_json: 'gemini-image' }]);
+        expect(result[0]).not.toHaveProperty('revised_prompt');
+        expect(result[0]).not.toHaveProperty('size');
+        expect(result[0]).not.toHaveProperty('quality');
         expect(fetchImpl).toHaveBeenCalledWith('https://example.test/generate', expect.objectContaining({
             method: 'POST',
             headers: {
@@ -614,3 +675,8 @@ describe('googleImageProvider', () => {
         });
     });
 });
+
+function createNowSequence(values: number[]) {
+    let index = 0;
+    return () => values[index++] ?? values.at(-1) ?? 0;
+}

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -1,4 +1,5 @@
 import { dataURLtoFile, fileToDataURL } from '../utils/file';
+import type { ActualImageParameters } from '../db/types';
 import {
     type ImageBackground,
     type ImageQuality,
@@ -46,6 +47,7 @@ export type GenerateBatchResult =
         slotIndex: number;
         status: 'success';
         imageUrl: string;
+        actualParameters?: ActualImageParameters;
     }
     | {
         slotIndex: number;
@@ -60,7 +62,16 @@ export interface ImageWorkflow {
     hydrateReferences(dataUrls: string[]): File[];
 }
 
-export function createImageWorkflow(providers: ImageProviderRegistry = imageProviderRegistry): ImageWorkflow {
+interface CreateImageWorkflowDeps {
+    now?: () => number;
+}
+
+export function createImageWorkflow(
+    providers: ImageProviderRegistry = imageProviderRegistry,
+    deps: CreateImageWorkflowDeps = {},
+): ImageWorkflow {
+    const now = deps.now ?? (() => performance.now());
+
     return {
         async generate(input) {
             const { model, modelSlug, provider } = resolveImageProvider(input.model, providers);
@@ -76,13 +87,15 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
             const batchSize = providerRequest.batchSize ?? 1;
 
             try {
+                const startedAt = now();
                 const responses = await provider.generate({
                     apiKey: input.apiKey,
                     model,
                     prompt: buildGenerationPrompt(input),
                     ...providerRequest,
                 });
-                const results = mapGenerateBatchResults(responses, batchSize);
+                const elapsedMs = Math.max(0, Math.round(now() - startedAt));
+                const results = mapGenerateBatchResults(responses, batchSize, elapsedMs);
 
                 if (!hasSuccessfulGeneratedImage(results) && batchSize === 1) {
                     const [result] = results;
@@ -188,7 +201,11 @@ function hasSuccessfulGeneratedImage(results: GenerateBatchResult[]): boolean {
     return getFirstSuccessfulGeneratedImage(results) !== null;
 }
 
-function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: number): GenerateBatchResult[] {
+function mapGenerateBatchResults(
+    responses: ImageProviderResponse[],
+    batchSize: number,
+    elapsedMs: number,
+): GenerateBatchResult[] {
     return Array.from({ length: batchSize }, (_, slotIndex) => {
         const response = responses[slotIndex];
 
@@ -197,6 +214,7 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
                 slotIndex,
                 status: 'success',
                 imageUrl: `data:image/png;base64,${response.b64_json}`,
+                actualParameters: buildActualImageParameters(response, elapsedMs),
             };
         }
 
@@ -206,4 +224,13 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
             error: 'No image data returned from image provider',
         };
     });
+}
+
+function buildActualImageParameters(response: ImageProviderResponse, elapsedMs: number): ActualImageParameters {
+    return {
+        ...(response.revised_prompt ? { revisedPrompt: response.revised_prompt } : {}),
+        ...(response.size ? { size: response.size } : {}),
+        ...(response.quality ? { quality: response.quality } : {}),
+        elapsedMs,
+    };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -791,6 +791,17 @@ textarea.aura-input {
     background: var(--color-charcoal);
 }
 
+.result-container.has-actual-parameters {
+    gap: var(--spacing-16);
+    padding-bottom: var(--spacing-16);
+}
+
+.result-container.has-actual-parameters .result-image {
+    height: auto;
+    max-height: min(70vh, 720px);
+    flex: 1;
+}
+
 .result-batch-container {
     width: 100%;
     min-height: 100%;
@@ -841,6 +852,109 @@ textarea.aura-input {
 
 .result-slot-actions {
     flex-wrap: wrap;
+}
+
+.actual-parameters-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    margin: 0 var(--spacing-16);
+    padding: var(--card-padding);
+    border: 1px solid var(--color-steel);
+    background: var(--color-snow);
+    color: var(--color-charcoal);
+}
+
+.result-slot-card .actual-parameters-panel,
+.modal-sidebar .actual-parameters-panel {
+    margin: 0;
+}
+
+.actual-parameters-panel.compact {
+    padding: var(--spacing-8);
+}
+
+.actual-parameter-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    margin: 0;
+}
+
+.actual-parameter-row,
+.actual-parameter-elapsed {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-16);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.actual-parameter-row dt,
+.actual-parameter-elapsed span,
+.actual-parameter-prompt span {
+    color: var(--color-steel);
+    text-transform: uppercase;
+}
+
+.actual-parameter-row dd {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    align-items: start;
+    gap: var(--element-gap);
+    margin: 0;
+    min-width: 0;
+}
+
+.actual-parameter-row dd span {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.actual-parameter-row small {
+    color: var(--color-steel);
+    font-size: 10px;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.actual-parameter-row strong,
+.actual-parameter-elapsed strong {
+    overflow-wrap: anywhere;
+    color: var(--color-charcoal);
+    font-weight: var(--font-weight-regular);
+}
+
+.actual-parameter-row em {
+    padding: 2px 6px;
+    border: 1px solid var(--color-amber-glow);
+    color: var(--color-amber-glow);
+    font-style: normal;
+    text-transform: uppercase;
+}
+
+.actual-parameter-row.changed {
+    padding-left: var(--spacing-8);
+    border-left: 2px solid var(--color-amber-glow);
+}
+
+.actual-parameter-prompt {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.actual-parameter-prompt p {
+    margin: 0;
+    color: var(--color-charcoal);
+    overflow-wrap: anywhere;
 }
 
 .result-slot-error {

--- a/src/lineage/generateLineageMetadata.ts
+++ b/src/lineage/generateLineageMetadata.ts
@@ -1,4 +1,4 @@
-import type { ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
 import {
     buildImageModelArchiveFields,
     sanitizeArchiveImageModelControls,
@@ -49,6 +49,7 @@ export interface GenerateLineageMetadata extends Record<string, unknown> {
     lighting: string;
     palette: string;
     sourceArchiveImageId: string | null;
+    actualParameters?: ActualImageParameters;
     referenceImages: GenerateLineageReferenceImages;
     referenceCount: number;
     referenceIds: string[];
@@ -83,6 +84,7 @@ export function buildGenerateLineageMetadata(input: {
         lighting: input.image.lighting ?? 'none',
         palette: input.image.palette ?? 'none',
         sourceArchiveImageId: input.sourceArchiveImageId,
+        ...(input.image.actualParameters ? { actualParameters: input.image.actualParameters } : {}),
         referenceImages: {
             count: referenceIds.length,
             ids: referenceIds,

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -26,6 +26,7 @@ function validateGenerateMetadata(metadata: Record<string, unknown>) {
     validateImageModel(metadata.imageModel);
     validateDimensions(metadata.dimensions);
     validateReferenceImages(metadata.referenceImages);
+    validateActualParameters(metadata.actualParameters);
 }
 
 function validateEditorMetadata(metadata: Record<string, unknown>) {
@@ -82,6 +83,26 @@ function validateReferenceImages(value: unknown) {
     requireFiniteNumber(referenceImages.count, 'lineage referenceImages count');
     if (!Array.isArray(referenceImages.ids) || !referenceImages.ids.every((id) => typeof id === 'string')) {
         throw new Error('Invalid lineage referenceImages ids');
+    }
+}
+
+function validateActualParameters(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const actualParameters = requireRecord(value, 'lineage actualParameters');
+    if (actualParameters.revisedPrompt !== undefined) {
+        requireString(actualParameters.revisedPrompt, 'lineage actualParameters revisedPrompt');
+    }
+    if (actualParameters.size !== undefined) {
+        requireString(actualParameters.size, 'lineage actualParameters size');
+    }
+    if (actualParameters.quality !== undefined) {
+        requireString(actualParameters.quality, 'lineage actualParameters quality');
+    }
+    if (actualParameters.elapsedMs !== undefined) {
+        requireFiniteNumber(actualParameters.elapsedMs, 'lineage actualParameters elapsedMs');
     }
 }
 

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -44,6 +44,33 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('extracts revised prompt and actual parameters from image responses', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            size: '1536x1024',
+            quality: 'high',
+            data: [{ b64_json: 'generated', revised_prompt: 'a refined cat prompt' }],
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat',
+                size: 'auto',
+                quality: 'medium',
+            });
+
+            expect(result).toEqual({
+                b64_json: 'generated',
+                revised_prompt: 'a refined cat prompt',
+                size: '1536x1024',
+                quality: 'high',
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts batched image generation requests with native n and returns every image payload', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -23,6 +23,9 @@ export interface OpenAiImageRequest {
 
 export interface OpenAiImageResponse {
     b64_json?: string;
+    revised_prompt?: string;
+    size?: string;
+    quality?: string;
 }
 
 export interface OpenAiResponsesRequest {
@@ -123,13 +126,21 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
     }
 
-    const data: { data?: OpenAiImageResponse[] } = await response.json();
+    const data: {
+        data?: OpenAiImageResponse[];
+        size?: string;
+        quality?: string;
+    } = await response.json();
 
     if (!data.data || data.data.length === 0) {
         throw new Error('No image data returned from OpenAI');
     }
 
-    return data.data;
+    return data.data.map((image) => ({
+        ...image,
+        ...(image.size === undefined && data.size !== undefined ? { size: data.size } : {}),
+        ...(image.quality === undefined && data.quality !== undefined ? { quality: data.quality } : {}),
+    }));
 }
 
 function coerceOpenAiBatchSize(value: unknown): number {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -6,7 +6,13 @@ import { useGenerateController } from '../generate-session/useGenerateController
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
+import ActualParametersPanel from '../components/ActualParametersPanel';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import {
+    buildActualParameterDetails,
+    getRequestedGenerateParameters,
+    hasActualParameterDetails,
+} from '../generate-session/actualParameters';
 import { DEFAULT_AUTOPILOT_MAX_ITERATIONS, DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD, MAX_AUTOPILOT_ITERATIONS } from '../autopilot/AutopilotSession';
 import { createGoalPromptTranslator } from '../autopilot/GoalPromptTranslator';
 import { createPromptRefiner } from '../autopilot/PromptRefiner';
@@ -201,6 +207,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const {
         currentResult,
         currentBatchResults,
+        currentRunDraft,
         loading,
         error,
         autopilot,
@@ -326,6 +333,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
     const showBatchGrid = currentBatchResults.length > 1 || currentBatchResults.some((result) => result.status === 'failed');
     const singleResultSlot = !showBatchGrid ? successfulBatchResults[0] : null;
+    const requestedParameters = getRequestedGenerateParameters(currentRunDraft ?? draft);
+    const singleResultActualDetails = singleResultSlot
+        ? buildActualParameterDetails({
+            actualParameters: singleResultSlot.actualParameters,
+            requestedParameters,
+        })
+        : null;
+    const hasSingleResultActualDetails = singleResultActualDetails
+        ? hasActualParameterDetails(singleResultActualDetails)
+        : false;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
         updateDraft({
             [activeModelDraftKey]: {
@@ -665,6 +682,13 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                         {result.status === 'success' ? (
                                             <>
                                                 <img src={result.imageUrl} alt={`Generated result ${result.slotIndex + 1}`} className="result-slot-image" />
+                                                <ActualParametersPanel
+                                                    compact
+                                                    details={buildActualParameterDetails({
+                                                        actualParameters: result.actualParameters,
+                                                        requestedParameters,
+                                                    })}
+                                                />
                                                 <div className="result-slot-actions">
                                                     <button
                                                         onClick={() => { void saveResult(result.slotIndex); }}
@@ -692,8 +716,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                             </button>
                         </div>
                     ) : currentResult ? (
-                        <div className="result-container">
+                        <div className={`result-container${hasSingleResultActualDetails ? ' has-actual-parameters' : ''}`}>
                             <img src={currentResult} alt="Generated result" className="result-image" />
+                            {singleResultActualDetails && (
+                                <ActualParametersPanel details={singleResultActualDetails} />
+                            )}
                             {isAutopilotMode && autopilot.iterations.length > 0 && (
                                 <div className="autopilot-result-banner glass-panel">
                                     <strong>


### PR DESCRIPTION
## Summary
- extract revised prompt plus actual size/quality from OpenAI image responses and measure elapsed generation time in the workflow
- persist actual parameters on archive images, transfer manifests, recovered metadata, and generation lineage metadata
- show requested-vs-actual values, rewritten prompt, and elapsed time in Generate results and image details
- add actual-parameters glossary entry

## Validation
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- npm run build
- playwright screenshot http://127.0.0.1:5173/ /tmp/aura-issue78-generate.png

Closes #78