### PR TITLE
Integrate remaining generation workflow issues

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ One slot in a **generation batch**. A batch result may be a generated image or a
 slot-level failure. Saving a successful batch result creates its own archive
 image and lineage step while preserving the full run inputs.
 
+## Actual parameters
+
+Provider- or workflow-reported facts about a completed generated image, such as
+the provider-rewritten prompt, applied size or quality, and elapsed generation
+time. Distinct from requested generation settings, which are what the user asked
+for before the provider processed the run. Actual parameters are recorded only
+when reported or measured; do not infer missing provider values.
+
 ## Favorite
 
 A user-marked archive image kept easy to find with the Archive favorites filter.

--- a/src/app/useAppController.ts
+++ b/src/app/useAppController.ts
@@ -10,6 +10,7 @@ import { initializeAuraPersistence } from '../db/AuraPersistence';
 import { saveEditedImage, type EditorSaveContext } from '../editor/saveEditedImage';
 import { lineageStore } from '../lineage/LineageStore';
 import { createLineageNavigator } from '../lineage/LineageNavigator';
+import type { EditorReplay } from '../lineage/replayLineageStep';
 import { browserCompletionNotificationPort, type CompletionNotificationReadiness } from './CompletionNotificationPort';
 
 export function useAppController() {
@@ -32,6 +33,7 @@ export function useAppController() {
         onError: handleArchiveError,
     });
     const [editingImage, setEditingImage] = useState<ArchiveImage | null>(null);
+    const [editorReplay, setEditorReplay] = useState<EditorReplay | null>(null);
     const [completionNotificationReadiness, setCompletionNotificationReadiness] = useState<CompletionNotificationReadiness>(
         () => browserCompletionNotificationPort.getReadiness(),
     );
@@ -128,6 +130,7 @@ export function useAppController() {
 
     const editImage = useCallback((image: ArchiveImage) => {
         setEditingImage(image);
+        setEditorReplay(null);
         changeView('editor');
     }, [changeView]);
 
@@ -152,6 +155,7 @@ export function useAppController() {
 
         changeView('archive');
         setEditingImage(null);
+        setEditorReplay(null);
     }, [addImage, addToast, changeView, editingImage]);
 
     const createSimilar = useCallback(async (image: ArchiveImage) => {
@@ -192,6 +196,7 @@ export function useAppController() {
                 return;
             }
             setEditingImage(outcome.image);
+            setEditorReplay(outcome.replay);
             changeView('editor');
             addToast('Lineage step loaded into Editor', 'info');
         } catch (error) {
@@ -254,6 +259,7 @@ export function useAppController() {
         },
         editorViewProps: {
             image: editingImage,
+            replay: editorReplay,
             getProviderKey: getKey,
             onSave: handleSaveEditedImage,
         },

--- a/src/archive/ArchiveManifest.test.ts
+++ b/src/archive/ArchiveManifest.test.ts
@@ -50,6 +50,27 @@ describe('ArchiveManifest', () => {
         ]);
     });
 
+    it('preserves actual parameters while keeping legacy images compatible by omission', () => {
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const manifest = parseArchiveManifest({
+            version: ARCHIVE_MANIFEST_VERSION,
+            images: [
+                createManifestImage({ id: 'actual-image', actualParameters }),
+                createManifestImage({ id: 'legacy-image' }),
+            ],
+        });
+
+        expect(manifest.images).toEqual([
+            expect.objectContaining({ id: 'actual-image', actualParameters }),
+            expect.not.objectContaining({ id: 'legacy-image', actualParameters: expect.anything() }),
+        ]);
+    });
+
     it('rejects malformed layer stack entries', () => {
         expect(() => parseArchiveManifest({
             version: ARCHIVE_MANIFEST_VERSION,

--- a/src/archive/ArchiveManifest.ts
+++ b/src/archive/ArchiveManifest.ts
@@ -1,4 +1,4 @@
-import { isLayerBlendMode, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
+import { isLayerBlendMode, type ActualImageParameters, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
 import { parseLineageMetadata } from '../lineage/lineageMetadata';
 import type { LineageStep } from '../lineage/types';
 
@@ -25,6 +25,7 @@ export interface ArchiveManifestImage {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     imageFileName?: string;
     references: ArchiveManifestReference[];
     layerStack?: ArchiveManifestLayerStack;
@@ -160,6 +161,7 @@ function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
         style: optionalString(value.style),
         lighting: optionalString(value.lighting),
         palette: optionalString(value.palette),
+        actualParameters: optionalActualParameters(value.actualParameters),
         imageFileName: optionalString(value.imageFileName),
         references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
         layerStack: parseOptionalLayerStack(value.layerStack),
@@ -308,6 +310,21 @@ function optionalNumber(value: unknown) {
 
 function optionalBoolean(value: unknown) {
     return typeof value === 'boolean' ? value : undefined;
+}
+
+function optionalActualParameters(value: unknown): ActualImageParameters | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+
+    const actualParameters: ActualImageParameters = {
+        ...(typeof value.revisedPrompt === 'string' ? { revisedPrompt: value.revisedPrompt } : {}),
+        ...(typeof value.size === 'string' ? { size: value.size } : {}),
+        ...(typeof value.quality === 'string' ? { quality: value.quality } : {}),
+        ...(typeof value.elapsedMs === 'number' && Number.isFinite(value.elapsedMs) ? { elapsedMs: value.elapsedMs } : {}),
+    };
+
+    return Object.keys(actualParameters).length > 0 ? actualParameters : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/archive/ArchiveStore.test.ts
+++ b/src/archive/ArchiveStore.test.ts
@@ -232,6 +232,45 @@ describe('ArchiveStore layer asset ownership', () => {
         ]));
     });
 
+    it('persists actual parameter metadata and treats legacy metadata as absent', async () => {
+        const { store, metadata } = createStore();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+
+        await store.save(createImageInput({
+            id: 'actual-image',
+            actualParameters,
+        }));
+        metadata.records.set('legacy-image', {
+            id: 'legacy-image',
+            storedUrl: 'data:image/png;base64,legacy',
+            prompt: 'legacy prompt',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-06-05T08:00:00.000Z',
+            width: 1024,
+            height: 1024,
+            referenceIds: [],
+        });
+
+        expect(metadata.records.get('actual-image')?.actualParameters).toEqual(actualParameters);
+        await expect(store.list()).resolves.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'actual-image',
+                actualParameters,
+            }),
+            expect.not.objectContaining({
+                id: 'legacy-image',
+                actualParameters: expect.anything(),
+            }),
+        ]));
+    });
+
     it('recovers orphaned image blobs when metadata is missing', async () => {
         const { store, metadata, blobs } = createStore();
         blobs.blobs.set('img_orphaned-image', 'data:image/png;base64,orphaned');
@@ -283,6 +322,7 @@ function createImageInput(overrides: Partial<ArchiveImage> = {}) {
         height: 1024,
         favorite: overrides.favorite,
         references: overrides.references,
+        actualParameters: overrides.actualParameters,
         layerStack: overrides.layerStack,
     };
 }

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -134,6 +134,7 @@ class LocalArchiveStore implements ArchiveStore {
                 style: input.style,
                 lighting: input.lighting,
                 palette: input.palette,
+                actualParameters: input.actualParameters,
                 referenceIds,
                 layerStack: durableLayerStack,
             });
@@ -159,6 +160,7 @@ class LocalArchiveStore implements ArchiveStore {
             style: input.style,
             lighting: input.lighting,
             palette: input.palette,
+            actualParameters: input.actualParameters,
             layerStack: input.layerStack,
         };
     }
@@ -215,6 +217,7 @@ class LocalArchiveStore implements ArchiveStore {
             style: record.style,
             lighting: record.lighting,
             palette: record.palette,
+            actualParameters: record.actualParameters,
             layerStack,
         };
     }

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -208,6 +208,41 @@ describe('ArchiveTransfer', () => {
         expect(archiveStore.images.get('image-2')?.favorite).toBeUndefined();
     });
 
+    it('round-trips actual parameters through the archive manifest', async () => {
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const sourceImages = createImages();
+        sourceImages[0] = {
+            ...sourceImages[0]!,
+            actualParameters,
+        };
+
+        const zipBytes = await buildArchiveZip(sourceImages, { lineageStore: createStore() });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const manifest = JSON.parse(await zip.file('archive-manifest.json')!.async('text')) as {
+            images: Array<{ id: string; actualParameters?: unknown }>;
+        };
+
+        expect(manifest.images).toEqual([
+            expect.objectContaining({ id: 'image-1', actualParameters }),
+            expect.not.objectContaining({ id: 'image-2', actualParameters: expect.anything() }),
+            expect.not.objectContaining({ id: 'image-3', actualParameters: expect.anything() }),
+        ]);
+
+        const archiveStore = new InMemoryArchiveStore();
+        await importArchiveZip(zipBytes, {
+            archiveStore,
+            lineageStore: createStore(),
+        });
+
+        expect(archiveStore.images.get('image-1')?.actualParameters).toEqual(actualParameters);
+        expect(archiveStore.images.get('image-2')?.actualParameters).toBeUndefined();
+    });
+
     it('round-trips layered image assets and stable layer ids', async () => {
         const sourceLineage = createStore();
         const sourceImages = [createLayeredImage()];

--- a/src/archive/ArchiveTransfer.test.ts
+++ b/src/archive/ArchiveTransfer.test.ts
@@ -5,6 +5,7 @@ import type { ArchiveImage } from '../db/types';
 import { buildArchiveZip, importArchiveZip, LINEAGE_MANIFEST_FILE, LINEAGE_MANIFEST_VERSION } from './ArchiveTransfer';
 import { createLineageStore, type LineageMetadataPort, type LineageStep, type LineageStore } from '../lineage/LineageStore';
 import { OPENAI_IMAGE_MODEL, OPENAI_RESPONSES_MODEL } from '../utils/openaiModels';
+import type { EditorLineageMetadata, EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -142,6 +143,75 @@ describe('ArchiveTransfer', () => {
             expect.objectContaining({
                 id: 'typed-autopilot-step',
                 metadata: autopilotMetadata,
+            }),
+        ]);
+    });
+
+    it('exports transform mask lineage assets as ZIP files and hydrates them on import', async () => {
+        const sourceLineage = createStore();
+        const maskedMetadata = createTypedEditorMetadata();
+        maskedMetadata.aiEdit.transformMask = {
+            assetId: 'image-1:transform-mask',
+            dataUrl: 'data:image/png;base64,bWFzaw==',
+            mimeType: 'image/png',
+        };
+        maskedMetadata.transformMaskAsset = maskedMetadata.aiEdit.transformMask;
+        await sourceLineage.save({
+            id: 'masked-editor-step',
+            archiveImageId: 'image-1',
+            parentStepId: null,
+            stepType: 'ai-edit',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: maskedMetadata,
+        });
+
+        const zipBytes = await buildArchiveZip([createImages()[0]!], { lineageStore: sourceLineage });
+        const zip = await JSZip.loadAsync(zipBytes);
+        const maskFileName = 'aura-masked-editor-step-transform-mask.png';
+        const manifest = JSON.parse(await zip.file(LINEAGE_MANIFEST_FILE)!.async('text')) as {
+            steps: LineageStep[];
+        };
+
+        expect(await zip.file(maskFileName)?.async('text')).toBe('mask');
+        expect(manifest.steps[0]?.metadata).toEqual(expect.objectContaining({
+            aiEdit: expect.objectContaining({
+                transformMask: {
+                    assetId: 'image-1:transform-mask',
+                    fileName: maskFileName,
+                    mimeType: 'image/png',
+                },
+            }),
+            transformMaskAsset: {
+                assetId: 'image-1:transform-mask',
+                fileName: maskFileName,
+                mimeType: 'image/png',
+            },
+        }));
+        expect(JSON.stringify(manifest.steps[0]?.metadata)).not.toContain('data:image/png');
+
+        const importedLineage = createStore();
+        await importArchiveZip(zipBytes, {
+            archiveStore: new InMemoryArchiveStore(),
+            lineageStore: importedLineage,
+        });
+
+        await expect(importedLineage.getByArchiveImageId('image-1')).resolves.toEqual([
+            expect.objectContaining({
+                id: 'masked-editor-step',
+                metadata: expect.objectContaining({
+                    aiEdit: expect.objectContaining({
+                        transformMask: {
+                            assetId: 'image-1:transform-mask',
+                            dataUrl: 'data:image/png;base64,bWFzaw==',
+                            mimeType: 'image/png',
+                        },
+                    }),
+                    transformMaskAsset: {
+                        assetId: 'image-1:transform-mask',
+                        dataUrl: 'data:image/png;base64,bWFzaw==',
+                        mimeType: 'image/png',
+                    },
+                }),
             }),
         ]);
     });
@@ -465,7 +535,11 @@ function createTypedGenerateMetadata() {
     };
 }
 
-function createTypedEditorMetadata() {
+function createTypedEditorMetadata(): EditorLineageMetadata & {
+    aiEdit: NonNullable<EditorLineageMetadata['aiEdit']> & {
+        transformMask?: EditorLineageTransformMaskAsset;
+    };
+} {
     return {
         sourceImage: {
             archiveImageId: 'image-1',

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -79,7 +79,8 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
 
     zip.file(ARCHIVE_MANIFEST_FILE, JSON.stringify(createArchiveManifest(archiveManifestImages), null, 2));
 
-    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify(createLineageManifest(dedupeLineageSteps(lineageCollections)), null, 2));
+    const lineageSteps = await addLineageAssetsToZip(zip, dedupeLineageSteps(lineageCollections));
+    zip.file(LINEAGE_MANIFEST_FILE, JSON.stringify(createLineageManifest(lineageSteps), null, 2));
 
     return zip.generateAsync({ type: 'uint8array' });
 }
@@ -142,8 +143,9 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
 
     const importedStepIds: string[] = [];
     for (const step of lineageManifest.steps) {
-        await deps.lineageStore.save(step);
-        importedStepIds.push(step.id);
+        const hydratedStep = await hydrateLineageAssetsFromZip(zip, step, missingAssetFiles);
+        await deps.lineageStore.save(hydratedStep);
+        importedStepIds.push(hydratedStep.id);
     }
 
     return {
@@ -200,12 +202,60 @@ function getLayerFileName(imageId: string, layerId: string) {
     return `aura-${imageId}-layer-${layerId}.png`;
 }
 
+function getTransformMaskFileName(stepId: string, mimeType: string) {
+    return `aura-${stepId}-transform-mask.${mimeType === 'image/png' ? 'png' : 'bin'}`;
+}
+
 async function addLayerStackToZip(zip: JSZip, imageId: string, layerStack: ArchiveLayerStack): Promise<ArchiveManifestLayerStack> {
     await Promise.all(layerStack.layers.map(async (layer) => {
         zip.file(getLayerFileName(imageId, layer.id), await imageUrlToBytes(layer.assetUrl));
     }));
 
     return createArchiveManifestLayerStack(imageId, layerStack, getLayerFileName);
+}
+
+async function addLineageAssetsToZip(zip: JSZip, steps: LineageStep[]): Promise<LineageStep[]> {
+    return Promise.all(steps.map(async (step) => {
+        const nextStep = cloneLineageStep(step);
+        const transformMask = getTransformMaskAsset(nextStep.metadata);
+
+        if (!transformMask?.dataUrl) {
+            return nextStep;
+        }
+
+        const fileName = getTransformMaskFileName(step.id, transformMask.mimeType);
+        zip.file(fileName, await imageUrlToBytes(transformMask.dataUrl));
+        setTransformMaskAsset(nextStep.metadata, {
+            assetId: transformMask.assetId,
+            fileName,
+            mimeType: transformMask.mimeType,
+        });
+
+        return nextStep;
+    }));
+}
+
+async function hydrateLineageAssetsFromZip(zip: JSZip, step: LineageStep, missingAssetFiles: string[]): Promise<LineageStep> {
+    const nextStep = cloneLineageStep(step);
+    const transformMask = getTransformMaskAsset(nextStep.metadata);
+
+    if (!transformMask?.fileName || transformMask.dataUrl) {
+        return nextStep;
+    }
+
+    const file = zip.file(transformMask.fileName);
+    if (!file) {
+        missingAssetFiles.push(transformMask.fileName);
+        return nextStep;
+    }
+
+    setTransformMaskAsset(nextStep.metadata, {
+        assetId: transformMask.assetId,
+        dataUrl: bytesToDataUrl(await file.async('uint8array'), transformMask.mimeType),
+        mimeType: transformMask.mimeType,
+    });
+
+    return nextStep;
 }
 
 async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStack | undefined, missingAssetFiles: string[]): Promise<ArchiveLayerStack | undefined> {
@@ -236,8 +286,11 @@ async function importLayerStack(zip: JSZip, layerStack: ArchiveManifestLayerStac
 }
 
 async function blobToDataUrl(blob: Blob) {
-    const mimeType = blob.type || 'image/png';
     const bytes = new Uint8Array(await blob.arrayBuffer());
+    return bytesToDataUrl(bytes, blob.type || 'image/png');
+}
+
+function bytesToDataUrl(bytes: Uint8Array, mimeType: string) {
     let binary = '';
 
     for (const byte of bytes) {
@@ -260,4 +313,57 @@ async function imageUrlToBytes(url: string) {
 
     const binary = atob(base64Data);
     return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+interface TransferTransformMaskAsset {
+    assetId: string | null;
+    dataUrl?: string;
+    fileName?: string;
+    mimeType: string;
+}
+
+function cloneLineageStep(step: LineageStep): LineageStep {
+    return {
+        ...step,
+        metadata: JSON.parse(JSON.stringify(step.metadata)) as Record<string, unknown>,
+    };
+}
+
+function getTransformMaskAsset(metadata: Record<string, unknown>): TransferTransformMaskAsset | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+    return readTransformMaskAsset(aiEdit?.transformMask) ?? readTransformMaskAsset(metadata.transformMaskAsset);
+}
+
+function setTransformMaskAsset(metadata: Record<string, unknown>, asset: TransferTransformMaskAsset) {
+    const aiEdit = asRecord(metadata.aiEdit);
+    if (aiEdit) {
+        aiEdit.transformMask = asset;
+    }
+    metadata.transformMaskAsset = asset;
+}
+
+function readTransformMaskAsset(value: unknown): TransferTransformMaskAsset | null {
+    const asset = asRecord(value);
+    if (!asset) {
+        return null;
+    }
+
+    const dataUrl = typeof asset.dataUrl === 'string' ? asset.dataUrl : undefined;
+    const fileName = typeof asset.fileName === 'string' ? asset.fileName : undefined;
+    if (!dataUrl && !fileName) {
+        return null;
+    }
+
+    return {
+        assetId: typeof asset.assetId === 'string' ? asset.assetId : null,
+        ...(dataUrl ? { dataUrl } : {}),
+        ...(fileName ? { fileName } : {}),
+        mimeType: typeof asset.mimeType === 'string' ? asset.mimeType : 'image/png',
+    };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
 }

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -71,6 +71,7 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             imageFileName,
             references,
             layerStack,
@@ -129,6 +130,7 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             references,
             layerStack,
         });

--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -3,7 +3,12 @@ import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { createDurableLayerStackMetadata } from './ArchiveAssets';
 
-type ArchiveImageRow = ArchiveImage & { favorite?: number | null; ref_ids?: string; layer_stack?: string };
+type ArchiveImageRow = ArchiveImage & {
+    favorite?: number | null;
+    ref_ids?: string;
+    layer_stack?: string;
+    actual_parameters?: string | null;
+};
 
 type ArchiveMetadataRecord = Omit<ArchiveImage, 'url' | 'references'> & {
     storedUrl: string;
@@ -46,6 +51,7 @@ export class SQLiteArchiveMetadataPort {
         await this.sql.sql`ALTER TABLE images ADD COLUMN palette TEXT`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN layer_stack TEXT`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN favorite INTEGER`.catch(() => null);
+        await this.sql.sql`ALTER TABLE images ADD COLUMN actual_parameters TEXT`.catch(() => null);
 
         this.initialized = true;
     }
@@ -54,7 +60,7 @@ export class SQLiteArchiveMetadataPort {
         await this.init();
 
         await this.sql.sql`
-            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack)
+            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack, actual_parameters)
             VALUES (
                 ${record.id},
                 ${record.storedUrl},
@@ -71,7 +77,8 @@ export class SQLiteArchiveMetadataPort {
                 ${record.style || null},
                 ${record.lighting || null},
                 ${record.palette || null},
-                ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null}
+                ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null},
+                ${record.actualParameters ? JSON.stringify(record.actualParameters) : null}
             )
         `;
     }
@@ -96,6 +103,7 @@ export class SQLiteArchiveMetadataPort {
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: parseActualParameters(image.actual_parameters),
             referenceIds: parseReferenceIds(image.ref_ids),
             layerStack: parseLayerStack(image.layer_stack),
         }));
@@ -125,6 +133,7 @@ export class SQLiteArchiveMetadataPort {
             style: row.style,
             lighting: row.lighting,
             palette: row.palette,
+            actualParameters: parseActualParameters(row.actual_parameters),
             referenceIds: parseReferenceIds(row.ref_ids),
             layerStack: parseLayerStack(row.layer_stack),
         };
@@ -154,6 +163,31 @@ const optionalNumber = (value: unknown): number | undefined => {
 
 const parseFavorite = (value: unknown): boolean | undefined => {
     return value === 1 || value === true ? true : undefined;
+};
+
+const parseActualParameters = (value?: string | null): ArchiveImage['actualParameters'] | undefined => {
+    if (!value) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return undefined;
+        }
+
+        const record = parsed as Record<string, unknown>;
+        const actualParameters: ArchiveImage['actualParameters'] = {
+            ...(typeof record.revisedPrompt === 'string' ? { revisedPrompt: record.revisedPrompt } : {}),
+            ...(typeof record.size === 'string' ? { size: record.size } : {}),
+            ...(typeof record.quality === 'string' ? { quality: record.quality } : {}),
+            ...(typeof record.elapsedMs === 'number' && Number.isFinite(record.elapsedMs) ? { elapsedMs: record.elapsedMs } : {}),
+        };
+
+        return Object.keys(actualParameters).length > 0 ? actualParameters : undefined;
+    } catch {
+        return undefined;
+    }
 };
 
 const parseLayerStack = (value?: string): ArchiveLayerStack | undefined => {

--- a/src/archive/recoverArchiveMetadata.test.ts
+++ b/src/archive/recoverArchiveMetadata.test.ts
@@ -14,6 +14,12 @@ describe('recoverArchiveMetadataFromManifests', () => {
         const generateMetadata = createTypedGenerateMetadata();
         const editorMetadata = createTypedEditorMetadata();
         const autopilotMetadata = createTypedAutopilotMetadata();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
 
         const summary = await recoverArchiveMetadataFromManifests({
             version: 1,
@@ -31,6 +37,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
                     style: 'none',
                     lighting: 'none',
                     palette: 'none',
+                    actualParameters,
                     imageFileName: 'aura-image-1.png',
                     references: [{ fileName: 'aura-image-1-reference-0.png' }],
                     layerStack: {
@@ -122,6 +129,7 @@ describe('recoverArchiveMetadataFromManifests', () => {
             aspectRatio: '1536x1024',
             referenceIds: [0],
             model: 'gpt-image-2',
+            actualParameters,
             layerStack: expect.objectContaining({
                 layers: [
                     expect.objectContaining({ id: 'base', assetUrl: '' }),

--- a/src/archive/recoverArchiveMetadata.ts
+++ b/src/archive/recoverArchiveMetadata.ts
@@ -1,5 +1,5 @@
 import { archiveMetadataPort } from '../db/AuraPersistence';
-import type { ArchiveLayerStack } from '../db/types';
+import type { ActualImageParameters, ArchiveLayerStack } from '../db/types';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { storage, type StorageProvider } from '../services/StorageService';
 import { getArchiveImageBlobKey } from './ArchiveAssets';
@@ -25,6 +25,7 @@ interface ArchiveMetadataRecord {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     referenceIds: number[];
     layerStack?: ArchiveLayerStack;
 }
@@ -80,6 +81,7 @@ export async function recoverArchiveMetadataFromManifests(
             style: image.style,
             lighting: image.lighting,
             palette: image.palette,
+            actualParameters: image.actualParameters,
             referenceIds: image.references.map((_, index) => index),
             layerStack: image.layerStack ? createLayerStackMetadata(image.layerStack) : undefined,
         });

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -128,6 +128,50 @@ describe('AutopilotSession', () => {
         expect(callbacks.onIterationComplete.mock.calls.map(([, runningBest]) => runningBest.iterationNumber)).toEqual([1, 1]);
     });
 
+    it('carries actual image parameters through completed iterations', async () => {
+        const lineage = createStore();
+        const callbacks = { onIterationComplete: vi.fn(), onError: vi.fn() };
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 1,
+            satisfactionThreshold: 90,
+            generate: vi.fn().mockResolvedValueOnce({
+                imageDataUrl: 'data:image/png;base64,one',
+                actualParameters: {
+                    revisedPrompt: 'refined prompt',
+                    size: '1536x1024',
+                    quality: 'high',
+                    elapsedMs: 240,
+                },
+            }),
+            evaluate: vi.fn().mockResolvedValueOnce({ score: 95, feedback: ['Strong match.'] }),
+            refine: vi.fn(),
+            lineageStore: lineage,
+            callbacks,
+        }).run();
+
+        expect(result.bestIteration).toEqual(expect.objectContaining({
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 240,
+            },
+        }));
+        expect(callbacks.onIterationComplete.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 240,
+            },
+        }));
+    });
+
     it('freezes the Reference image snapshot for every iteration', async () => {
         const lineage = createStore();
         const firstReference = new File(['reference-0'], 'ref-0.png', { type: 'image/png' });

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -1,9 +1,9 @@
 import { promptRefiner } from './PromptRefiner';
 import { satisfactionEvaluator } from './SatisfactionEvaluator';
 import type { LineageStore } from '../lineage/LineageStore';
+import type { ActualImageParameters } from '../db/types';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
-import { getFirstSuccessfulGeneratedImage } from '../image-workflow/ImageWorkflow';
 import { buildAutopilotLineageMetadata } from '../lineage/autopilotLineageMetadata';
 
 export const DEFAULT_AUTOPILOT_MAX_ITERATIONS = 4;
@@ -16,8 +16,14 @@ export interface AutopilotIteration {
     iterationNumber: number;
     prompt: string;
     imageDataUrl: string;
+    actualParameters?: ActualImageParameters;
     score: number;
     feedback: string[];
+}
+
+export interface AutopilotGeneratedImage {
+    imageDataUrl: string;
+    actualParameters?: ActualImageParameters;
 }
 
 export interface AutopilotSessionResult {
@@ -47,7 +53,7 @@ interface CreateAutopilotSessionInput {
     initialParentStepId?: string | null;
     maxIterations?: number;
     satisfactionThreshold?: number;
-    generate?: (input: GenerateImageInput) => Promise<string>;
+    generate?: (input: GenerateImageInput) => Promise<string | AutopilotGeneratedImage>;
     evaluate?: (input: { imageDataUrl: string; goal: string; apiKey: string }) => Promise<{ score: number; feedback: string[] }>;
     refine?: (input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }) => Promise<string>;
     lineageStore: Pick<LineageStore, 'save'>;
@@ -84,11 +90,12 @@ class DefaultAutopilotSession implements AutopilotSession {
         for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
             try {
                 const iterationSettings = snapshotAutopilotSettings(runSettings);
-                const imageDataUrl = await generate({
+                const generatedImage = normalizeAutopilotGeneratedImage(await generate({
                     ...iterationSettings,
                     apiKey: this.input.apiKey,
                     prompt: currentPrompt,
-                });
+                }));
+                const imageDataUrl = generatedImage.imageDataUrl;
 
                 const evaluation = await evaluate({
                     imageDataUrl,
@@ -119,6 +126,7 @@ class DefaultAutopilotSession implements AutopilotSession {
                     iterationNumber,
                     prompt: currentPrompt,
                     imageDataUrl,
+                    actualParameters: generatedImage.actualParameters,
                     score: evaluation.score,
                     feedback: evaluation.feedback,
                 };
@@ -191,18 +199,27 @@ export function createAutopilotSession(input: CreateAutopilotSessionInput): Auto
     return new DefaultAutopilotSession(input);
 }
 
-async function generateSingleImage(input: GenerateImageInput): Promise<string> {
+async function generateSingleImage(input: GenerateImageInput): Promise<AutopilotGeneratedImage> {
     const results = await imageWorkflow.generate({
         ...input,
         batchSize: 1,
     });
-    const imageDataUrl = getFirstSuccessfulGeneratedImage(results);
+    const result = results.find((result) => result.status === 'success');
 
-    if (!imageDataUrl) {
+    if (!result) {
         throw new Error('No image data returned from image provider');
     }
 
-    return imageDataUrl;
+    return {
+        imageDataUrl: result.imageUrl,
+        actualParameters: result.actualParameters,
+    };
+}
+
+function normalizeAutopilotGeneratedImage(result: string | AutopilotGeneratedImage): AutopilotGeneratedImage {
+    return typeof result === 'string'
+        ? { imageDataUrl: result }
+        : result;
 }
 
 function snapshotAutopilotSettings(

--- a/src/components/ActualParametersPanel.tsx
+++ b/src/components/ActualParametersPanel.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+    hasActualParameterDetails,
+    type ActualParameterDetails,
+} from '../generate-session/actualParameters';
+
+interface ActualParametersPanelProps {
+    details: ActualParameterDetails;
+    compact?: boolean;
+}
+
+const ActualParametersPanel: React.FC<ActualParametersPanelProps> = ({ details, compact = false }) => {
+    if (!hasActualParameterDetails(details)) {
+        return null;
+    }
+
+    return (
+        <div className={`actual-parameters-panel${compact ? ' compact' : ''}`}>
+            <label className="section-label">Actual Parameters</label>
+
+            {details.rows.length > 0 && (
+                <dl className="actual-parameter-list">
+                    {details.rows.map((row) => (
+                        <div key={row.label} className={`actual-parameter-row${row.changed ? ' changed' : ''}`}>
+                            <dt>{row.label}</dt>
+                            <dd>
+                                <span>
+                                    <small>Requested</small>
+                                    <strong>{row.requested ?? 'Not set'}</strong>
+                                </span>
+                                <span>
+                                    <small>Actual</small>
+                                    <strong>{row.actual}</strong>
+                                </span>
+                                {row.changed && <em>Changed</em>}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            )}
+
+            {details.elapsedLabel && (
+                <div className="actual-parameter-elapsed">
+                    <span>Elapsed</span>
+                    <strong>{details.elapsedLabel}</strong>
+                </div>
+            )}
+
+            {details.revisedPrompt && (
+                <div className="actual-parameter-prompt">
+                    <span>Rewritten Prompt</span>
+                    <p>{details.revisedPrompt}</p>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ActualParametersPanel;

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -7,6 +7,11 @@ import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLi
 import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig } from '../utils/openaiModels';
+import ActualParametersPanel from './ActualParametersPanel';
+import {
+    buildActualParameterDetails,
+    getRequestedArchiveParameters,
+} from '../generate-session/actualParameters';
 
 interface ImageDetailModalProps {
     image: ArchiveImage;
@@ -37,6 +42,10 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
     const imageModel = isImageModelSlug(image.model) ? image.model : OPENAI_IMAGE_MODEL;
     const modelLabel = resolveImageModelConfig(imageModel).label;
     const isNanoImage = imageModel === NANO_BANANA_PRO_IMAGE_MODEL;
+    const actualParameterDetails = buildActualParameterDetails({
+        actualParameters: image.actualParameters,
+        requestedParameters: getRequestedArchiveParameters(image),
+    });
 
     const copyPrompt = () => {
         navigator.clipboard.writeText(image.prompt);
@@ -193,6 +202,8 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                 </div>
                             )}
                         </div>
+
+                        <ActualParametersPanel details={actualParameterDetails} />
 
                         {image.references && image.references.length > 0 && (
                             <div className="sidebar-section">

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,3 +1,10 @@
+export interface ActualImageParameters {
+    revisedPrompt?: string;
+    size?: string;
+    quality?: string;
+    elapsedMs?: number;
+}
+
 export interface ArchiveImage {
     id: string;
     url: string;
@@ -14,6 +21,7 @@ export interface ArchiveImage {
     style?: string;
     lighting?: string;
     palette?: string;
+    actualParameters?: ActualImageParameters;
     layerStack?: ArchiveLayerStack;
 }
 

--- a/src/editor/aiTransform.ts
+++ b/src/editor/aiTransform.ts
@@ -1,5 +1,7 @@
 import type { ArchiveLayerStack } from '../db/types';
+import type { EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { ImageModelSlug } from '../utils/openaiModels';
+import { fileToDataURL } from '../utils/file';
 import {
     insertAiResultLayer,
     planAiTransformTarget,
@@ -43,11 +45,13 @@ export interface AiTransformSaveProvenance extends AiTransformTargetMetadata {
     aiEditModel: ImageModelSlug;
     aiResultLayerId: string;
     aiResultLayerName: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export interface AiTransformProvenanceInput {
     prompt: string;
     model: ImageModelSlug;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export async function renderAiTransformEditInput({
@@ -98,6 +102,7 @@ export function applyAiTransformResultToDraft(
             ? {
                 aiEditPrompt: provenanceInput.prompt,
                 aiEditModel: provenanceInput.model,
+                ...(provenanceInput.transformMask ? { transformMask: provenanceInput.transformMask } : {}),
                 targetMode: targetPlan.metadata.targetMode,
                 targetLayerCount: targetPlan.metadata.targetLayerCount,
                 targetIncludesBaseLayer: targetPlan.metadata.targetIncludesBaseLayer,
@@ -153,4 +158,12 @@ function getWholeCompositionBounds(layerStack: ArchiveLayerStack): LayerBounds {
 
 function blobToFile(blob: Blob, name: string) {
     return new File([blob], name, { type: blob.type || 'image/png' });
+}
+
+export async function blobToTransformMaskAsset(maskImage: File | Blob): Promise<EditorLineageTransformMaskAsset> {
+    return {
+        assetId: null,
+        dataUrl: await fileToDataURL(maskImage),
+        mimeType: maskImage.type || 'image/png',
+    };
 }

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -246,6 +246,46 @@ describe('saveEditedImage', () => {
         }));
     });
 
+    it('stores masked AI edit lineage as a transform mask asset without adding mask layers', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+
+        const savedImage = await saveEditedImage(createArchiveImage(), 'data:image/png;base64,masked-edit', {
+            ...createSaveContext(),
+            isCopy: true,
+            layerStack: createLayerStack(),
+            aiEditPrompt: 'replace only the painted area',
+            targetMode: 'selected-layers',
+            transformMask: {
+                assetId: null,
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
+        }, {
+            saveImage: vi.fn(async (image) => image),
+            lineageStore: lineage,
+            makeId: () => 'masked-copy',
+        });
+
+        const steps = await lineage.getByArchiveImageId(savedImage.id);
+        expect(steps.at(-1)?.metadata).toEqual(expect.objectContaining({
+            aiEdit: expect.objectContaining({
+                transformMask: {
+                    assetId: 'masked-copy:transform-mask',
+                    dataUrl: 'data:image/png;base64,bWFzaw==',
+                    mimeType: 'image/png',
+                },
+            }),
+            transformMaskAsset: {
+                assetId: 'masked-copy:transform-mask',
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
+        }));
+        expect(savedImage.layerStack?.layers.map((layer) => layer.id)).toEqual(['base', 'upload', 'ai-layer']);
+        expect(savedImage.layerStack?.layers.some((layer) => layer.id.includes('mask'))).toBe(false);
+    });
+
     it('persists layered save metadata without putting the full stack in lineage', async () => {
         const lineage = createStore();
         await seedSourceLineage(lineage);

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -1,5 +1,5 @@
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
-import { buildEditorLineageMetadata } from '../lineage/editorLineageMetadata';
+import { buildEditorLineageMetadata, type EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { EditorAdjustments } from './layers';
 
@@ -15,6 +15,7 @@ export interface EditorSaveContext {
     aiResultLayerName?: string | null;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export interface SaveEditedImageDeps {
@@ -104,5 +105,6 @@ function buildMetadata(sourceImage: ArchiveImage, savedImage: ArchiveImage, cont
         aiResultLayerName: context.aiResultLayerName,
         aiEditPrompt: context.aiEditPrompt,
         aiEditModel: context.aiEditModel,
+        transformMask: context.transformMask,
     });
 }

--- a/src/editor/useEditorController.test.ts
+++ b/src/editor/useEditorController.test.ts
@@ -70,6 +70,11 @@ describe('Editor controller AI transform flow', () => {
             isCopy: false,
             aiEditPrompt: 'replace the jacket',
             aiEditModel: OPENAI_IMAGE_MODEL,
+            transformMask: {
+                assetId: null,
+                dataUrl: 'data:image/png;base64,bWFzaw==',
+                mimeType: 'image/png',
+            },
             targetMode: 'selected-layers',
             targetLayerCount: 1,
             targetIncludesBaseLayer: false,

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -3,6 +3,7 @@ import { imageWorkflow, type EditImageInput } from '../image-workflow/ImageWorkf
 import type { ImageModelSlug } from '../utils/openaiModels';
 import {
     applyAiTransformResultToDraft,
+    blobToTransformMaskAsset,
     getAiTransformSaveProvenance,
     renderAiTransformEditInput,
     type AiTransformRenderer,
@@ -187,6 +188,9 @@ export async function runEditorAiTransform({
         maskImage,
         quality: 'medium',
     });
+    const transformMask = maskImage
+        ? await blobToTransformMaskAsset(maskImage)
+        : null;
 
     return applyAiTransformResultToDraft(
         draft,
@@ -196,6 +200,7 @@ export async function runEditorAiTransform({
         {
             prompt: trimmedPrompt,
             model,
+            transformMask,
         },
     );
 }
@@ -224,6 +229,7 @@ export function buildEditorSaveContext({
         layerStack: draft && hasDurableLayerStack(draft.layerStack) ? draft.layerStack : null,
         aiEditPrompt: saveProvenance?.aiEditPrompt,
         aiEditModel: saveProvenance?.aiEditModel,
+        transformMask: saveProvenance?.transformMask ?? undefined,
         targetMode: saveProvenance?.targetMode,
         targetLayerCount: saveProvenance?.targetLayerCount,
         targetIncludesBaseLayer: saveProvenance?.targetIncludesBaseLayer,

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -89,6 +89,42 @@ describe('GenerateSession draft migration', () => {
         await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
     });
 
+    it('clears stale current generation results when transferring an archive image into Generate', async () => {
+        const store = createGenerateSessionStore({
+            blobStorage: new InMemoryStorageProvider(),
+        });
+        await store.saveCurrentBatch({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,stale-result',
+                isSaved: false,
+            }],
+            references: ['data:image/png;base64,stale-ref'],
+            draft: DEFAULT_GENERATE_DRAFT,
+            lineageSource: { archiveImageId: 'old-source' },
+        });
+
+        await store.transferFromArchive({
+            id: 'archive-image',
+            url: 'data:image/png;base64,archive',
+            prompt: 'use this image',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-06-05T12:00:00.000Z',
+            width: 1024,
+            height: 1024,
+            model: 'gpt-image-2',
+            references: ['data:image/png;base64,archive-ref'],
+        });
+
+        await expect(store.loadCurrentBatch()).resolves.toBeNull();
+        await expect(store.loadCurrentResult()).resolves.toBeNull();
+        await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
+        await expect(store.consumeTransferredReferences()).resolves.toEqual(['data:image/png;base64,archive-ref']);
+    });
+
     it('round-trips the current generation batch with slot state and run context', async () => {
         const store = createGenerateSessionStore({
             blobStorage: new InMemoryStorageProvider(),

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -28,6 +28,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '3:2',
                 imageSize: '1K',
+                batchSize: 1,
             },
             isSaved: true,
         });
@@ -46,6 +47,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 9,
             },
         })).toMatchObject({
             model: 'nano-banana-pro',
@@ -58,6 +60,7 @@ describe('GenerateSession draft migration', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 4,
             },
         });
     });

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { StorageProvider } from '../services/StorageService';
-import { createGenerateSessionStore, DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft } from './GenerateSession';
+import { createGenerateSessionStore, DEFAULT_GENERATE_DRAFT, sanitizeGenerateDraft, type GenerateBatchSnapshot } from './GenerateSession';
 
 describe('GenerateSession draft migration', () => {
     it('migrates legacy flat controls into the gpt-image-2 block', () => {
@@ -84,6 +84,74 @@ describe('GenerateSession draft migration', () => {
 
         await expect(store.loadCurrentResult()).resolves.toBeNull();
         await expect(store.loadCurrentResultReferences()).resolves.toBeNull();
+    });
+
+    it('round-trips the current generation batch with slot state and run context', async () => {
+        const store = createGenerateSessionStore({
+            blobStorage: new InMemoryStorageProvider(),
+        });
+        const batch: GenerateBatchSnapshot = {
+            results: [
+                {
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,result-0',
+                    isSaved: true,
+                    archiveImageId: 'archive-0',
+                },
+                {
+                    slotIndex: 1,
+                    status: 'failed',
+                    error: 'content filter',
+                },
+                {
+                    slotIndex: 2,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,result-2',
+                    isSaved: false,
+                },
+            ],
+            references: ['data:image/png;base64,used-ref'],
+            draft: {
+                ...DEFAULT_GENERATE_DRAFT,
+                prompt: 'stored run prompt',
+                gptImage2: {
+                    ...DEFAULT_GENERATE_DRAFT.gptImage2,
+                    batchSize: 3,
+                },
+            },
+            lineageSource: {
+                archiveImageId: 'source-image',
+                stepId: 'source-step',
+            },
+        };
+
+        await store.saveCurrentBatch(batch);
+
+        await expect(store.loadCurrentBatch()).resolves.toEqual(batch);
+        await expect(store.loadCurrentResult()).resolves.toBe('data:image/png;base64,result-0');
+        await expect(store.loadCurrentResultReferences()).resolves.toEqual(['data:image/png;base64,used-ref']);
+    });
+
+    it('migrates legacy single-result storage into a one-item generation batch', async () => {
+        const blobStorage = new InMemoryStorageProvider();
+        await blobStorage.save('generate_current_result', 'data:image/png;base64,legacy-result');
+        await blobStorage.save('generate_current_result_references', JSON.stringify([
+            'data:image/png;base64,legacy-ref',
+        ]));
+        const store = createGenerateSessionStore({ blobStorage });
+
+        await expect(store.loadCurrentBatch()).resolves.toEqual({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,legacy-result',
+                isSaved: false,
+            }],
+            references: ['data:image/png;base64,legacy-ref'],
+            draft: null,
+            lineageSource: null,
+        });
     });
 });
 

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -165,6 +165,7 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         } else {
             this.clearLineageSource();
         }
+        await this.clearCurrentResult();
 
         if (image.references && image.references.length > 0) {
             await this.blobStorage.save(GENERATE_TRANSFERRED_REFERENCES_KEY, JSON.stringify(image.references));

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -23,6 +23,7 @@ import {
 const GENERATE_DRAFT_KEY = 'aura_generate_draft';
 const GENERATE_CURRENT_RESULT_KEY = 'generate_current_result';
 const GENERATE_CURRENT_RESULT_REFERENCES_KEY = 'generate_current_result_references';
+const GENERATE_CURRENT_BATCH_KEY = 'generate_current_batch';
 const GENERATE_TRANSFERRED_REFERENCES_KEY = 'generate_transferred_references';
 const GENERATE_LINEAGE_SOURCE_KEY = 'generate_lineage_source';
 
@@ -57,6 +58,27 @@ export interface GenerateLineageSource {
     stepId?: string | null;
 }
 
+export type GenerateResultSlot =
+    | {
+        slotIndex: number;
+        status: 'success';
+        imageUrl: string;
+        isSaved: boolean;
+        archiveImageId?: string;
+    }
+    | {
+        slotIndex: number;
+        status: 'failed';
+        error: string;
+    };
+
+export interface GenerateBatchSnapshot {
+    results: GenerateResultSlot[];
+    references: string[] | null;
+    draft: GenerateDraft | null;
+    lineageSource: GenerateLineageSource | null;
+}
+
 export interface GenerateSessionStore {
     readDraft(): GenerateDraft;
     writeDraft(draft: GenerateDraft): void;
@@ -64,6 +86,8 @@ export interface GenerateSessionStore {
     loadLineageSource(): GenerateLineageSource | null;
     saveLineageSource(source: GenerateLineageSource): void;
     clearLineageSource(): void;
+    loadCurrentBatch(): Promise<GenerateBatchSnapshot | null>;
+    saveCurrentBatch(batch: GenerateBatchSnapshot): Promise<void>;
     loadCurrentResult(): Promise<string | null>;
     loadCurrentResultReferences(): Promise<string[] | null>;
     saveCurrentResult(result: string, usedReferences?: string[] | null): Promise<void>;
@@ -161,38 +185,71 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
         this.localStorage.removeItem(GENERATE_LINEAGE_SOURCE_KEY);
     }
 
-    loadCurrentResult(): Promise<string | null> {
-        return this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
-    }
+    async loadCurrentBatch(): Promise<GenerateBatchSnapshot | null> {
+        const storedBatch = await this.blobStorage.load(GENERATE_CURRENT_BATCH_KEY);
+        const batch = storedBatch ? parseGenerateBatchSnapshot(storedBatch) : null;
 
-    async loadCurrentResultReferences(): Promise<string[] | null> {
-        const value = await this.blobStorage.load(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
-        if (!value) {
-            return null;
+        if (batch) {
+            return batch;
         }
 
-        try {
-            const references = JSON.parse(value) as unknown;
-            return Array.isArray(references) && references.every((reference) => typeof reference === 'string')
-                ? references
-                : null;
-        } catch {
-            return null;
-        }
+        return this.loadLegacyCurrentBatch();
     }
 
-    async saveCurrentResult(result: string, usedReferences: string[] | null = null): Promise<void> {
-        await this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, result);
-        if (Array.isArray(usedReferences)) {
-            await this.blobStorage.save(GENERATE_CURRENT_RESULT_REFERENCES_KEY, JSON.stringify(usedReferences));
+    async saveCurrentBatch(batch: GenerateBatchSnapshot): Promise<void> {
+        const snapshot = sanitizeGenerateBatchSnapshot(batch);
+
+        if (!snapshot) {
+            await this.clearCurrentResult();
             return;
         }
 
-        await this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+        await this.blobStorage.save(GENERATE_CURRENT_BATCH_KEY, JSON.stringify(snapshot));
+        const firstSuccessfulResult = getFirstSuccessfulResultSlot(snapshot.results);
+
+        if (firstSuccessfulResult) {
+            await this.blobStorage.save(GENERATE_CURRENT_RESULT_KEY, firstSuccessfulResult.imageUrl);
+            if (Array.isArray(snapshot.references)) {
+                await this.blobStorage.save(GENERATE_CURRENT_RESULT_REFERENCES_KEY, JSON.stringify(snapshot.references));
+                return;
+            }
+
+            await this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+            return;
+        }
+
+        await Promise.all([
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY),
+            this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY),
+        ]);
+    }
+
+    async loadCurrentResult(): Promise<string | null> {
+        const batch = await this.loadCurrentBatch();
+        return getFirstSuccessfulResultSlot(batch?.results ?? [])?.imageUrl ?? null;
+    }
+
+    async loadCurrentResultReferences(): Promise<string[] | null> {
+        return (await this.loadCurrentBatch())?.references ?? null;
+    }
+
+    async saveCurrentResult(result: string, usedReferences: string[] | null = null): Promise<void> {
+        await this.saveCurrentBatch({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: result,
+                isSaved: false,
+            }],
+            references: usedReferences,
+            draft: null,
+            lineageSource: null,
+        });
     }
 
     async clearCurrentResult(): Promise<void> {
         await Promise.all([
+            this.blobStorage.remove(GENERATE_CURRENT_BATCH_KEY),
             this.blobStorage.remove(GENERATE_CURRENT_RESULT_KEY),
             this.blobStorage.remove(GENERATE_CURRENT_RESULT_REFERENCES_KEY),
         ]);
@@ -242,6 +299,42 @@ class LocalGenerateSessionStore implements GenerateSessionStore {
 
     private clearLegacyDraftKeys() {
         Object.values(LEGACY_KEYS).forEach((key) => this.localStorage.removeItem(key));
+    }
+
+    private async loadLegacyCurrentBatch(): Promise<GenerateBatchSnapshot | null> {
+        const result = await this.blobStorage.load(GENERATE_CURRENT_RESULT_KEY);
+
+        if (!result) {
+            return null;
+        }
+
+        return {
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: result,
+                isSaved: false,
+            }],
+            references: await this.loadLegacyCurrentResultReferences(),
+            draft: null,
+            lineageSource: this.loadLineageSource(),
+        };
+    }
+
+    private async loadLegacyCurrentResultReferences(): Promise<string[] | null> {
+        const value = await this.blobStorage.load(GENERATE_CURRENT_RESULT_REFERENCES_KEY);
+        if (!value) {
+            return null;
+        }
+
+        try {
+            const references = JSON.parse(value) as unknown;
+            return Array.isArray(references) && references.every((reference) => typeof reference === 'string')
+                ? references
+                : null;
+        } catch {
+            return null;
+        }
     }
 }
 
@@ -338,3 +431,103 @@ export function getActiveGenerateArchiveFields(draft: GenerateDraft): ImageModel
 }
 
 export const getImageModelDraftKey = resolveImageModelDraftKey;
+
+function parseGenerateBatchSnapshot(value: string): GenerateBatchSnapshot | null {
+    try {
+        return sanitizeGenerateBatchSnapshot(JSON.parse(value) as unknown);
+    } catch {
+        return null;
+    }
+}
+
+function sanitizeGenerateBatchSnapshot(value: unknown): GenerateBatchSnapshot | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const results = Array.isArray(record.results)
+        ? record.results.map(sanitizeGenerateResultSlot).filter((result): result is GenerateResultSlot => result !== null)
+        : [];
+
+    if (results.length === 0) {
+        return null;
+    }
+
+    return {
+        results,
+        references: sanitizeReferenceDataUrls(record.references),
+        draft: record.draft ? sanitizeGenerateDraft(record.draft as DraftLike) : null,
+        lineageSource: sanitizeGenerateLineageSource(record.lineageSource),
+    };
+}
+
+function sanitizeGenerateResultSlot(value: unknown): GenerateResultSlot | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const slotIndex = coerceSlotIndex(record.slotIndex);
+    if (slotIndex === null) {
+        return null;
+    }
+
+    if (record.status === 'success' && typeof record.imageUrl === 'string' && record.imageUrl.length > 0) {
+        return {
+            slotIndex,
+            status: 'success',
+            imageUrl: record.imageUrl,
+            isSaved: record.isSaved === true,
+            ...(typeof record.archiveImageId === 'string' && record.archiveImageId
+                ? { archiveImageId: record.archiveImageId }
+                : {}),
+        };
+    }
+
+    if (record.status === 'failed' && typeof record.error === 'string' && record.error.length > 0) {
+        return {
+            slotIndex,
+            status: 'failed',
+            error: record.error,
+        };
+    }
+
+    return null;
+}
+
+function sanitizeReferenceDataUrls(value: unknown): string[] | null {
+    return Array.isArray(value) && value.every((reference) => typeof reference === 'string')
+        ? value
+        : null;
+}
+
+function sanitizeGenerateLineageSource(value: unknown): GenerateLineageSource | null {
+    const record = asRecord(value);
+    if (!record || typeof record.archiveImageId !== 'string' || !record.archiveImageId) {
+        return null;
+    }
+
+    return {
+        archiveImageId: record.archiveImageId,
+        stepId: typeof record.stepId === 'string' ? record.stepId : null,
+    };
+}
+
+function getFirstSuccessfulResultSlot(results: GenerateResultSlot[]) {
+    return results.find((result): result is Extract<GenerateResultSlot, { status: 'success' }> =>
+        result.status === 'success',
+    ) ?? null;
+}
+
+function coerceSlotIndex(value: unknown): number | null {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        return null;
+    }
+
+    return value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}

--- a/src/generate-session/actualParameters.test.ts
+++ b/src/generate-session/actualParameters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildActualParameterDetails, hasActualParameterDetails } from './actualParameters';
+
+describe('actual parameter details', () => {
+    it('omits details for legacy images without actual parameters', () => {
+        const details = buildActualParameterDetails({});
+
+        expect(details).toEqual({ rows: [] });
+        expect(hasActualParameterDetails(details)).toBe(false);
+    });
+
+    it('compares requested and actual size and quality values', () => {
+        const details = buildActualParameterDetails({
+            requestedParameters: {
+                size: '1024x1024',
+                quality: 'high',
+            },
+            actualParameters: {
+                size: '1536x1024',
+                quality: 'high',
+            },
+        });
+
+        expect(details.rows).toEqual([
+            {
+                label: 'Size',
+                requested: '1024x1024',
+                actual: '1536x1024',
+                changed: true,
+            },
+            {
+                label: 'Quality',
+                requested: 'high',
+                actual: 'high',
+                changed: false,
+            },
+        ]);
+        expect(hasActualParameterDetails(details)).toBe(true);
+    });
+
+    it('formats revised prompt and elapsed time when present', () => {
+        expect(buildActualParameterDetails({
+            actualParameters: {
+                revisedPrompt: 'A more detailed prompt',
+                elapsedMs: 930,
+            },
+        })).toEqual({
+            rows: [],
+            revisedPrompt: 'A more detailed prompt',
+            elapsedLabel: '930 ms',
+        });
+
+        expect(buildActualParameterDetails({
+            actualParameters: {
+                elapsedMs: 1234,
+            },
+        }).elapsedLabel).toBe('1.2 s');
+    });
+});

--- a/src/generate-session/actualParameters.ts
+++ b/src/generate-session/actualParameters.ts
@@ -1,0 +1,83 @@
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
+import { getActiveGenerateArchiveFields, type GenerateDraft } from './GenerateSession';
+
+export interface RequestedImageParameters {
+    size?: string;
+    quality?: string;
+}
+
+export interface ActualParameterRow {
+    label: string;
+    requested?: string;
+    actual: string;
+    changed: boolean;
+}
+
+export interface ActualParameterDetails {
+    rows: ActualParameterRow[];
+    revisedPrompt?: string;
+    elapsedLabel?: string;
+}
+
+export function getRequestedGenerateParameters(draft: GenerateDraft): RequestedImageParameters {
+    const fields = getActiveGenerateArchiveFields(draft);
+
+    return {
+        size: fields.aspectRatio,
+        quality: fields.quality,
+    };
+}
+
+export function getRequestedArchiveParameters(image: ArchiveImage): RequestedImageParameters {
+    return {
+        size: image.aspectRatio,
+        quality: image.quality,
+    };
+}
+
+export function buildActualParameterDetails(input: {
+    actualParameters?: ActualImageParameters;
+    requestedParameters?: RequestedImageParameters;
+}): ActualParameterDetails {
+    const actualParameters = input.actualParameters;
+    if (!actualParameters) {
+        return { rows: [] };
+    }
+
+    const rows: ActualParameterRow[] = [];
+    if (actualParameters.size) {
+        rows.push(buildRow('Size', input.requestedParameters?.size, actualParameters.size));
+    }
+    if (actualParameters.quality) {
+        rows.push(buildRow('Quality', input.requestedParameters?.quality, actualParameters.quality));
+    }
+
+    return {
+        rows,
+        ...(actualParameters.revisedPrompt ? { revisedPrompt: actualParameters.revisedPrompt } : {}),
+        ...(typeof actualParameters.elapsedMs === 'number' && Number.isFinite(actualParameters.elapsedMs)
+            ? { elapsedLabel: formatElapsedMs(actualParameters.elapsedMs) }
+            : {}),
+    };
+}
+
+export function hasActualParameterDetails(details: ActualParameterDetails) {
+    return details.rows.length > 0 || Boolean(details.revisedPrompt) || Boolean(details.elapsedLabel);
+}
+
+function buildRow(label: string, requested: string | undefined, actual: string): ActualParameterRow {
+    return {
+        label,
+        requested,
+        actual,
+        changed: Boolean(requested && requested !== actual),
+    };
+}
+
+function formatElapsedMs(elapsedMs: number) {
+    if (elapsedMs < 1000) {
+        return `${Math.round(elapsedMs)} ms`;
+    }
+
+    return `${(elapsedMs / 1000).toFixed(1)} s`;
+}

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -16,6 +16,7 @@ describe('runGenerateAutopilot', () => {
                     iterationNumber: 1,
                     prompt: 'refined prompt',
                     imageDataUrl: 'data:image/png;base64,best',
+                    actualParameters: { elapsedMs: 123, size: '1536x1024' },
                     score: 97,
                     feedback: ['Great match.'],
                 },
@@ -26,13 +27,14 @@ describe('runGenerateAutopilot', () => {
                 iterationNumber: 1,
                 prompt: 'refined prompt',
                 imageDataUrl: 'data:image/png;base64,best',
+                actualParameters: { elapsedMs: 123, size: '1536x1024' },
                 score: 97,
                 feedback: ['Great match.'],
             },
         }));
         const cancel = vi.fn();
         const createSession = vi.fn(() => ({ run, cancel }));
-        const saveCurrentResult = vi.fn(async () => undefined);
+        const saveCurrentBatch = vi.fn(async () => undefined);
         const saveLineageSource = vi.fn();
         const onSessionCreated = vi.fn();
 
@@ -63,7 +65,7 @@ describe('runGenerateAutopilot', () => {
             referenceImages: [],
             sessionStore: {
                 loadLineageSource: () => ({ archiveImageId: 'source-image', stepId: 'step-parent' }),
-                saveCurrentResult,
+                saveCurrentBatch,
                 saveLineageSource,
             },
             lineageStore: {
@@ -82,7 +84,19 @@ describe('runGenerateAutopilot', () => {
         }));
         expect(run).toHaveBeenCalledOnce();
         expect(onSessionCreated).toHaveBeenCalledWith(expect.objectContaining({ run, cancel }));
-        expect(saveCurrentResult).toHaveBeenCalledWith('data:image/png;base64,best', []);
+        expect(saveCurrentBatch).toHaveBeenCalledWith({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,best',
+                isSaved: false,
+                actualParameters: { elapsedMs: 123, size: '1536x1024' },
+                archiveImageId: 'autopilot:run:iteration:1',
+            }],
+            references: [],
+            draft: null,
+            lineageSource: { archiveImageId: 'autopilot:run:iteration:1', stepId: 'step-1' },
+        });
         expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'autopilot:run:iteration:1', stepId: 'step-1' });
         expect(outcome.session.cancel).toBe(cancel);
     });
@@ -109,9 +123,13 @@ describe('runGenerateAutopilot', () => {
                 slotIndex: 0,
                 status: 'success' as const,
                 imageUrl: `data:image/png;base64,iteration-${seenReferenceNames.length}`,
+                actualParameters: {
+                    elapsedMs: seenReferenceNames.length * 100,
+                    size: '4096x2304',
+                },
             }];
         });
-        const saveCurrentResult = vi.fn(async () => undefined);
+        const saveCurrentBatch = vi.fn(async () => undefined);
         const serializeReferences = vi.fn(async (files: File[]) =>
             files.map((file) => referenceDataUrlByFile.get(file) ?? 'data:image/png;base64,unknown'),
         );
@@ -154,7 +172,7 @@ describe('runGenerateAutopilot', () => {
             referenceImages: selectedReferenceFiles,
             sessionStore: {
                 loadLineageSource: () => null,
-                saveCurrentResult,
+                saveCurrentBatch,
                 saveLineageSource: vi.fn(),
             },
             lineageStore: {
@@ -177,10 +195,25 @@ describe('runGenerateAutopilot', () => {
             expectedProviderReferenceNames,
         ]);
         expect(serializeReferences).toHaveBeenCalledWith(expectedProviderReferenceFiles);
-        expect(saveCurrentResult).toHaveBeenCalledWith(
-            'data:image/png;base64,iteration-2',
-            selectedReferenceDataUrls.slice(0, 14),
-        );
+        expect(saveCurrentBatch).toHaveBeenCalledWith({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,iteration-2',
+                isSaved: false,
+                actualParameters: {
+                    elapsedMs: 200,
+                    size: '4096x2304',
+                },
+                archiveImageId: expect.stringMatching(/^autopilot:/),
+            }],
+            references: selectedReferenceDataUrls.slice(0, 14),
+            draft: null,
+            lineageSource: {
+                archiveImageId: expect.stringMatching(/^autopilot:/),
+                stepId: 'step-2',
+            },
+        });
         expect(outcome.usedReferenceImages.map((file) => file.name)).toEqual(
             expectedProviderReferenceNames,
         );

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -56,6 +56,7 @@ describe('runGenerateAutopilot', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -146,6 +147,7 @@ describe('runGenerateAutopilot', () => {
                 nanoBananaPro: {
                     aspectRatio: '16:9',
                     imageSize: '4K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -1,9 +1,8 @@
-import { createAutopilotSession, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
+import { createAutopilotSession, type AutopilotGeneratedImage, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
 import { getActiveGenerateControls, type GenerateDraft, type GenerateSessionStore } from './GenerateSession';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { GenerateImageInput, ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
-import { getFirstSuccessfulGeneratedImage } from '../image-workflow/ImageWorkflow';
 import { promptRefiner } from '../autopilot/PromptRefiner';
 import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageModelControls';
@@ -15,7 +14,7 @@ interface RunGenerateAutopilotInput {
     reasoningModel?: string;
     draft: GenerateDraft;
     referenceImages: File[];
-    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'saveCurrentResult' | 'saveLineageSource'>;
+    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'saveCurrentBatch' | 'saveLineageSource'>;
     lineageStore: Pick<LineageStore, 'save'>;
     createSession?: typeof createAutopilotSession;
     workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
@@ -77,11 +76,24 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
 
     if (result.bestIteration) {
         usedReferences = await workflow.serializeReferences(usedReferenceImages.slice());
-        await input.sessionStore.saveCurrentResult(result.bestIteration.imageDataUrl, usedReferences);
-        input.sessionStore.saveLineageSource({
+        const lineageSource = {
             archiveImageId: result.bestIteration.archiveImageId,
             stepId: result.bestIteration.stepId,
+        };
+        await input.sessionStore.saveCurrentBatch({
+            results: [{
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: result.bestIteration.imageDataUrl,
+                isSaved: false,
+                actualParameters: result.bestIteration.actualParameters,
+                archiveImageId: result.bestIteration.archiveImageId,
+            }],
+            references: usedReferences,
+            draft: null,
+            lineageSource,
         });
+        input.sessionStore.saveLineageSource(lineageSource);
     }
 
     return {
@@ -95,16 +107,19 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
 async function generateSingleImage(
     workflow: Pick<ImageWorkflow, 'generate'>,
     request: GenerateImageInput,
-): Promise<string> {
+): Promise<AutopilotGeneratedImage> {
     const results = await workflow.generate({
         ...request,
         batchSize: 1,
     });
-    const imageDataUrl = getFirstSuccessfulGeneratedImage(results);
+    const result = results.find((result) => result.status === 'success');
 
-    if (!imageDataUrl) {
+    if (!result) {
         throw new Error('No image data returned from image provider');
     }
 
-    return imageDataUrl;
+    return {
+        imageDataUrl: result.imageUrl,
+        actualParameters: result.actualParameters,
+    };
 }

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -127,6 +127,36 @@ describe('saveGeneratedImage', () => {
         ]);
     });
 
+    it('writes actual parameters into generation lineage metadata', async () => {
+        const lineage = createStore();
+        const sessionStore = createSessionStore();
+        const actualParameters = {
+            revisedPrompt: 'refined prompt',
+            size: '1536x1024',
+            quality: 'high',
+            elapsedMs: 930,
+        };
+        const image = createArchiveImage({
+            id: 'generated-with-actuals',
+            actualParameters,
+        });
+
+        await saveGeneratedImage(image, {
+            saveImage: vi.fn(async (nextImage) => nextImage),
+            lineageStore: lineage,
+            sessionStore,
+        });
+
+        await expect(lineage.getByArchiveImageId('generated-with-actuals')).resolves.toEqual([
+            expect.objectContaining({
+                stepType: 'generation',
+                metadata: expect.objectContaining({
+                    actualParameters,
+                }),
+            }),
+        ]);
+    });
+
     it('records Nano Banana Pro reference-generation lineage from the saved used Reference images', async () => {
         const lineage = createStore();
         const sessionStore = createSessionStore();

--- a/src/generate-session/saveGeneratedImage.test.ts
+++ b/src/generate-session/saveGeneratedImage.test.ts
@@ -188,6 +188,7 @@ describe('saveGeneratedImage', () => {
                         controls: {
                             aspectRatio: '16:9',
                             imageSize: '2K',
+                            batchSize: 1,
                         },
                     },
                     dimensions: {

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -7,6 +7,7 @@ import {
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
     notifyGenerateCompletion,
+    shouldStreamGeneratePartials,
     snapshotGeneratedReferenceImages,
 } from './useGenerateController';
 
@@ -94,6 +95,34 @@ describe('Generate controller batch result slots', () => {
                 error: 'content filter',
             },
         ]);
+    });
+});
+
+describe('Generate controller partial preview gating', () => {
+    it('streams partial previews only for single-slot GPT Image 2 runs', () => {
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: OPENAI_IMAGE_MODEL,
+            gptImage2: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'auto',
+                batchSize: 1,
+            },
+        }))).toBe(true);
+
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: OPENAI_IMAGE_MODEL,
+            gptImage2: {
+                quality: 'high',
+                size: '1024x1024',
+                background: 'auto',
+                batchSize: 2,
+            },
+        }))).toBe(false);
+
+        expect(shouldStreamGeneratePartials(createDraft({
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+        }))).toBe(false);
     });
 });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -3,6 +3,7 @@ import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageMo
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
 import {
+    addGeneratedResultAsReference,
     buildGenerateResultSlots,
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
@@ -94,6 +95,69 @@ describe('Generate controller batch result slots', () => {
                 error: 'content filter',
             },
         ]);
+    });
+});
+
+describe('Generate controller result Reference iteration', () => {
+    it('adds a saved generated result as a Reference image and keeps its lineage source', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+
+        const added = addGeneratedResultAsReference({
+            slot: {
+                slotIndex: 2,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,c2F2ZWQtcmVzdWx0',
+                isSaved: true,
+                archiveImageId: 'archive-image-123',
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+        });
+
+        expect(added).toBe(true);
+        expect(addReferenceFiles).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'generated-result-3.png',
+                type: 'image/png',
+            }),
+        ]);
+        expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'archive-image-123' });
+        expect(clearLineageSource).not.toHaveBeenCalled();
+    });
+
+    it('adds an unsaved generated result as a Reference image without carrying a lineage source', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+
+        const added = addGeneratedResultAsReference({
+            slot: {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,dW5zYXZlZC1yZXN1bHQ=',
+                isSaved: false,
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+        });
+
+        expect(added).toBe(true);
+        expect(addReferenceFiles).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'generated-result-1.png',
+                type: 'image/png',
+            }),
+        ]);
+        expect(saveLineageSource).not.toHaveBeenCalled();
+        expect(clearLineageSource).toHaveBeenCalled();
     });
 });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -7,6 +7,7 @@ import {
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
     notifyGenerateCompletion,
+    saveGenerateResultSlots,
     snapshotGeneratedReferenceImages,
 } from './useGenerateController';
 
@@ -92,6 +93,96 @@ describe('Generate controller batch result slots', () => {
                 slotIndex: 1,
                 status: 'failed',
                 error: 'content filter',
+            },
+        ]);
+    });
+
+    it('save-all archives each unsaved successful slot without duplicating saved or failed slots', async () => {
+        const savedImages: string[] = [];
+        const nextResults = await saveGenerateResultSlots({
+            results: [
+                {
+                    slotIndex: 0,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,one',
+                    isSaved: false,
+                },
+                {
+                    slotIndex: 1,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,two',
+                    isSaved: true,
+                    archiveImageId: 'already-saved',
+                },
+                {
+                    slotIndex: 2,
+                    status: 'failed',
+                    error: 'content filter',
+                },
+                {
+                    slotIndex: 3,
+                    status: 'success',
+                    imageUrl: 'data:image/png;base64,four',
+                    isSaved: false,
+                },
+            ],
+            draft: createDraft({ prompt: 'batch prompt' }),
+            runDraft: null,
+            usedReferences: [],
+            runLineageSource: null,
+            serializeReferences: vi.fn(async () => []),
+            saveImage: vi.fn(async (image) => {
+                savedImages.push(image.id);
+                return image;
+            }),
+            lineageStore: {
+                getByArchiveImageId: vi.fn(async () => []),
+                save: vi.fn(async (input) => ({
+                    id: input.id ?? 'lineage-step',
+                    archiveImageId: input.archiveImageId,
+                    parentStepId: input.parentStepId ?? null,
+                    stepType: input.stepType,
+                    timestamp: input.timestamp ?? '2026-06-05T12:00:00.000Z',
+                    metadata: input.metadata,
+                })),
+            },
+            sessionStore: {
+                loadLineageSource: vi.fn(() => null),
+                clearLineageSource: vi.fn(),
+            },
+            createArchiveImageId: vi.fn()
+                .mockReturnValueOnce('archive-0')
+                .mockReturnValueOnce('archive-3'),
+            now: vi.fn(() => new Date('2026-06-05T12:00:00.000Z')),
+        });
+
+        expect(savedImages).toEqual(['archive-0', 'archive-3']);
+        expect(nextResults).toEqual([
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,one',
+                isSaved: true,
+                archiveImageId: 'archive-0',
+            },
+            {
+                slotIndex: 1,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,two',
+                isSaved: true,
+                archiveImageId: 'already-saved',
+            },
+            {
+                slotIndex: 2,
+                status: 'failed',
+                error: 'content filter',
+            },
+            {
+                slotIndex: 3,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,four',
+                isSaved: true,
+                archiveImageId: 'archive-3',
             },
         ]);
     });

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -9,6 +9,7 @@ import {
     notifyGenerateCompletion,
     shouldStreamGeneratePartials,
     snapshotGeneratedReferenceImages,
+    startGeneratePartialPreviewRun,
 } from './useGenerateController';
 
 describe('Generate controller Image model archive metadata', () => {
@@ -123,6 +124,44 @@ describe('Generate controller partial preview gating', () => {
         expect(shouldStreamGeneratePartials(createDraft({
             model: NANO_BANANA_PRO_IMAGE_MODEL,
         }))).toBe(false);
+    });
+
+    it('updates and clears partial preview state only for the active run', () => {
+        let currentRunId = 0;
+        let currentPartialResult: string | null = 'data:image/png;base64,old';
+        const setCurrentPartialResult = vi.fn((imageUrl: string | null) => {
+            currentPartialResult = imageUrl;
+        });
+
+        const firstRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => currentRunId,
+            setCurrentRunId: (runId) => {
+                currentRunId = runId;
+            },
+            setCurrentPartialResult,
+        });
+
+        expect(currentPartialResult).toBeNull();
+
+        firstRun.update('data:image/png;base64,partial-1');
+        expect(currentPartialResult).toBe('data:image/png;base64,partial-1');
+
+        const secondRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => currentRunId,
+            setCurrentRunId: (runId) => {
+                currentRunId = runId;
+            },
+            setCurrentPartialResult,
+        });
+
+        secondRun.update('data:image/png;base64,partial-2');
+        firstRun.update('data:image/png;base64,stale-partial');
+        firstRun.clear();
+
+        expect(currentPartialResult).toBe('data:image/png;base64,partial-2');
+
+        secondRun.clear();
+        expect(currentPartialResult).toBeNull();
     });
 });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -341,6 +341,37 @@ describe('Generate controller result Reference iteration', () => {
         expect(clearLineageSource).toHaveBeenCalled();
     });
 
+    it('keeps lineage when adding an unsaved autopilot result as a Reference image', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+
+        const added = addGeneratedResultAsReference({
+            slot: {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,YXV0b3BpbG90',
+                isSaved: false,
+                archiveImageId: 'autopilot:run:iteration:1',
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+        });
+
+        expect(added).toBe(true);
+        expect(addReferenceFiles).toHaveBeenCalledWith([
+            expect.objectContaining({
+                name: 'generated-result-1.png',
+                type: 'image/png',
+            }),
+        ]);
+        expect(saveLineageSource).toHaveBeenCalledWith({ archiveImageId: 'autopilot:run:iteration:1' });
+        expect(clearLineageSource).not.toHaveBeenCalled();
+    });
+
     it('blocks result Reference iteration at model capacity without changing session lineage', () => {
         const addReferenceFiles = vi.fn();
         const saveLineageSource = vi.fn();

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -46,6 +46,7 @@ describe('Generate controller Image model archive metadata', () => {
             nanoBananaPro: {
                 aspectRatio: '16:9',
                 imageSize: '4K',
+                batchSize: 1,
             },
         });
 

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -28,6 +28,12 @@ describe('Generate controller Image model archive metadata', () => {
             timestamp: '2026-06-05T12:00:00.000Z',
             draft,
             references: ['data:image/png;base64,ref'],
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 420,
+            },
         })).toMatchObject({
             id: 'generated-openai',
             model: OPENAI_IMAGE_MODEL,
@@ -37,6 +43,12 @@ describe('Generate controller Image model archive metadata', () => {
             width: 1536,
             height: 1024,
             references: ['data:image/png;base64,ref'],
+            actualParameters: {
+                revisedPrompt: 'refined prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 420,
+            },
         });
     });
 
@@ -75,6 +87,10 @@ describe('Generate controller batch result slots', () => {
                 slotIndex: 0,
                 status: 'success',
                 imageUrl: 'data:image/png;base64,one',
+                actualParameters: {
+                    elapsedMs: 350,
+                    size: '1536x1024',
+                },
             },
             {
                 slotIndex: 1,
@@ -87,6 +103,10 @@ describe('Generate controller batch result slots', () => {
                 status: 'success',
                 imageUrl: 'data:image/png;base64,one',
                 isSaved: false,
+                actualParameters: {
+                    elapsedMs: 350,
+                    size: '1536x1024',
+                },
             },
             {
                 slotIndex: 1,

--- a/src/generate-session/useGenerateController.test.ts
+++ b/src/generate-session/useGenerateController.test.ts
@@ -4,6 +4,7 @@ import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openai
 import { DEFAULT_GENERATE_DRAFT, type GenerateDraft } from './GenerateSession';
 import {
     addGeneratedResultAsReference,
+    addGeneratedResultAsReferenceFromAction,
     buildGenerateResultSlots,
     buildGeneratedArchiveImage,
     buildGeneratedArchiveImageForSave,
@@ -158,6 +159,77 @@ describe('Generate controller result Reference iteration', () => {
         ]);
         expect(saveLineageSource).not.toHaveBeenCalled();
         expect(clearLineageSource).toHaveBeenCalled();
+    });
+
+    it('blocks result Reference iteration at model capacity without changing session lineage', () => {
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+        const setNotice = vi.fn();
+
+        const added = addGeneratedResultAsReferenceFromAction({
+            slot: {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,Y2FwYWNpdHk=',
+                isSaved: true,
+                archiveImageId: 'archive-at-capacity',
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+            capacityMessage: 'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+            setNotice,
+        });
+
+        expect(added).toBe(false);
+        expect(addReferenceFiles).not.toHaveBeenCalled();
+        expect(saveLineageSource).not.toHaveBeenCalled();
+        expect(clearLineageSource).not.toHaveBeenCalled();
+        expect(setNotice).toHaveBeenCalledWith(
+            'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+        );
+    });
+
+    it('runs the result Reference action without mutating the draft prompt or controls', () => {
+        const draft = createDraft({
+            prompt: 'keep this prompt',
+            gptImage2: {
+                quality: 'high',
+                size: '1536x1024',
+                background: 'transparent',
+                batchSize: 4,
+            },
+        });
+        const draftBeforeAction = structuredClone(draft);
+        const addReferenceFiles = vi.fn();
+        const saveLineageSource = vi.fn();
+        const clearLineageSource = vi.fn();
+        const setNotice = vi.fn();
+
+        const added = addGeneratedResultAsReferenceFromAction({
+            slot: {
+                slotIndex: 1,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,aXRlcmF0ZQ==',
+                isSaved: false,
+            },
+            addReferenceFiles,
+            session: {
+                saveLineageSource,
+                clearLineageSource,
+            },
+            capacityMessage: null,
+            setNotice,
+        });
+
+        expect(added).toBe(true);
+        expect(draft).toEqual(draftBeforeAction);
+        expect(addReferenceFiles).toHaveBeenCalledTimes(1);
+        expect(clearLineageSource).toHaveBeenCalled();
+        expect(setNotice).toHaveBeenCalledWith(null);
     });
 });
 

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -95,6 +95,11 @@ interface AddGeneratedResultAsReferenceInput {
     session: Pick<GenerateSessionStore, 'saveLineageSource' | 'clearLineageSource'>;
 }
 
+interface AddGeneratedResultAsReferenceActionInput extends AddGeneratedResultAsReferenceInput {
+    capacityMessage: string | null;
+    setNotice: (message: string | null) => void;
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -168,6 +173,28 @@ export function addGeneratedResultAsReference({
     }
 
     return true;
+}
+
+export function addGeneratedResultAsReferenceFromAction({
+    capacityMessage,
+    setNotice,
+    ...input
+}: AddGeneratedResultAsReferenceActionInput) {
+    if (capacityMessage) {
+        setNotice(capacityMessage);
+        return false;
+    }
+
+    try {
+        const added = addGeneratedResultAsReference(input);
+        if (added) {
+            setNotice(null);
+        }
+        return added;
+    } catch (referenceError) {
+        setNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
+        return false;
+    }
 }
 
 export function notifyGenerateCompletion({

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import type { ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
 import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateLineageSource, type GenerateSessionStore } from './GenerateSession';
 import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResult, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
@@ -37,6 +37,7 @@ export type GenerateResultSlot =
         status: 'success';
         imageUrl: string;
         isSaved: boolean;
+        actualParameters?: ActualImageParameters;
         archiveImageId?: string;
     }
     | {
@@ -72,6 +73,7 @@ interface BuildGeneratedArchiveImageInput {
     timestamp: string;
     draft: GenerateDraft;
     references: string[];
+    actualParameters?: ActualImageParameters;
 }
 
 interface SnapshotGeneratedReferenceImagesInput {
@@ -85,6 +87,7 @@ interface BuildGeneratedArchiveImageForSaveInput {
     timestamp: string;
     draft: GenerateDraft;
     usedReferences: string[] | null;
+    actualParameters?: ActualImageParameters;
     serializeReferences: () => Promise<string[]>;
 }
 
@@ -94,6 +97,7 @@ export function buildGeneratedArchiveImage({
     timestamp,
     draft,
     references,
+    actualParameters,
 }: BuildGeneratedArchiveImageInput): ArchiveImage {
     const archiveFields = getActiveGenerateArchiveFields(draft);
 
@@ -111,6 +115,7 @@ export function buildGeneratedArchiveImage({
         style: draft.style,
         lighting: draft.lighting,
         palette: draft.palette,
+        actualParameters,
         references,
     };
 }
@@ -128,6 +133,7 @@ export async function buildGeneratedArchiveImageForSave({
     timestamp,
     draft,
     usedReferences,
+    actualParameters,
     serializeReferences,
 }: BuildGeneratedArchiveImageForSaveInput): Promise<ArchiveImage> {
     const references = usedReferences ?? await serializeReferences();
@@ -137,6 +143,7 @@ export async function buildGeneratedArchiveImageForSave({
         url,
         timestamp,
         draft,
+        actualParameters,
         references,
     });
 }
@@ -502,6 +509,7 @@ export function useGenerateController({
                 timestamp: new Date().toISOString(),
                 draft: currentRunDraft ?? draft,
                 usedReferences: currentResultReferences,
+                actualParameters: slot.actualParameters,
                 serializeReferences,
             });
             await saveGeneratedImage(image, {
@@ -555,6 +563,7 @@ export function useGenerateController({
     return {
         currentResult,
         currentBatchResults,
+        currentRunDraft,
         loading,
         error,
         autopilot,
@@ -577,6 +586,7 @@ export function buildGenerateResultSlots(results: GenerateBatchResult[]): Genera
             status: 'success',
             imageUrl: result.imageUrl,
             isSaved: false,
+            actualParameters: result.actualParameters,
         }
         : result);
 }

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -89,6 +89,37 @@ interface BuildGeneratedArchiveImageForSaveInput {
     serializeReferences: () => Promise<string[]>;
 }
 
+interface StartGeneratePartialPreviewRunInput {
+    getCurrentRunId: () => number;
+    setCurrentRunId: (runId: number) => void;
+    setCurrentPartialResult: (imageUrl: string | null) => void;
+}
+
+export function startGeneratePartialPreviewRun({
+    getCurrentRunId,
+    setCurrentRunId,
+    setCurrentPartialResult,
+}: StartGeneratePartialPreviewRunInput) {
+    const runId = getCurrentRunId() + 1;
+    setCurrentRunId(runId);
+    setCurrentPartialResult(null);
+
+    const isCurrentRun = () => getCurrentRunId() === runId;
+
+    return {
+        update(imageUrl: string) {
+            if (isCurrentRun()) {
+                setCurrentPartialResult(imageUrl);
+            }
+        },
+        clear() {
+            if (isCurrentRun()) {
+                setCurrentPartialResult(null);
+            }
+        },
+    };
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -268,9 +299,13 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
-        const partialRunId = partialRunIdRef.current + 1;
-        partialRunIdRef.current = partialRunId;
-        setCurrentPartialResult(null);
+        const partialPreviewRun = startGeneratePartialPreviewRun({
+            getCurrentRunId: () => partialRunIdRef.current,
+            setCurrentRunId: (runId) => {
+                partialRunIdRef.current = runId;
+            },
+            setCurrentPartialResult,
+        });
         setAutopilot((current) => ({
             ...current,
             running: false,
@@ -284,11 +319,7 @@ export function useGenerateController({
             const runDraft = cloneGenerateDraft(draft);
             const runLineageSource = session.loadLineageSource();
             const onPartialImage = shouldStreamGeneratePartials(draft)
-                ? (imageUrl: string) => {
-                    if (partialRunIdRef.current === partialRunId) {
-                        setCurrentPartialResult(imageUrl);
-                    }
-                }
+                ? partialPreviewRun.update
                 : undefined;
             const usedReferences = await snapshotGeneratedReferenceImages({
                 referenceImages: usedReferenceImages,
@@ -316,7 +347,7 @@ export function useGenerateController({
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
-            setCurrentPartialResult(null);
+            partialPreviewRun.clear();
 
             if (!imageUrl) {
                 setCurrentResult(null);
@@ -339,7 +370,7 @@ export function useGenerateController({
             };
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to generate image';
-            setCurrentPartialResult(null);
+            partialPreviewRun.clear();
             setError(message);
             completionNotification = {
                 title: 'Generation failed',

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
-import { generateSessionStore, getActiveGenerateArchiveFields, getActiveGenerateControls, type GenerateDraft, type GenerateLineageSource, type GenerateSessionStore } from './GenerateSession';
+import {
+    generateSessionStore,
+    getActiveGenerateArchiveFields,
+    getActiveGenerateControls,
+    type GenerateBatchSnapshot,
+    type GenerateDraft,
+    type GenerateLineageSource,
+    type GenerateResultSlot,
+    type GenerateSessionStore,
+} from './GenerateSession';
 import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResult, type ImageWorkflow } from '../image-workflow/ImageWorkflow';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
@@ -31,20 +40,6 @@ interface AutopilotProgressState {
     lastErrorIteration: number | null;
 }
 
-export type GenerateResultSlot =
-    | {
-        slotIndex: number;
-        status: 'success';
-        imageUrl: string;
-        isSaved: boolean;
-        archiveImageId?: string;
-    }
-    | {
-        slotIndex: number;
-        status: 'failed';
-        error: string;
-    };
-
 interface UseGenerateControllerOptions {
     apiKey: string | null;
     reasoningApiKey?: string | null;
@@ -56,7 +51,7 @@ interface UseGenerateControllerOptions {
     serializeReferences: () => Promise<string[]>;
     onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
     lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
-    session?: Pick<GenerateSessionStore, 'loadCurrentResult' | 'loadCurrentResultReferences' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentBatch' | 'saveCurrentBatch' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
     workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     createAutopilot?: typeof createAutopilotSession;
     evaluate?: typeof satisfactionEvaluator.evaluate;
@@ -86,6 +81,21 @@ interface BuildGeneratedArchiveImageForSaveInput {
     draft: GenerateDraft;
     usedReferences: string[] | null;
     serializeReferences: () => Promise<string[]>;
+}
+
+interface SaveGenerateResultSlotsInput {
+    results: GenerateResultSlot[];
+    slotIndexes?: number[];
+    draft: GenerateDraft;
+    runDraft: GenerateDraft | null;
+    usedReferences: string[] | null;
+    runLineageSource: GenerateLineageSource | null;
+    serializeReferences: () => Promise<string[]>;
+    saveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
+    lineageStore: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
+    sessionStore: Pick<GenerateSessionStore, 'loadLineageSource' | 'clearLineageSource'>;
+    createArchiveImageId?: () => string;
+    now?: () => Date;
 }
 
 export function buildGeneratedArchiveImage({
@@ -139,6 +149,50 @@ export async function buildGeneratedArchiveImageForSave({
         draft,
         references,
     });
+}
+
+export async function saveGenerateResultSlots({
+    results,
+    slotIndexes,
+    draft,
+    runDraft,
+    usedReferences,
+    runLineageSource,
+    serializeReferences,
+    saveImage,
+    lineageStore,
+    sessionStore,
+    createArchiveImageId = () => crypto.randomUUID(),
+    now = () => new Date(),
+}: SaveGenerateResultSlotsInput): Promise<GenerateResultSlot[]> {
+    const selectedSlotIndexes = new Set(slotIndexes);
+    const shouldSaveSlot = (slot: GenerateResultSlot): slot is Extract<GenerateResultSlot, { status: 'success' }> => (
+        slot.status === 'success' &&
+        !slot.isSaved &&
+        (!slotIndexes || selectedSlotIndexes.has(slot.slotIndex))
+    );
+    let nextResults = results;
+
+    for (const slot of results.filter(shouldSaveSlot)) {
+        const archiveImageId = createArchiveImageId();
+        const image = await buildGeneratedArchiveImageForSave({
+            id: archiveImageId,
+            url: slot.imageUrl,
+            timestamp: now().toISOString(),
+            draft: runDraft ?? draft,
+            usedReferences,
+            serializeReferences,
+        });
+        await saveGeneratedImage(image, {
+            saveImage: async (image) => Promise.resolve(saveImage(image)),
+            lineageStore,
+            sessionStore,
+            lineageSource: runLineageSource,
+        });
+        nextResults = markGenerateResultSlotSaved(nextResults, slot.slotIndex, archiveImageId);
+    }
+
+    return nextResults;
 }
 
 export function notifyGenerateCompletion({
@@ -230,20 +284,16 @@ export function useGenerateController({
     }, [setDraft]);
 
     useEffect(() => {
-        Promise.all([
-            session.loadCurrentResult(),
-            session.loadCurrentResultReferences(),
-        ]).then(([value, references]) => {
-            if (value) {
-                setCurrentResult(value);
-                setCurrentBatchResults([{
-                    slotIndex: 0,
-                    status: 'success',
-                    imageUrl: value,
-                    isSaved: false,
-                }]);
-                setCurrentResultReferences(references);
+        session.loadCurrentBatch().then((batch) => {
+            if (!batch) {
+                return;
             }
+
+            setCurrentResult(getFirstSuccessfulResultSlot(batch.results)?.imageUrl ?? null);
+            setCurrentBatchResults(batch.results);
+            setCurrentResultReferences(batch.references);
+            setCurrentRunDraft(batch.draft);
+            setCurrentRunLineageSource(batch.lineageSource);
         });
 
         session.consumeTransferredReferences().then((references) => {
@@ -297,17 +347,23 @@ export function useGenerateController({
             });
             const imageUrl = getFirstSuccessfulGeneratedImage(results);
             const batchResults = buildGenerateResultSlots(results);
+            const batchSnapshot: GenerateBatchSnapshot = {
+                results: batchResults,
+                references: usedReferences,
+                draft: runDraft,
+                lineageSource: runLineageSource,
+            };
 
             setCurrentBatchResults(batchResults);
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
+            await session.saveCurrentBatch(batchSnapshot);
 
             if (!imageUrl) {
                 setCurrentResult(null);
                 updateDraft({ isSaved: false });
                 setError('Generation failed for every batch result.');
-                await session.clearCurrentResult();
                 completionNotification = {
                     title: 'Generation failed',
                     body: 'Every batch result failed.',
@@ -317,7 +373,6 @@ export function useGenerateController({
 
             setCurrentResult(imageUrl);
             updateDraft({ isSaved: false });
-            await session.saveCurrentResult(imageUrl, usedReferences);
             completionNotification = {
                 title: 'Generation complete',
                 body: 'Your image is ready in AURA.',
@@ -488,6 +543,13 @@ export function useGenerateController({
         autopilotSessionRef.current?.cancel();
     }, []);
 
+    const persistCurrentBatch = useCallback((results: GenerateResultSlot[]) => session.saveCurrentBatch({
+        results,
+        references: currentResultReferences,
+        draft: currentRunDraft ?? draft,
+        lineageSource: currentRunLineageSource,
+    }), [currentResultReferences, currentRunDraft, currentRunLineageSource, draft, session]);
+
     const saveResult = useCallback(async (slotIndex: number) => {
         const slot = currentBatchResults.find((result) => result.slotIndex === slotIndex);
         if (!slot || slot.status !== 'success' || slot.isSaved) {
@@ -495,34 +557,50 @@ export function useGenerateController({
         }
 
         try {
-            const archiveImageId = crypto.randomUUID();
-            const image = await buildGeneratedArchiveImageForSave({
-                id: archiveImageId,
-                url: slot.imageUrl,
-                timestamp: new Date().toISOString(),
-                draft: currentRunDraft ?? draft,
+            const nextResults = await saveGenerateResultSlots({
+                results: currentBatchResults,
+                slotIndexes: [slot.slotIndex],
+                draft,
+                runDraft: currentRunDraft,
                 usedReferences: currentResultReferences,
+                runLineageSource: currentRunLineageSource,
                 serializeReferences,
-            });
-            await saveGeneratedImage(image, {
-                saveImage: async (image) => Promise.resolve(onSaveImage(image)),
+                saveImage: onSaveImage,
                 lineageStore: lineage,
                 sessionStore: session,
-                lineageSource: currentRunLineageSource,
             });
-            const nextResults = currentBatchResults.map((result) => result.slotIndex === slotIndex && result.status === 'success'
-                ? {
-                    ...result,
-                    isSaved: true,
-                    archiveImageId,
-                }
-                : result);
             setCurrentBatchResults(nextResults);
+            await persistCurrentBatch(nextResults);
             updateDraft({ isSaved: areAllSuccessfulResultsSaved(nextResults) });
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Failed to save image');
         }
-    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, serializeReferences, session, updateDraft]);
+    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, persistCurrentBatch, serializeReferences, session, updateDraft]);
+
+    const saveAllResults = useCallback(async () => {
+        if (!hasUnsavedSuccessfulResults(currentBatchResults)) {
+            return;
+        }
+
+        try {
+            const nextResults = await saveGenerateResultSlots({
+                results: currentBatchResults,
+                draft,
+                runDraft: currentRunDraft,
+                usedReferences: currentResultReferences,
+                runLineageSource: currentRunLineageSource,
+                serializeReferences,
+                saveImage: onSaveImage,
+                lineageStore: lineage,
+                sessionStore: session,
+            });
+            setCurrentBatchResults(nextResults);
+            await persistCurrentBatch(nextResults);
+            updateDraft({ isSaved: areAllSuccessfulResultsSaved(nextResults) });
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Failed to save batch');
+        }
+    }, [currentBatchResults, currentResultReferences, currentRunDraft, currentRunLineageSource, draft, lineage, onSaveImage, persistCurrentBatch, serializeReferences, session, updateDraft]);
 
     const save = useCallback(async () => {
         await saveResult(0);
@@ -564,6 +642,7 @@ export function useGenerateController({
         cancelAutopilot,
         save,
         saveResult,
+        saveAllResults,
         download,
         downloadResult,
         clear,
@@ -587,6 +666,30 @@ function areAllSuccessfulResultsSaved(results: GenerateResultSlot[]) {
     );
 
     return successfulResults.length > 0 && successfulResults.every((result) => result.isSaved);
+}
+
+function hasUnsavedSuccessfulResults(results: GenerateResultSlot[]) {
+    return results.some((result) => result.status === 'success' && !result.isSaved);
+}
+
+function getFirstSuccessfulResultSlot(results: GenerateResultSlot[]) {
+    return results.find((result): result is Extract<GenerateResultSlot, { status: 'success' }> =>
+        result.status === 'success',
+    ) ?? null;
+}
+
+function markGenerateResultSlotSaved(
+    results: GenerateResultSlot[],
+    slotIndex: number,
+    archiveImageId: string,
+): GenerateResultSlot[] {
+    return results.map((result) => result.slotIndex === slotIndex && result.status === 'success'
+        ? {
+            ...result,
+            isSaved: true,
+            archiveImageId,
+        }
+        : result);
 }
 
 function cloneGenerateDraft(draft: GenerateDraft): GenerateDraft {

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -14,6 +14,7 @@ import {
     type CompletionNotificationPayload,
     type CompletionNotificationPort,
 } from '../app/CompletionNotificationPort';
+import { resolveImageModelConfig } from '../utils/openaiModels';
 
 interface AutopilotProgressState {
     running: boolean;
@@ -214,6 +215,7 @@ export function useGenerateController({
     const [currentResultReferences, setCurrentResultReferences] = useState<string[] | null>(null);
     const [currentRunDraft, setCurrentRunDraft] = useState<GenerateDraft | null>(null);
     const [currentRunLineageSource, setCurrentRunLineageSource] = useState<GenerateLineageSource | null>(null);
+    const [currentPartialResult, setCurrentPartialResult] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [autopilot, setAutopilot] = useState<AutopilotProgressState>({
@@ -224,6 +226,7 @@ export function useGenerateController({
         lastErrorIteration: null,
     });
     const autopilotSessionRef = useRef<AutopilotSession | null>(null);
+    const partialRunIdRef = useRef(0);
 
     const updateDraft = useCallback((patch: Partial<GenerateDraft>) => {
         setDraft((currentDraft) => ({ ...currentDraft, ...patch }));
@@ -265,6 +268,9 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        const partialRunId = partialRunIdRef.current + 1;
+        partialRunIdRef.current = partialRunId;
+        setCurrentPartialResult(null);
         setAutopilot((current) => ({
             ...current,
             running: false,
@@ -277,6 +283,13 @@ export function useGenerateController({
             const usedReferenceImages = referenceImages.slice();
             const runDraft = cloneGenerateDraft(draft);
             const runLineageSource = session.loadLineageSource();
+            const onPartialImage = shouldStreamGeneratePartials(draft)
+                ? (imageUrl: string) => {
+                    if (partialRunIdRef.current === partialRunId) {
+                        setCurrentPartialResult(imageUrl);
+                    }
+                }
+                : undefined;
             const usedReferences = await snapshotGeneratedReferenceImages({
                 referenceImages: usedReferenceImages,
                 serializeReferenceFiles: workflow.serializeReferences,
@@ -294,6 +307,7 @@ export function useGenerateController({
                 lighting: draft.lighting,
                 palette: draft.palette,
                 referenceImages: usedReferenceImages,
+                onPartialImage,
             });
             const imageUrl = getFirstSuccessfulGeneratedImage(results);
             const batchResults = buildGenerateResultSlots(results);
@@ -302,6 +316,7 @@ export function useGenerateController({
             setCurrentRunDraft(runDraft);
             setCurrentRunLineageSource(runLineageSource);
             setCurrentResultReferences(usedReferences);
+            setCurrentPartialResult(null);
 
             if (!imageUrl) {
                 setCurrentResult(null);
@@ -324,6 +339,7 @@ export function useGenerateController({
             };
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to generate image';
+            setCurrentPartialResult(null);
             setError(message);
             completionNotification = {
                 title: 'Generation failed',
@@ -359,6 +375,7 @@ export function useGenerateController({
 
         setLoading(true);
         setError(null);
+        setCurrentPartialResult(null);
         setCurrentResultReferences(null);
         setCurrentBatchResults([]);
         setCurrentRunDraft(null);
@@ -545,6 +562,7 @@ export function useGenerateController({
 
     const clear = useCallback(async () => {
         setCurrentResult(null);
+        setCurrentPartialResult(null);
         setCurrentBatchResults([]);
         setCurrentResultReferences(null);
         setCurrentRunDraft(null);
@@ -554,6 +572,7 @@ export function useGenerateController({
 
     return {
         currentResult,
+        currentPartialResult,
         currentBatchResults,
         loading,
         error,
@@ -568,6 +587,13 @@ export function useGenerateController({
         downloadResult,
         clear,
     };
+}
+
+export function shouldStreamGeneratePartials(draft: GenerateDraft) {
+    const model = resolveImageModelConfig(draft.model);
+    const controls = getActiveGenerateControls(draft);
+
+    return model.capabilities.partialImageStreaming && controls.batchSize === 1;
 }
 
 export function buildGenerateResultSlots(results: GenerateBatchResult[]): GenerateResultSlot[] {

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -14,6 +14,7 @@ import {
     type CompletionNotificationPayload,
     type CompletionNotificationPort,
 } from '../app/CompletionNotificationPort';
+import { dataURLtoFile } from '../utils/file';
 
 interface AutopilotProgressState {
     running: boolean;
@@ -88,6 +89,12 @@ interface BuildGeneratedArchiveImageForSaveInput {
     serializeReferences: () => Promise<string[]>;
 }
 
+interface AddGeneratedResultAsReferenceInput {
+    slot: GenerateResultSlot;
+    addReferenceFiles: (files: File[]) => void;
+    session: Pick<GenerateSessionStore, 'saveLineageSource' | 'clearLineageSource'>;
+}
+
 export function buildGeneratedArchiveImage({
     id,
     url,
@@ -139,6 +146,28 @@ export async function buildGeneratedArchiveImageForSave({
         draft,
         references,
     });
+}
+
+export function addGeneratedResultAsReference({
+    slot,
+    addReferenceFiles,
+    session,
+}: AddGeneratedResultAsReferenceInput) {
+    if (slot.status !== 'success') {
+        return false;
+    }
+
+    addReferenceFiles([
+        dataURLtoFile(slot.imageUrl, `generated-result-${slot.slotIndex + 1}.png`),
+    ]);
+
+    if (slot.isSaved && slot.archiveImageId) {
+        session.saveLineageSource({ archiveImageId: slot.archiveImageId });
+    } else {
+        session.clearLineageSource();
+    }
+
+    return true;
 }
 
 export function notifyGenerateCompletion({

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -15,7 +15,7 @@ import { getFirstSuccessfulGeneratedImage, imageWorkflow, type GenerateBatchResu
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { saveGeneratedImage } from './saveGeneratedImage';
 import { runGenerateAutopilot } from './runGenerateAutopilot';
-import { createAutopilotSession, type AutopilotSession, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
+import { createAutopilotSession, type AutopilotIteration, type AutopilotSession, type AutopilotSessionResult } from '../autopilot/AutopilotSession';
 import { promptRefiner } from '../autopilot/PromptRefiner';
 import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import {
@@ -55,7 +55,7 @@ interface UseGenerateControllerOptions {
     serializeReferences: () => Promise<string[]>;
     onSaveImage: (image: ArchiveImage) => ArchiveImage | Promise<ArchiveImage>;
     lineage?: Pick<LineageStore, 'getByArchiveImageId' | 'save'>;
-    session?: Pick<GenerateSessionStore, 'loadCurrentBatch' | 'saveCurrentBatch' | 'saveCurrentResult' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
+    session?: Pick<GenerateSessionStore, 'loadCurrentBatch' | 'saveCurrentBatch' | 'clearCurrentResult' | 'consumeTransferredReferences' | 'loadLineageSource' | 'saveLineageSource' | 'clearLineageSource'>;
     workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     createAutopilot?: typeof createAutopilotSession;
     evaluate?: typeof satisfactionEvaluator.evaluate;
@@ -261,7 +261,7 @@ export function addGeneratedResultAsReference({
         dataURLtoFile(slot.imageUrl, `generated-result-${slot.slotIndex + 1}.png`),
     ]);
 
-    if (slot.isSaved && slot.archiveImageId) {
+    if (slot.archiveImageId) {
         session.saveLineageSource({ archiveImageId: slot.archiveImageId });
     } else {
         session.clearLineageSource();
@@ -568,13 +568,7 @@ export function useGenerateController({
                         bestIterationNumber: runningBest.iterationNumber,
                     }));
                     setCurrentResult(iteration.imageDataUrl);
-                    setCurrentBatchResults([{
-                        slotIndex: 0,
-                        status: 'success',
-                        imageUrl: iteration.imageDataUrl,
-                        isSaved: false,
-                        archiveImageId: iteration.archiveImageId,
-                    }]);
+                    setCurrentBatchResults([buildAutopilotResultSlot(iteration)]);
                 },
                 onError: (error, iterationNumber) => {
                     setError(error.message);
@@ -590,25 +584,26 @@ export function useGenerateController({
                     referenceImages: outcome.usedReferenceImages,
                     serializeReferenceFiles: workflow.serializeReferences,
                 });
-                setCurrentResult(outcome.result.bestIteration.imageDataUrl);
-                setCurrentBatchResults([{
-                    slotIndex: 0,
-                    status: 'success',
-                    imageUrl: outcome.result.bestIteration.imageDataUrl,
-                    isSaved: false,
-                    archiveImageId: outcome.result.bestIteration.archiveImageId,
-                }]);
-                setCurrentResultReferences(usedReferences);
-                setCurrentRunDraft(null);
-                setCurrentRunLineageSource({
+                const bestSlot = buildAutopilotResultSlot(outcome.result.bestIteration);
+                const lineageSource = {
                     archiveImageId: outcome.result.bestIteration.archiveImageId,
                     stepId: outcome.result.bestIteration.stepId,
-                });
+                };
+                setCurrentResult(outcome.result.bestIteration.imageDataUrl);
+                setCurrentBatchResults([bestSlot]);
+                setCurrentResultReferences(usedReferences);
+                setCurrentRunDraft(null);
+                setCurrentRunLineageSource(lineageSource);
                 updateDraft({
                     prompt: outcome.result.bestIteration.prompt,
                     isSaved: false,
                 });
-                await session.saveCurrentResult(outcome.result.bestIteration.imageDataUrl, usedReferences);
+                await session.saveCurrentBatch({
+                    results: [bestSlot],
+                    references: usedReferences,
+                    draft: null,
+                    lineageSource,
+                });
             }
 
             if (outcome.result.status === 'failed' && outcome.result.error) {
@@ -814,6 +809,17 @@ function markGenerateResultSlotSaved(
             archiveImageId,
         }
         : result);
+}
+
+function buildAutopilotResultSlot(iteration: AutopilotIteration): Extract<GenerateResultSlot, { status: 'success' }> {
+    return {
+        slotIndex: 0,
+        status: 'success',
+        imageUrl: iteration.imageDataUrl,
+        isSaved: false,
+        archiveImageId: iteration.archiveImageId,
+        ...(iteration.actualParameters ? { actualParameters: iteration.actualParameters } : {}),
+    };
 }
 
 function cloneGenerateDraft(draft: GenerateDraft): GenerateDraft {

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -69,6 +69,7 @@ describe('Image model controls', () => {
         expect(getImageModelGenerateControls(NANO_BANANA_PRO_IMAGE_MODEL).map((control) => control.id)).toEqual([
             'aspectRatio',
             'imageSize',
+            'batchSize',
         ]);
     });
 
@@ -87,6 +88,7 @@ describe('Image model controls', () => {
         expect(getDefaultImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL)).toEqual({
             aspectRatio: '1:1',
             imageSize: '1K',
+            batchSize: 1,
         });
         expect(sanitizeImageModelControls(OPENAI_IMAGE_MODEL, {
             quality: 'high',
@@ -117,11 +119,14 @@ describe('Image model controls', () => {
         expect(sanitizeImageModelControls(NANO_BANANA_PRO_IMAGE_MODEL, {
             aspectRatio: '1536x1024',
             imageSize: '4K',
+            batchSize: 8,
         })).toEqual({
             aspectRatio: '3:2',
             imageSize: '4K',
+            batchSize: 4,
         });
         expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'aspectRatio', '1024x1536')).toBe('2:3');
+        expect(coerceImageModelControlValue(NANO_BANANA_PRO_IMAGE_MODEL, 'batchSize', '3')).toBe('3');
         expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'quality', 'best')).toBe('medium');
         expect(coerceImageModelControlValue(OPENAI_IMAGE_MODEL, 'batchSize', '9')).toBe('4');
     });
@@ -172,11 +177,13 @@ describe('Image model controls', () => {
             quality: 'high',
             aspectRatio: '1024x1536',
             background: 'transparent',
+            batchSize: 4,
             imageSize: '4K',
             referenceImages: references,
         })).toEqual({
             aspectRatio: '2:3',
             imageSize: '4K',
+            batchSize: 4,
             referenceImages: references.slice(0, 14),
         });
     });

--- a/src/image-models/ImageModelControls.test.ts
+++ b/src/image-models/ImageModelControls.test.ts
@@ -6,6 +6,7 @@ import {
     coerceImageModelControlValue,
     getDefaultImageModelControls,
     getImageModelGenerateControls,
+    getImageModelReferenceCapacityMessage,
     getImageModelReferenceLimitMessage,
     getImageModelUiChoices,
     imageModelSupportsTransformMask,
@@ -227,6 +228,14 @@ describe('Image model controls', () => {
             'ref-12.png',
             'ref-13.png',
         ]);
+    });
+
+    it('reports when a Generate result cannot be appended as another Reference image', () => {
+        expect(getImageModelReferenceCapacityMessage(OPENAI_IMAGE_MODEL, 50, 'generation')).toBeNull();
+        expect(getImageModelReferenceCapacityMessage(NANO_BANANA_PRO_IMAGE_MODEL, 13, 'generation')).toBeNull();
+        expect(getImageModelReferenceCapacityMessage(NANO_BANANA_PRO_IMAGE_MODEL, 14, 'generation')).toBe(
+            'Nano Banana Pro already has 14 reference images for generation. Remove one before adding another.',
+        );
     });
 
     it('applies future gpt-image-2 Reference limits from Image model facts consistently', () => {

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -437,6 +437,19 @@ export function getImageModelReferenceLimitMessage(
     return `${IMAGE_MODEL_REGISTRY[model].label} uses the first ${limit} reference images for ${context}.`;
 }
 
+export function getImageModelReferenceCapacityMessage(
+    model: ImageModelSlug,
+    referenceCount: number,
+    context: string,
+): string | null {
+    const limit = IMAGE_MODEL_CONTROL_FACTS[model].referenceLimit;
+    if (limit === null || referenceCount < limit) {
+        return null;
+    }
+
+    return `${IMAGE_MODEL_REGISTRY[model].label} already has ${limit} reference images for ${context}. Remove one before adding another.`;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
         ? value as Record<string, unknown>

--- a/src/image-models/ImageModelControls.ts
+++ b/src/image-models/ImageModelControls.ts
@@ -22,6 +22,7 @@ export type GptImage2Controls = {
 export type NanoBananaProControls = {
     aspectRatio: NanoBananaAspectRatio;
     imageSize: NanoBananaImageSize;
+    batchSize: number;
 };
 
 export type ImageModelControls = GptImage2Controls | NanoBananaProControls;
@@ -133,6 +134,7 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
         defaults: {
             aspectRatio: '1:1',
             imageSize: '1K',
+            batchSize: 1,
         },
         generateControls: [
             {
@@ -160,6 +162,17 @@ export const IMAGE_MODEL_CONTROL_FACTS = {
                     { value: '1K', label: '1K' },
                     { value: '2K', label: '2K' },
                     { value: '4K', label: '4K' },
+                ],
+            },
+            {
+                id: 'batchSize',
+                label: 'BATCH SIZE',
+                kind: 'toggle',
+                options: [
+                    { value: '1', label: '1' },
+                    { value: '2', label: '2' },
+                    { value: '3', label: '3' },
+                    { value: '4', label: '4' },
                 ],
             },
         ],
@@ -230,6 +243,7 @@ export function sanitizeImageModelControls(
         return {
             aspectRatio: coerceNanoAspectRatio(record?.aspectRatio, fallbackControls.aspectRatio),
             imageSize: coerceNanoImageSize(record?.imageSize, fallbackControls.imageSize),
+            batchSize: coerceGptBatchSize(record?.batchSize, fallbackControls.batchSize),
         };
     }
 
@@ -270,6 +284,9 @@ export function coerceImageModelControlValue(model: ImageModelSlug, controlId: s
         if (controlId === 'imageSize') {
             return coerceNanoImageSize(value, defaults.imageSize);
         }
+        if (controlId === 'batchSize') {
+            return String(coerceGptBatchSize(value, defaults.batchSize));
+        }
         return '';
     }
 
@@ -298,7 +315,7 @@ export function getActiveImageModelGenerateControls(model: ImageModelSlug, contr
             imageSize: sanitized.imageSize,
             quality: gptDefaults.quality,
             background: gptDefaults.background,
-            batchSize: 1,
+            batchSize: sanitized.batchSize,
         };
     }
 
@@ -355,10 +372,12 @@ export function mapImageModelGenerateProviderRequest(
         const controls = sanitizeImageModelControls(model, {
             aspectRatio: input.aspectRatio,
             imageSize: input.imageSize,
+            batchSize: input.batchSize,
         }) as NanoBananaProControls;
         return {
             aspectRatio: controls.aspectRatio,
             imageSize: controls.imageSize,
+            batchSize: controls.batchSize,
             referenceImages: referenceRunPlan.providerReferenceImages,
         };
     }

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -80,7 +80,26 @@ export function createGoogleImageProvider(fetchImpl: typeof fetch = fetch): Imag
     };
 
     return {
-        generate: async (request) => [await createImage(request)],
+        async generate(request) {
+            const batchSize = coerceProviderBatchSize(request.batchSize);
+
+            if (batchSize === 1) {
+                return [await createImage(request)];
+            }
+
+            return Promise.all(Array.from({ length: batchSize }, async () => {
+                try {
+                    return await createImage({
+                        ...request,
+                        batchSize: 1,
+                    });
+                } catch (error) {
+                    return {
+                        error: error instanceof Error ? error.message : 'Google Gemini image generation failed',
+                    };
+                }
+            }));
+        },
         edit: createImage,
     };
 }
@@ -129,6 +148,20 @@ async function fileToBase64(file: File) {
         binary += String.fromCharCode(byte);
     });
     return btoa(binary);
+}
+
+function coerceProviderBatchSize(value: unknown): number {
+    const parsed = typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+            ? Number(value.trim())
+            : NaN;
+
+    if (!Number.isFinite(parsed)) {
+        return 1;
+    }
+
+    return Math.min(4, Math.max(1, Math.trunc(parsed)));
 }
 
 export function extractGoogleImageData(data: unknown): string | null {

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -20,6 +20,7 @@ export interface ImageProviderRequest {
     batchSize?: number;
     referenceImages?: File[];
     maskImage?: File | Blob | null;
+    onPartialImage?: (partial: ImageProviderResponse) => void;
 }
 
 export type ImageProviderResponse = OpenAiImageResponse;
@@ -43,6 +44,7 @@ export function createOpenAiImageProvider(client: OpenAiImageClient = openAiImag
         batchSize: request.batchSize,
         referenceImages: request.referenceImages,
         maskImage: request.maskImage,
+        onPartialImage: request.onPartialImage,
     });
 
     return {

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -883,7 +883,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'a luminous teapot city',
             aspectRatio: '16:9',

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -34,6 +34,9 @@ describe('ImageWorkflow', () => {
             slotIndex: 0,
             status: 'success',
             imageUrl: 'data:image/png;base64,generated',
+            actualParameters: {
+                elapsedMs: expect.any(Number),
+            },
         }]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             apiKey: 'sk-test',
@@ -78,13 +81,68 @@ describe('ImageWorkflow', () => {
         });
 
         expect(results).toEqual([
-            { slotIndex: 0, status: 'success', imageUrl: 'data:image/png;base64,generated-0' },
+            {
+                slotIndex: 0,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,generated-0',
+                actualParameters: {
+                    elapsedMs: expect.any(Number),
+                },
+            },
             { slotIndex: 1, status: 'failed', error: 'No image data returned from image provider' },
-            { slotIndex: 2, status: 'success', imageUrl: 'data:image/png;base64,generated-2' },
+            {
+                slotIndex: 2,
+                status: 'success',
+                imageUrl: 'data:image/png;base64,generated-2',
+                actualParameters: {
+                    elapsedMs: expect.any(Number),
+                },
+            },
         ]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             batchSize: 3,
         }));
+    });
+
+    it('attaches actual parameters and elapsed time to successful generated results', async () => {
+        const generate = vi.fn(async () => [{
+            b64_json: 'generated',
+            revised_prompt: 'refined mountain prompt',
+            size: '1536x1024',
+            quality: 'high',
+        }]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        }, {
+            now: createNowSequence([1000, 1275]),
+        });
+
+        const results = await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'medium',
+            aspectRatio: 'auto',
+            background: 'transparent',
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        });
+
+        expect(results).toEqual([{
+            slotIndex: 0,
+            status: 'success',
+            imageUrl: 'data:image/png;base64,generated',
+            actualParameters: {
+                revisedPrompt: 'refined mountain prompt',
+                size: '1536x1024',
+                quality: 'high',
+                elapsedMs: 275,
+            },
+        }]);
     });
 
     it('routes edit requests through the configured provider for the default model', async () => {
@@ -417,6 +475,9 @@ describe('googleImageProvider', () => {
         });
 
         expect(result).toEqual([{ b64_json: 'gemini-image' }]);
+        expect(result[0]).not.toHaveProperty('revised_prompt');
+        expect(result[0]).not.toHaveProperty('size');
+        expect(result[0]).not.toHaveProperty('quality');
         expect(fetchImpl).toHaveBeenCalledWith('https://example.test/generate', expect.objectContaining({
             method: 'POST',
             headers: {
@@ -614,3 +675,8 @@ describe('googleImageProvider', () => {
         });
     });
 });
+
+function createNowSequence(values: number[]) {
+    let index = 0;
+    return () => values[index++] ?? values.at(-1) ?? 0;
+}

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -87,6 +87,38 @@ describe('ImageWorkflow', () => {
         }));
     });
 
+    it('uses provider slot errors when batch generation partially fails', async () => {
+        const generate = vi.fn(async () => [
+            { b64_json: 'generated-0' },
+            { error: 'Google Gemini API Error: overloaded' },
+            { b64_json: 'generated-2' },
+        ]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await expect(workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 3,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        })).resolves.toEqual([
+            { slotIndex: 0, status: 'success', imageUrl: 'data:image/png;base64,generated-0' },
+            { slotIndex: 1, status: 'failed', error: 'Google Gemini API Error: overloaded' },
+            { slotIndex: 2, status: 'success', imageUrl: 'data:image/png;base64,generated-2' },
+        ]);
+    });
+
+
     it('routes edit requests through the configured provider for the default model', async () => {
         const edit = vi.fn(async () => ({ b64_json: 'edited' }));
         const providers: ImageProviderRegistry = {
@@ -612,5 +644,53 @@ describe('googleImageProvider', () => {
             aspectRatio: '1:1',
             imageSize: '1K',
         });
+    });
+
+    it('fans out Nano Banana batch generation and keeps failed slots isolated', async () => {
+        const pendingResponses: Array<(response: Response) => void> = [];
+        const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>((resolve) => {
+            pendingResponses.push(resolve);
+        }));
+        const provider = createGoogleImageProvider(fetchImpl);
+
+        const resultPromise = provider.generate({
+            apiKey: 'google-key',
+            model: {
+                slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                provider: 'google',
+                apiModel: 'gemini-3-pro-image-preview',
+                label: 'Nano Banana Pro',
+                endpoints: {
+                    generate: 'https://example.test/generate',
+                    edit: 'https://example.test/generate',
+                },
+                parameters: {},
+                capabilities: { transformMask: false },
+            },
+            prompt: 'a luminous teapot city',
+            aspectRatio: '16:9',
+            imageSize: '2K',
+            batchSize: 3,
+            referenceImages: [],
+        });
+
+        await Promise.resolve();
+        expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+        pendingResponses[0]?.(new Response(JSON.stringify({
+            candidates: [{ content: { parts: [{ inlineData: { data: 'gemini-image-0' } }] } }],
+        })));
+        pendingResponses[1]?.(new Response(JSON.stringify({
+            error: { message: 'quota exceeded' },
+        }), { status: 429 }));
+        pendingResponses[2]?.(new Response(JSON.stringify({
+            candidates: [{ content: { parts: [{ inlineData: { data: 'gemini-image-2' } }] } }],
+        })));
+
+        await expect(resultPromise).resolves.toEqual([
+            { b64_json: 'gemini-image-0' },
+            { error: 'quota exceeded' },
+            { b64_json: 'gemini-image-2' },
+        ]);
     });
 });

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -87,6 +87,112 @@ describe('ImageWorkflow', () => {
         }));
     });
 
+    it('forwards single-slot OpenAI partial images as data URLs', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [{ b64_json: 'generated' }];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 1,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).toHaveBeenCalledWith('data:image/png;base64,partial');
+        expect(generate).toHaveBeenCalledWith(expect.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
+    it('does not forward partial image callbacks for batch generation', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+            ];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            batchSize: 2,
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).not.toHaveBeenCalled();
+        expect(generate).toHaveBeenCalledWith(expect.not.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
+    it('does not forward partial image callbacks for Nano Banana generation', async () => {
+        const onPartialImage = vi.fn();
+        const generate = vi.fn(async (input: Parameters<ImageProvider['generate']>[0]) => {
+            input.onPartialImage?.({ b64_json: 'partial' });
+            return [{ b64_json: 'generated' }];
+        });
+        const workflow = createImageWorkflow({
+            openai: {
+                generate: vi.fn(),
+                edit: vi.fn(),
+            },
+            google: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        await workflow.generate({
+            apiKey: 'google-key',
+            model: NANO_BANANA_PRO_IMAGE_MODEL,
+            prompt: 'teapot city',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+            onPartialImage,
+        });
+
+        expect(onPartialImage).not.toHaveBeenCalled();
+        expect(generate).toHaveBeenCalledWith(expect.not.objectContaining({
+            onPartialImage: expect.any(Function),
+        }));
+    });
+
     it('routes edit requests through the configured provider for the default model', async () => {
         const edit = vi.fn(async () => ({ b64_json: 'edited' }));
         const providers: ImageProviderRegistry = {
@@ -408,7 +514,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'a luminous teapot city',
             aspectRatio: '16:9',
@@ -435,6 +541,44 @@ describe('googleImageProvider', () => {
             aspectRatio: '16:9',
             imageSize: '2K',
         });
+    });
+
+    it('ignores partial image callbacks for Gemini requests', async () => {
+        const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+            candidates: [{
+                content: {
+                    parts: [{ inlineData: { data: 'gemini-image' } }],
+                },
+            }],
+        })));
+        const provider = createGoogleImageProvider(fetchImpl);
+        const onPartialImage = vi.fn();
+
+        const result = await provider.generate({
+            apiKey: 'google-key',
+            model: {
+                slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                provider: 'google',
+                apiModel: 'gemini-3-pro-image-preview',
+                label: 'Nano Banana Pro',
+                endpoints: {
+                    generate: 'https://example.test/generate',
+                    edit: 'https://example.test/generate',
+                },
+                parameters: {},
+                capabilities: { transformMask: false, partialImageStreaming: false },
+            },
+            prompt: 'a luminous teapot city',
+            onPartialImage,
+        });
+
+        expect(result).toEqual([{ b64_json: 'gemini-image' }]);
+        expect(onPartialImage).not.toHaveBeenCalled();
+
+        const requestInit = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+        const body = JSON.parse(String(requestInit.body));
+        expect(JSON.stringify(body)).not.toContain('partial');
+        expect(JSON.stringify(body)).not.toContain('stream');
     });
 
     it('normalizes unsupported Nano Banana aspect ratios to 1:1', async () => {
@@ -545,7 +689,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'make it cinematic',
             preserveSourceDimensions: true,
@@ -600,7 +744,7 @@ describe('googleImageProvider', () => {
                     edit: 'https://example.test/generate',
                 },
                 parameters: {},
-                capabilities: { transformMask: false },
+                capabilities: { transformMask: false, partialImageStreaming: false },
             },
             prompt: 'a luminous teapot city',
             referenceImages: [],

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -203,7 +203,7 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
         return {
             slotIndex,
             status: 'failed',
-            error: 'No image data returned from image provider',
+            error: response?.error ?? 'No image data returned from image provider',
         };
     });
 }

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -1,4 +1,5 @@
 import { dataURLtoFile, fileToDataURL } from '../utils/file';
+import type { ActualImageParameters } from '../db/types';
 import {
     type ImageBackground,
     type ImageQuality,
@@ -46,6 +47,7 @@ export type GenerateBatchResult =
         slotIndex: number;
         status: 'success';
         imageUrl: string;
+        actualParameters?: ActualImageParameters;
     }
     | {
         slotIndex: number;
@@ -60,7 +62,16 @@ export interface ImageWorkflow {
     hydrateReferences(dataUrls: string[]): File[];
 }
 
-export function createImageWorkflow(providers: ImageProviderRegistry = imageProviderRegistry): ImageWorkflow {
+interface CreateImageWorkflowDeps {
+    now?: () => number;
+}
+
+export function createImageWorkflow(
+    providers: ImageProviderRegistry = imageProviderRegistry,
+    deps: CreateImageWorkflowDeps = {},
+): ImageWorkflow {
+    const now = deps.now ?? (() => performance.now());
+
     return {
         async generate(input) {
             const { model, modelSlug, provider } = resolveImageProvider(input.model, providers);
@@ -76,13 +87,15 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
             const batchSize = providerRequest.batchSize ?? 1;
 
             try {
+                const startedAt = now();
                 const responses = await provider.generate({
                     apiKey: input.apiKey,
                     model,
                     prompt: buildGenerationPrompt(input),
                     ...providerRequest,
                 });
-                const results = mapGenerateBatchResults(responses, batchSize);
+                const elapsedMs = Math.max(0, Math.round(now() - startedAt));
+                const results = mapGenerateBatchResults(responses, batchSize, elapsedMs);
 
                 if (!hasSuccessfulGeneratedImage(results) && batchSize === 1) {
                     const [result] = results;
@@ -188,7 +201,11 @@ function hasSuccessfulGeneratedImage(results: GenerateBatchResult[]): boolean {
     return getFirstSuccessfulGeneratedImage(results) !== null;
 }
 
-function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: number): GenerateBatchResult[] {
+function mapGenerateBatchResults(
+    responses: ImageProviderResponse[],
+    batchSize: number,
+    elapsedMs: number,
+): GenerateBatchResult[] {
     return Array.from({ length: batchSize }, (_, slotIndex) => {
         const response = responses[slotIndex];
 
@@ -197,6 +214,7 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
                 slotIndex,
                 status: 'success',
                 imageUrl: `data:image/png;base64,${response.b64_json}`,
+                actualParameters: buildActualImageParameters(response, elapsedMs),
             };
         }
 
@@ -206,4 +224,13 @@ function mapGenerateBatchResults(responses: ImageProviderResponse[], batchSize: 
             error: 'No image data returned from image provider',
         };
     });
+}
+
+function buildActualImageParameters(response: ImageProviderResponse, elapsedMs: number): ActualImageParameters {
+    return {
+        ...(response.revised_prompt ? { revisedPrompt: response.revised_prompt } : {}),
+        ...(response.size ? { size: response.size } : {}),
+        ...(response.quality ? { quality: response.quality } : {}),
+        elapsedMs,
+    };
 }

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -26,6 +26,7 @@ export interface GenerateImageInput {
     lighting: string;
     palette: string;
     referenceImages: File[];
+    onPartialImage?: (imageUrl: string) => void;
 }
 
 export interface EditImageInput {
@@ -74,6 +75,9 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
             });
 
             const batchSize = providerRequest.batchSize ?? 1;
+            const onPartialImage = batchSize === 1 && model.capabilities.partialImageStreaming
+                ? createPartialImageHandler(input.onPartialImage)
+                : undefined;
 
             try {
                 const responses = await provider.generate({
@@ -81,6 +85,7 @@ export function createImageWorkflow(providers: ImageProviderRegistry = imageProv
                     model,
                     prompt: buildGenerationPrompt(input),
                     ...providerRequest,
+                    ...(onPartialImage ? { onPartialImage } : {}),
                 });
                 const results = mapGenerateBatchResults(responses, batchSize);
 
@@ -148,6 +153,24 @@ const buildGenerationPrompt = (input: GenerateImageInput) => {
         ? `${input.prompt}, ${modifiers.join(', ')}`
         : input.prompt;
 };
+
+function createPartialImageHandler(onPartialImage: GenerateImageInput['onPartialImage']) {
+    if (!onPartialImage) {
+        return undefined;
+    }
+
+    return (partial: ImageProviderResponse) => {
+        if (!partial.b64_json) {
+            return;
+        }
+
+        try {
+            onPartialImage(`data:image/png;base64,${partial.b64_json}`);
+        } catch {
+            // Partial previews should not interrupt the final generation result.
+        }
+    };
+}
 
 const createEditSourceFile = (sourceImage: Blob) => {
     return new File([sourceImage], 'edit-input.png', {

--- a/src/index.css
+++ b/src/index.css
@@ -791,6 +791,28 @@ textarea.aura-input {
     background: var(--color-charcoal);
 }
 
+.partial-result-image {
+    opacity: 0.88;
+}
+
+.partial-result-banner {
+    position: absolute;
+    top: var(--spacing-24);
+    left: 50%;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--element-gap);
+    padding: var(--spacing-8) var(--spacing-16);
+    transform: translateX(-50%);
+    background: var(--color-snow);
+    color: var(--color-charcoal);
+    white-space: nowrap;
+}
+
+.partial-result-banner span {
+    color: var(--color-steel);
+}
+
 .result-batch-container {
     width: 100%;
     min-height: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -867,7 +867,10 @@ textarea.aura-input {
     left: 50%;
     bottom: var(--spacing-24);
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: var(--spacing-16);
+    max-width: calc(100% - 48px);
     padding: var(--card-padding);
     transform: translateX(-50%);
     background: rgba(0, 0, 0, 0.55);

--- a/src/index.css
+++ b/src/index.css
@@ -791,6 +791,17 @@ textarea.aura-input {
     background: var(--color-charcoal);
 }
 
+.result-container.has-actual-parameters {
+    gap: var(--spacing-16);
+    padding-bottom: var(--spacing-16);
+}
+
+.result-container.has-actual-parameters .result-image {
+    height: auto;
+    max-height: min(70vh, 720px);
+    flex: 1;
+}
+
 .result-batch-container {
     width: 100%;
     min-height: 100%;
@@ -841,6 +852,109 @@ textarea.aura-input {
 
 .result-slot-actions {
     flex-wrap: wrap;
+}
+
+.actual-parameters-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    margin: 0 var(--spacing-16);
+    padding: var(--card-padding);
+    border: 1px solid var(--color-steel);
+    background: var(--color-snow);
+    color: var(--color-charcoal);
+}
+
+.result-slot-card .actual-parameters-panel,
+.modal-sidebar .actual-parameters-panel {
+    margin: 0;
+}
+
+.actual-parameters-panel.compact {
+    padding: var(--spacing-8);
+}
+
+.actual-parameter-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    margin: 0;
+}
+
+.actual-parameter-row,
+.actual-parameter-elapsed {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-16);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.actual-parameter-row dt,
+.actual-parameter-elapsed span,
+.actual-parameter-prompt span {
+    color: var(--color-steel);
+    text-transform: uppercase;
+}
+
+.actual-parameter-row dd {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    align-items: start;
+    gap: var(--element-gap);
+    margin: 0;
+    min-width: 0;
+}
+
+.actual-parameter-row dd span {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.actual-parameter-row small {
+    color: var(--color-steel);
+    font-size: 10px;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.actual-parameter-row strong,
+.actual-parameter-elapsed strong {
+    overflow-wrap: anywhere;
+    color: var(--color-charcoal);
+    font-weight: var(--font-weight-regular);
+}
+
+.actual-parameter-row em {
+    padding: 2px 6px;
+    border: 1px solid var(--color-amber-glow);
+    color: var(--color-amber-glow);
+    font-style: normal;
+    text-transform: uppercase;
+}
+
+.actual-parameter-row.changed {
+    padding-left: var(--spacing-8);
+    border-left: 2px solid var(--color-amber-glow);
+}
+
+.actual-parameter-prompt {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.actual-parameter-prompt p {
+    margin: 0;
+    color: var(--color-charcoal);
+    overflow-wrap: anywhere;
 }
 
 .result-slot-error {

--- a/src/index.css
+++ b/src/index.css
@@ -857,6 +857,13 @@ textarea.aura-input {
     text-align: center;
 }
 
+.result-batch-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--element-gap);
+    flex-wrap: wrap;
+}
+
 .result-batch-clear {
     align-self: flex-end;
 }

--- a/src/lineage/LineageNavigator.test.ts
+++ b/src/lineage/LineageNavigator.test.ts
@@ -72,11 +72,45 @@ describe('LineageNavigator', () => {
 
             const outcome = await navigator.replayIntoEditor('step-4');
 
-            expect(outcome).toEqual({ status: 'replayed', image });
+            expect(outcome).toEqual({ status: 'replayed', image, replay: { prompt: null, model: null } });
             expect(sessionStore.saveLineageSource).toHaveBeenCalledWith({
                 archiveImageId: 'image-4',
                 stepId: 'step-4',
             });
+        });
+
+        it('returns masked editor replay metadata for the Editor to send on the next AI transform', async () => {
+            const step = createStep({
+                id: 'masked-step',
+                archiveImageId: 'masked-image',
+                stepType: 'ai-edit',
+                metadata: {
+                    aiEdit: {
+                        prompt: 'replace the masked area',
+                        imageModel: { slug: 'gpt-image-2' },
+                        transformMask: {
+                            dataUrl: 'data:image/png;base64,bWFzaw==',
+                            mimeType: 'image/png',
+                        },
+                    },
+                },
+            });
+            const image = createImage({ id: 'masked-image' });
+            const { navigator } = setup({ steps: [step], images: [image] });
+
+            const outcome = await navigator.replayIntoEditor('masked-step');
+
+            expect(outcome.status).toBe('replayed');
+            if (outcome.status !== 'replayed') {
+                return;
+            }
+            expect(outcome.image).toBe(image);
+            expect(outcome.replay).toMatchObject({
+                prompt: 'replace the masked area',
+                model: 'gpt-image-2',
+            });
+            expect(outcome.replay.maskImage).toBeInstanceOf(File);
+            await expect(outcome.replay.maskImage?.text()).resolves.toBe('mask');
         });
 
         it('reports unavailable when the image is missing from the archive', async () => {

--- a/src/lineage/LineageNavigator.ts
+++ b/src/lineage/LineageNavigator.ts
@@ -1,14 +1,14 @@
 import type { ArchiveImage } from '../db/types';
 import type { GenerateSessionStore } from '../generate-session/GenerateSession';
 import type { LineageStore } from './LineageStore';
-import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+import { buildEditorReplay, buildGenerateReplay, isEditorReplayable, isGenerateReplayable, type EditorReplay } from './replayLineageStep';
 
 export type ReplayIntoGenerateOutcome =
     | { status: 'replayed' }
     | { status: 'unavailable'; reason: string };
 
 export type ReplayIntoEditorOutcome =
-    | { status: 'replayed'; image: ArchiveImage }
+    | { status: 'replayed'; image: ArchiveImage; replay: EditorReplay }
     | { status: 'unavailable'; reason: string };
 
 export type ForkOutcome =
@@ -60,9 +60,14 @@ export function createLineageNavigator(deps: LineageNavigatorDeps): LineageNavig
                 return { status: 'unavailable', reason: 'Selected step image is missing from the local archive' };
             }
 
+            const replay = buildEditorReplay(step);
+            if (!replay) {
+                return { status: 'unavailable', reason: 'This step cannot be replayed into Editor' };
+            }
+
             sessionStore.saveLineageSource({ archiveImageId: step.archiveImageId, stepId: step.id });
 
-            return { status: 'replayed', image };
+            return { status: 'replayed', image, replay };
         },
 
         async fork(stepId) {

--- a/src/lineage/editorLineageMetadata.ts
+++ b/src/lineage/editorLineageMetadata.ts
@@ -34,11 +34,19 @@ export interface EditorLineageAiTransformTarget {
     includesBaseLayer: boolean | null;
 }
 
+export interface EditorLineageTransformMaskAsset {
+    assetId: string | null;
+    dataUrl?: string;
+    fileName?: string;
+    mimeType: string;
+}
+
 export interface EditorLineageAiEdit {
     prompt: string;
     imageModel: EditorLineageImageModel | null;
     referenceImages: EditorLineageReferenceImages;
     transformTarget: EditorLineageAiTransformTarget;
+    transformMask?: EditorLineageTransformMaskAsset;
 }
 
 export interface EditorLineageAiResultLayerFact {
@@ -75,6 +83,7 @@ export interface EditorLineageMetadata extends Record<string, unknown> {
     targetIncludesBaseLayer: boolean | null;
     aiResultLayerId: string | null;
     aiResultLayerName: string | null;
+    transformMaskAsset?: EditorLineageTransformMaskAsset;
 }
 
 export interface EditorTimelineMetadata {
@@ -97,6 +106,7 @@ export function buildEditorLineageMetadata(input: {
     aiResultLayerName?: string | null;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
+    transformMask?: EditorLineageTransformMaskAsset | null;
 }): EditorLineageMetadata {
     const layerStack = input.layerStack ?? input.savedImage.layerStack;
     const editPrompt = normalizeString(input.aiEditPrompt);
@@ -113,6 +123,7 @@ export function buildEditorLineageMetadata(input: {
         aiResultLayerId: input.aiResultLayerId ?? null,
         aiResultLayerName: input.aiResultLayerName ?? null,
     });
+    const transformMask = buildEditorTransformMaskAsset(input.transformMask, input.savedImage.id);
 
     return {
         sourceImage: {
@@ -134,6 +145,7 @@ export function buildEditorLineageMetadata(input: {
                     count: referenceCount,
                 },
                 transformTarget: aiTransformTarget,
+                ...(transformMask ? { transformMask } : {}),
             }
             : null,
         layers,
@@ -152,6 +164,7 @@ export function buildEditorLineageMetadata(input: {
         targetIncludesBaseLayer: aiTransformTarget.includesBaseLayer,
         aiResultLayerId: layers.aiResultLayer?.id ?? null,
         aiResultLayerName: layers.aiResultLayer?.name ?? null,
+        ...(transformMask ? { transformMaskAsset: transformMask } : {}),
     };
 }
 
@@ -214,6 +227,11 @@ export function readEditorLineageAiTransformTarget(metadata: Record<string, unkn
     };
 }
 
+export function readEditorLineageTransformMask(metadata: Record<string, unknown>): EditorLineageTransformMaskAsset | null {
+    const aiEdit = asRecord(metadata.aiEdit);
+    return readTransformMaskAsset(aiEdit?.transformMask) ?? readTransformMaskAsset(metadata.transformMaskAsset);
+}
+
 function buildEditorAdjustment(adjustments: EditorAdjustments): EditorLineageAdjustment {
     return {
         brightness: adjustments.brightness,
@@ -247,6 +265,45 @@ function buildEditorLineageImageModel(model: string | null): EditorLineageImageM
     return isImageModelSlug(model)
         ? { slug: model }
         : null;
+}
+
+function buildEditorTransformMaskAsset(
+    transformMask: EditorLineageTransformMaskAsset | null | undefined,
+    savedImageId: string,
+): EditorLineageTransformMaskAsset | null {
+    if (!transformMask?.dataUrl && !transformMask?.fileName) {
+        return null;
+    }
+
+    return {
+        assetId: transformMask.assetId || `${savedImageId}:transform-mask`,
+        ...(transformMask.dataUrl ? { dataUrl: transformMask.dataUrl } : {}),
+        ...(transformMask.fileName ? { fileName: transformMask.fileName } : {}),
+        mimeType: transformMask.mimeType || 'image/png',
+    };
+}
+
+function readTransformMaskAsset(value: unknown): EditorLineageTransformMaskAsset | null {
+    const asset = asRecord(value);
+    if (!asset) {
+        return null;
+    }
+
+    const dataUrl = typeof asset.dataUrl === 'string' ? asset.dataUrl : undefined;
+    const fileName = typeof asset.fileName === 'string' ? asset.fileName : undefined;
+    const mimeType = typeof asset.mimeType === 'string' ? asset.mimeType : 'image/png';
+    const assetId = typeof asset.assetId === 'string' ? asset.assetId : null;
+
+    if (!dataUrl && !fileName) {
+        return null;
+    }
+
+    return {
+        assetId,
+        ...(dataUrl ? { dataUrl } : {}),
+        ...(fileName ? { fileName } : {}),
+        mimeType,
+    };
 }
 
 function readAdjustment(value: unknown): EditorLineageAdjustment | null {

--- a/src/lineage/generateLineageMetadata.ts
+++ b/src/lineage/generateLineageMetadata.ts
@@ -1,4 +1,4 @@
-import type { ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ArchiveImage } from '../db/types';
 import {
     buildImageModelArchiveFields,
     sanitizeArchiveImageModelControls,
@@ -49,6 +49,7 @@ export interface GenerateLineageMetadata extends Record<string, unknown> {
     lighting: string;
     palette: string;
     sourceArchiveImageId: string | null;
+    actualParameters?: ActualImageParameters;
     referenceImages: GenerateLineageReferenceImages;
     referenceCount: number;
     referenceIds: string[];
@@ -83,6 +84,7 @@ export function buildGenerateLineageMetadata(input: {
         lighting: input.image.lighting ?? 'none',
         palette: input.image.palette ?? 'none',
         sourceArchiveImageId: input.sourceArchiveImageId,
+        ...(input.image.actualParameters ? { actualParameters: input.image.actualParameters } : {}),
         referenceImages: {
             count: referenceIds.length,
             ids: referenceIds,

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -26,6 +26,7 @@ function validateGenerateMetadata(metadata: Record<string, unknown>) {
     validateImageModel(metadata.imageModel);
     validateDimensions(metadata.dimensions);
     validateReferenceImages(metadata.referenceImages);
+    validateActualParameters(metadata.actualParameters);
 }
 
 function validateEditorMetadata(metadata: Record<string, unknown>) {
@@ -82,6 +83,26 @@ function validateReferenceImages(value: unknown) {
     requireFiniteNumber(referenceImages.count, 'lineage referenceImages count');
     if (!Array.isArray(referenceImages.ids) || !referenceImages.ids.every((id) => typeof id === 'string')) {
         throw new Error('Invalid lineage referenceImages ids');
+    }
+}
+
+function validateActualParameters(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    const actualParameters = requireRecord(value, 'lineage actualParameters');
+    if (actualParameters.revisedPrompt !== undefined) {
+        requireString(actualParameters.revisedPrompt, 'lineage actualParameters revisedPrompt');
+    }
+    if (actualParameters.size !== undefined) {
+        requireString(actualParameters.size, 'lineage actualParameters size');
+    }
+    if (actualParameters.quality !== undefined) {
+        requireString(actualParameters.quality, 'lineage actualParameters quality');
+    }
+    if (actualParameters.elapsedMs !== undefined) {
+        requireFiniteNumber(actualParameters.elapsedMs, 'lineage actualParameters elapsedMs');
     }
 }
 

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -35,6 +35,7 @@ function validateEditorMetadata(metadata: Record<string, unknown>) {
     validateEditorAdjustment(metadata.editorAdjustment);
     validateEditorAiEdit(metadata.aiEdit);
     validateEditorLayers(metadata.layers);
+    validateTransformMaskAsset(metadata.transformMaskAsset);
 }
 
 function validateAutopilotMetadata(metadata: Record<string, unknown>) {
@@ -133,6 +134,7 @@ function validateEditorAiEdit(value: unknown) {
         requireFiniteNumber(referenceImages.count, 'lineage aiEdit referenceImages count');
     }
     validateEditorTransformTarget(aiEdit.transformTarget);
+    validateTransformMaskAsset(aiEdit.transformMask);
 }
 
 function validateEditorTransformTarget(value: unknown) {
@@ -154,6 +156,24 @@ function validateEditorTransformTarget(value: unknown) {
     if (transformTarget.includesBaseLayer !== null) {
         requireBoolean(transformTarget.includesBaseLayer, 'lineage transformTarget includesBaseLayer');
     }
+}
+
+function validateTransformMaskAsset(value: unknown) {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    const asset = requireRecord(value, 'lineage transformMask');
+    if (asset.assetId !== null) {
+        requireString(asset.assetId, 'lineage transformMask assetId');
+    }
+    if (asset.dataUrl !== undefined) {
+        requireString(asset.dataUrl, 'lineage transformMask dataUrl');
+    }
+    if (asset.fileName !== undefined) {
+        requireString(asset.fileName, 'lineage transformMask fileName');
+    }
+    requireString(asset.mimeType, 'lineage transformMask mimeType');
 }
 
 function validateEditorLayers(value: unknown) {

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -39,6 +39,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -90,6 +91,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },
@@ -138,6 +140,7 @@ describe('replayLineageStep', () => {
                 nanoBananaPro: {
                     aspectRatio: '1:1',
                     imageSize: '1K',
+                    batchSize: 1,
                 },
                 isSaved: false,
             },

--- a/src/lineage/replayLineageStep.test.ts
+++ b/src/lineage/replayLineageStep.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ArchiveImage } from '../db/types';
 import type { LineageStep } from './LineageStore';
-import { buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
+import { buildEditorReplay, buildGenerateReplay, isEditorReplayable, isGenerateReplayable } from './replayLineageStep';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 
 describe('replayLineageStep', () => {
@@ -55,6 +55,45 @@ describe('replayLineageStep', () => {
         expect(isGenerateReplayable(createStep({ id: 'b', archiveImageId: 'image-b', stepType: 'ai-edit', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
         expect(isEditorReplayable(createStep({ id: 'c', archiveImageId: 'image-c', stepType: 'save-as-copy', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(true);
         expect(isEditorReplayable(createStep({ id: 'd', archiveImageId: 'image-d', stepType: 'reference-generation', timestamp: '2026-04-04T09:00:00.000Z' }))).toBe(false);
+    });
+
+    it('hydrates masked editor replay metadata into an edit request mask image', async () => {
+        const step = createStep({
+            id: 'masked-step',
+            archiveImageId: 'masked-image',
+            stepType: 'ai-edit',
+            timestamp: '2026-04-04T10:00:00.000Z',
+            metadata: {
+                aiEdit: {
+                    prompt: 'replace only the painted area',
+                    imageModel: {
+                        slug: OPENAI_IMAGE_MODEL,
+                    },
+                    referenceImages: {
+                        count: 0,
+                    },
+                    transformTarget: {
+                        mode: 'selected-layers',
+                        layerCount: 1,
+                        includesBaseLayer: false,
+                    },
+                    transformMask: {
+                        assetId: 'masked-copy:transform-mask',
+                        dataUrl: 'data:image/png;base64,bWFzaw==',
+                        mimeType: 'image/png',
+                    },
+                },
+            },
+        });
+
+        const replay = buildEditorReplay(step);
+
+        expect(replay).toEqual(expect.objectContaining({
+            prompt: 'replace only the painted area',
+            model: OPENAI_IMAGE_MODEL,
+        }));
+        expect(replay?.maskImage).toBeInstanceOf(File);
+        await expect(replay?.maskImage?.text()).resolves.toBe('mask');
     });
 
     it('hydrates a generate draft from an autopilot step without an archive image fallback', () => {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -5,6 +5,12 @@ import { sanitizeImageModelControls } from '../image-models/ImageModelControls';
 import type { LineageStep } from './LineageStore';
 import { readGenerateLineageImageModel } from './generateLineageMetadata';
 import { readAutopilotGenerateReplayMetadata } from './autopilotLineageMetadata';
+import {
+    readEditorLineageEditPrompt,
+    readEditorLineageImageModel,
+    readEditorLineageTransformMask,
+} from './editorLineageMetadata';
+import { dataURLtoFile } from '../utils/file';
 
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 type GenerateReplayImageModel = NonNullable<ReturnType<typeof readGenerateLineageImageModel>>;
@@ -28,6 +34,25 @@ export function isGenerateReplayable(step: ReplayableStep) {
 
 export function isEditorReplayable(step: ReplayableStep) {
     return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
+}
+
+export function buildEditorReplay(step: LineageStep): {
+    prompt: string | null;
+    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
+    maskImage?: File;
+} | null {
+    if (!isEditorReplayable(step)) {
+        return null;
+    }
+
+    const transformMask = readEditorLineageTransformMask(step.metadata);
+    const dataUrl = transformMask?.dataUrl;
+
+    return {
+        prompt: readEditorLineageEditPrompt(step.metadata),
+        model: readEditorLineageImageModel(step.metadata)?.slug ?? null,
+        ...(dataUrl ? { maskImage: dataURLtoFile(dataUrl, 'transform-mask.png') } : {}),
+    };
 }
 
 export function buildGenerateReplay(image: ArchiveImage | null, step: LineageStep): {

--- a/src/lineage/replayLineageStep.ts
+++ b/src/lineage/replayLineageStep.ts
@@ -15,6 +15,12 @@ import { dataURLtoFile } from '../utils/file';
 type ReplayableStep = Pick<LineageStep, 'stepType'>;
 type GenerateReplayImageModel = NonNullable<ReturnType<typeof readGenerateLineageImageModel>>;
 
+export interface EditorReplay {
+    prompt: string | null;
+    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
+    maskImage?: File;
+}
+
 interface GenerateReplayMetadata {
     imageModel: GenerateReplayImageModel | null;
     model: ReturnType<typeof resolveReplayModel> | null;
@@ -36,11 +42,7 @@ export function isEditorReplayable(step: ReplayableStep) {
     return step.stepType === 'ai-edit' || step.stepType === 'save-as-copy';
 }
 
-export function buildEditorReplay(step: LineageStep): {
-    prompt: string | null;
-    model: typeof OPENAI_IMAGE_MODEL | typeof NANO_BANANA_PRO_IMAGE_MODEL | null;
-    maskImage?: File;
-} | null {
+export function buildEditorReplay(step: LineageStep): EditorReplay | null {
     if (!isEditorReplayable(step)) {
         return null;
     }

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -108,7 +108,7 @@ describe('openAiImageClient', () => {
         const fetchMock = vi.fn(async () => createSseResponse([
             'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","b64_json":"partial-0"}\n\n',
             'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","partial_image":{"b64_json":"partial-1"}}\n\n',
-            'event: image_generation.completed\ndata: {"type":"image_generation.completed","data":[{"b64_json":"final"}]}\n\n',
+            'event: image_generation.completed\ndata: {"type":"image_generation.completed","size":"1536x1024","quality":"high","data":[{"b64_json":"final","revised_prompt":"a refined slow cat"}]}\n\n',
         ]));
         const partials: Array<{ b64_json?: string }> = [];
 
@@ -120,7 +120,12 @@ describe('openAiImageClient', () => {
                 onPartialImage: (partial) => partials.push(partial),
             });
 
-            expect(result).toEqual({ b64_json: 'final' });
+            expect(result).toEqual({
+                b64_json: 'final',
+                revised_prompt: 'a refined slow cat',
+                size: '1536x1024',
+                quality: 'high',
+            });
             expect(partials).toEqual([
                 { b64_json: 'partial-0' },
                 { b64_json: 'partial-1' },

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -77,6 +77,94 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('streams partial image events and resolves with the completed image', async () => {
+        const fetchMock = vi.fn(async () => createSseResponse([
+            'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","b64_json":"partial-0"}\n\n',
+            'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","partial_image":{"b64_json":"partial-1"}}\n\n',
+            'event: image_generation.completed\ndata: {"type":"image_generation.completed","data":[{"b64_json":"final"}]}\n\n',
+        ]));
+        const partials: Array<{ b64_json?: string }> = [];
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat appearing slowly',
+                onPartialImage: (partial) => partials.push(partial),
+            });
+
+            expect(result).toEqual({ b64_json: 'final' });
+            expect(partials).toEqual([
+                { b64_json: 'partial-0' },
+                { b64_json: 'partial-1' },
+            ]);
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body).toMatchObject({
+                stream: true,
+                partial_images: 3,
+                n: 1,
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('falls back to the normal JSON response when streaming is requested but SSE is not returned', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [{ b64_json: 'generated' }],
+        }), {
+            headers: { 'Content-Type': 'application/json' },
+        }));
+        const onPartialImage = vi.fn();
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat in a hat',
+                onPartialImage,
+            });
+
+            expect(result).toEqual({ b64_json: 'generated' });
+            expect(onPartialImage).not.toHaveBeenCalled();
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body.stream).toBe(true);
+            expect(body.partial_images).toBe(3);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('does not request streaming for batched image generation', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [
+                { b64_json: 'generated-0' },
+                { b64_json: 'generated-1' },
+            ],
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            await openAiImageClient.createImages({
+                apiKey: 'sk-test',
+                prompt: 'two cats',
+                batchSize: 2,
+                onPartialImage: vi.fn(),
+            });
+
+            const [, request] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const body = JSON.parse(String(request.body));
+            expect(body.stream).toBeUndefined();
+            expect(body.partial_images).toBeUndefined();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts image edit requests with multipart form data to the edit endpoint', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [{ b64_json: 'edited' }],
@@ -156,6 +244,19 @@ describe('openAiImageClient', () => {
         }
     });
 });
+
+function createSseResponse(chunks: string[]) {
+    const encoder = new TextEncoder();
+
+    return new Response(new ReadableStream({
+        start(controller) {
+            chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+            controller.close();
+        },
+    }), {
+        headers: { 'Content-Type': 'text/event-stream' },
+    });
+}
 
 describe('openAiResponsesClient', () => {
     it('posts image reasoning requests to the responses endpoint', async () => {

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -44,6 +44,33 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('extracts revised prompt and actual parameters from image responses', async () => {
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            size: '1536x1024',
+            quality: 'high',
+            data: [{ b64_json: 'generated', revised_prompt: 'a refined cat prompt' }],
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat',
+                size: 'auto',
+                quality: 'medium',
+            });
+
+            expect(result).toEqual({
+                b64_json: 'generated',
+                revised_prompt: 'a refined cat prompt',
+                size: '1536x1024',
+                quality: 'high',
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts batched image generation requests with native n and returns every image payload', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -332,18 +332,36 @@ function parseJsonRecord(value: string): Record<string, unknown> | null {
     }
 }
 
-function extractImageResponses(value: unknown): OpenAiImageResponse[] {
+function extractImageResponses(
+    value: unknown,
+    inheritedParameters: Pick<OpenAiImageResponse, 'size' | 'quality'> = {},
+): OpenAiImageResponse[] {
     if (typeof value !== 'object' || value === null) {
         return [];
     }
 
     const record = value as Record<string, unknown>;
+    const actualParameters = {
+        size: typeof record.size === 'string' ? record.size : inheritedParameters.size,
+        quality: typeof record.quality === 'string' ? record.quality : inheritedParameters.quality,
+    };
     if (Array.isArray(record.data)) {
-        return record.data.flatMap(extractImageResponses);
+        return record.data.flatMap((item) => extractImageResponses(item, actualParameters));
+    }
+
+    if (typeof record.data === 'object' && record.data !== null) {
+        return extractImageResponses(record.data, actualParameters);
     }
 
     const b64Json = extractImageB64Json(record);
-    return b64Json ? [{ b64_json: b64Json }] : [];
+    return b64Json
+        ? [{
+            b64_json: b64Json,
+            ...(typeof record.revised_prompt === 'string' ? { revised_prompt: record.revised_prompt } : {}),
+            ...(actualParameters.size ? { size: actualParameters.size } : {}),
+            ...(actualParameters.quality ? { quality: actualParameters.quality } : {}),
+        }]
+        : [];
 }
 
 function extractImageB64Json(value: unknown): string | null {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -19,6 +19,7 @@ export interface OpenAiImageRequest {
     batchSize?: number;
     referenceImages?: File[];
     maskImage?: File | Blob | null;
+    onPartialImage?: (partial: OpenAiImageResponse) => void;
 }
 
 export interface OpenAiImageResponse {
@@ -60,12 +61,15 @@ export const openAiImageClient: OpenAiImageClient = {
     },
 };
 
+const OPENAI_PARTIAL_IMAGE_COUNT = 3;
+
 async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiImageResponse[]> {
     const isEdit = request.referenceImages && request.referenceImages.length > 0;
     const apiModel = request.apiModel ?? request.model ?? OPENAI_IMAGE_MODEL;
     const endpoints = request.endpoints ?? IMAGE_MODEL_REGISTRY[OPENAI_IMAGE_MODEL].endpoints;
     const endpoint = isEdit ? endpoints.edit : endpoints.generate;
     const batchSize = coerceOpenAiBatchSize(request.batchSize);
+    const streamPartialImages = Boolean(request.onPartialImage) && batchSize === 1 && supportsOpenAiImageStreaming(apiModel);
 
     let body: BodyInit;
     const headers: Record<string, string> = {
@@ -89,6 +93,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         if (request.size && request.size !== 'auto') formData.append('size', request.size);
         if (request.quality) formData.append('quality', request.quality);
         if (request.background && request.background !== 'auto') formData.append('background', request.background);
+        if (streamPartialImages) {
+            formData.append('stream', 'true');
+            formData.append('partial_images', String(OPENAI_PARTIAL_IMAGE_COUNT));
+        }
 
         body = formData;
     } else {
@@ -100,6 +108,8 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
             size?: string;
             quality?: ImageQuality;
             background?: 'transparent' | 'opaque';
+            stream?: boolean;
+            partial_images?: number;
         } = {
             model: apiModel,
             prompt: request.prompt,
@@ -108,6 +118,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         if (request.size && request.size !== 'auto') jsonBody.size = request.size;
         if (request.quality) jsonBody.quality = request.quality;
         if (request.background && request.background !== 'auto') jsonBody.background = request.background;
+        if (streamPartialImages) {
+            jsonBody.stream = true;
+            jsonBody.partial_images = OPENAI_PARTIAL_IMAGE_COUNT;
+        }
 
         body = JSON.stringify(jsonBody);
     }
@@ -123,6 +137,10 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
     }
 
+    if (streamPartialImages && isEventStreamResponse(response)) {
+        return readOpenAiImageStream(response, request.onPartialImage);
+    }
+
     const data: { data?: OpenAiImageResponse[] } = await response.json();
 
     if (!data.data || data.data.length === 0) {
@@ -130,6 +148,211 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
     }
 
     return data.data;
+}
+
+function supportsOpenAiImageStreaming(apiModel: string) {
+    return apiModel === OPENAI_IMAGE_MODEL;
+}
+
+function isEventStreamResponse(response: Response) {
+    return response.headers.get('content-type')?.toLowerCase().includes('text/event-stream') ?? false;
+}
+
+async function readOpenAiImageStream(
+    response: Response,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+): Promise<OpenAiImageResponse[]> {
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+        return parseOpenAiImageEventStream(await response.text(), onPartialImage);
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    const completed = {
+        images: null as OpenAiImageResponse[] | null,
+    };
+    const processBlock = (block: string) => {
+        const nextImages = parseOpenAiImageEventBlock(block, onPartialImage);
+        if (nextImages) {
+            completed.images = nextImages;
+        }
+    };
+
+    while (true) {
+        const { value, done } = await reader.read();
+        if (value) {
+            buffer += decoder.decode(value, { stream: !done });
+            buffer = drainEventStreamBlocks(buffer, processBlock);
+        }
+
+        if (done) {
+            buffer += decoder.decode();
+            break;
+        }
+    }
+
+    if (buffer.trim()) {
+        processBlock(buffer);
+    }
+
+    const completedImages = completed.images;
+    if (!completedImages || completedImages.length === 0) {
+        throw new Error('No image data returned from OpenAI');
+    }
+
+    return completedImages;
+}
+
+function parseOpenAiImageEventStream(
+    eventStream: string,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+) {
+    let completedImages: OpenAiImageResponse[] | null = null;
+    const buffer = drainEventStreamBlocks(eventStream, (block) => {
+        const nextImages = parseOpenAiImageEventBlock(block, onPartialImage);
+        if (nextImages) {
+            completedImages = nextImages;
+        }
+    });
+
+    if (buffer.trim()) {
+        const nextImages = parseOpenAiImageEventBlock(buffer, onPartialImage);
+        if (nextImages) {
+            completedImages = nextImages;
+        }
+    }
+
+    if (!completedImages || completedImages.length === 0) {
+        throw new Error('No image data returned from OpenAI');
+    }
+
+    return completedImages;
+}
+
+function drainEventStreamBlocks(buffer: string, onBlock: (block: string) => void) {
+    let remaining = buffer;
+
+    while (true) {
+        const separator = remaining.match(/\r?\n\r?\n/);
+        if (!separator || separator.index === undefined) {
+            return remaining;
+        }
+
+        const block = remaining.slice(0, separator.index);
+        remaining = remaining.slice(separator.index + separator[0].length);
+        if (block.trim()) {
+            onBlock(block);
+        }
+    }
+}
+
+function parseOpenAiImageEventBlock(
+    block: string,
+    onPartialImage: ((partial: OpenAiImageResponse) => void) | undefined,
+): OpenAiImageResponse[] | null {
+    const event = parseServerSentEvent(block);
+    if (!event.data || event.data === '[DONE]') {
+        return null;
+    }
+
+    const payload = parseJsonRecord(event.data);
+    if (!payload) {
+        return null;
+    }
+
+    const eventType = [
+        event.name,
+        typeof payload.type === 'string' ? payload.type : '',
+        typeof payload.event === 'string' ? payload.event : '',
+    ].join(' ').toLowerCase();
+
+    if (eventType.includes('partial_image')) {
+        const b64Json = extractImageB64Json(payload);
+        if (b64Json && onPartialImage) {
+            try {
+                onPartialImage({ b64_json: b64Json });
+            } catch {
+                // Partial previews are opportunistic; the final generation should still resolve.
+            }
+        }
+        return null;
+    }
+
+    const images = extractImageResponses(payload);
+    if (images.length > 0 && (eventType.includes('completed') || eventType.includes('complete') || !event.name)) {
+        return images;
+    }
+
+    return null;
+}
+
+function parseServerSentEvent(block: string) {
+    const dataLines: string[] = [];
+    let name = '';
+
+    block.split(/\r?\n/).forEach((line) => {
+        if (line.startsWith('event:')) {
+            name = line.slice('event:'.length).trim();
+            return;
+        }
+
+        if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).trimStart());
+        }
+    });
+
+    return {
+        name,
+        data: dataLines.join('\n').trim(),
+    };
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+    try {
+        const parsed: unknown = JSON.parse(value);
+        return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+            ? parsed as Record<string, unknown>
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function extractImageResponses(value: unknown): OpenAiImageResponse[] {
+    if (typeof value !== 'object' || value === null) {
+        return [];
+    }
+
+    const record = value as Record<string, unknown>;
+    if (Array.isArray(record.data)) {
+        return record.data.flatMap(extractImageResponses);
+    }
+
+    const b64Json = extractImageB64Json(record);
+    return b64Json ? [{ b64_json: b64Json }] : [];
+}
+
+function extractImageB64Json(value: unknown): string | null {
+    if (Array.isArray(value)) {
+        return value.map(extractImageB64Json).find((item): item is string => Boolean(item)) ?? null;
+    }
+
+    if (typeof value !== 'object' || value === null) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const key of ['b64_json', 'partial_image_b64', 'image_b64', 'b64']) {
+        if (typeof record[key] === 'string') {
+            return record[key] as string;
+        }
+    }
+
+    return extractImageB64Json(record.partial_image)
+        ?? extractImageB64Json(record.image)
+        ?? extractImageB64Json(record.data);
 }
 
 function coerceOpenAiBatchSize(value: unknown): number {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -23,6 +23,9 @@ export interface OpenAiImageRequest {
 
 export interface OpenAiImageResponse {
     b64_json?: string;
+    revised_prompt?: string;
+    size?: string;
+    quality?: string;
 }
 
 export interface OpenAiResponsesRequest {
@@ -123,13 +126,21 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         throw new Error(errorData.error?.message || `OpenAI API Error: ${response.status}`);
     }
 
-    const data: { data?: OpenAiImageResponse[] } = await response.json();
+    const data: {
+        data?: OpenAiImageResponse[];
+        size?: string;
+        quality?: string;
+    } = await response.json();
 
     if (!data.data || data.data.length === 0) {
         throw new Error('No image data returned from OpenAI');
     }
 
-    return data.data;
+    return data.data.map((image) => ({
+        ...image,
+        ...(image.size === undefined && data.size !== undefined ? { size: data.size } : {}),
+        ...(image.quality === undefined && data.quality !== undefined ? { quality: data.quality } : {}),
+    }));
 }
 
 function coerceOpenAiBatchSize(value: unknown): number {

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -23,6 +23,7 @@ export interface OpenAiImageRequest {
 
 export interface OpenAiImageResponse {
     b64_json?: string;
+    error?: string;
 }
 
 export interface OpenAiResponsesRequest {

--- a/src/utils/openaiModels.ts
+++ b/src/utils/openaiModels.ts
@@ -24,6 +24,7 @@ export interface ImageModelConfig {
     parameters: Partial<Record<'size' | 'quality' | 'background' | 'aspectRatio' | 'imageSize', string>>;
     capabilities: {
         transformMask: boolean;
+        partialImageStreaming: boolean;
     };
 }
 
@@ -52,6 +53,7 @@ export const IMAGE_MODEL_REGISTRY = {
         },
         capabilities: {
             transformMask: true,
+            partialImageStreaming: true,
         },
     },
     [NANO_BANANA_PRO_IMAGE_MODEL]: {
@@ -69,6 +71,7 @@ export const IMAGE_MODEL_REGISTRY = {
         },
         capabilities: {
             transformMask: false,
+            partialImageStreaming: false,
         },
     },
 } as const satisfies Record<string, ImageModelConfig>;

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -12,14 +12,16 @@ import { getImageModelReferenceLimitMessage, getImageModelUiChoices, imageModelS
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { renderAiTransformEditInput } from '../editor/aiTransform';
 import { classifyTransformMaskCoverage } from '../editor/transformMask';
+import type { EditorReplay } from '../lineage/replayLineageStep';
 
 interface EditorViewProps {
     image: ArchiveImage | null;
+    replay?: EditorReplay | null;
     getProviderKey: (provider: Provider) => string | null;
     onSave: (updatedUrl: string, context: EditorSaveContext) => void;
 }
 
-const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }) => {
+const EditorView: React.FC<EditorViewProps> = ({ image, replay, getProviderKey, onSave }) => {
     const defaultModel = image && isImageModelSlug(image.model) ? image.model : OPENAI_IMAGE_MODEL;
     const [aiEditModel, setAiEditModel] = useState<ImageModelSlug>(defaultModel);
     const [adjustmentsOpen, setAdjustmentsOpen] = useState(true);
@@ -110,6 +112,20 @@ const EditorView: React.FC<EditorViewProps> = ({ image, getProviderKey, onSave }
         onSave,
     });
     const aiReferenceWarning = getImageModelReferenceLimitMessage(aiEditModel, referenceImages.length, 'AI transforms');
+
+    useEffect(() => {
+        if (!replay) {
+            return;
+        }
+
+        if (replay.model) {
+            setAiEditModel(replay.model);
+        }
+        if (replay.prompt) {
+            setAiPrompt(replay.prompt);
+        }
+        setTransformMaskFile(replay.maskImage ?? null);
+    }, [replay, setAiPrompt]);
 
     useEffect(() => {
         if (!supportsTransformMask) {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
-import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X } from 'lucide-react';
+import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X, ImagePlus } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
-import { getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
-import { useGenerateController } from '../generate-session/useGenerateController';
+import { generateSessionStore, getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
+import { addGeneratedResultAsReference, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
@@ -17,6 +17,7 @@ import {
     buildImageModelGenerateReferenceRunPlan,
     coerceImageModelControlValue,
     getImageModelGenerateControls,
+    getImageModelReferenceCapacityMessage,
     getImageModelUiChoices,
     type ImageModelControlId,
 } from '../image-models/ImageModelControls';
@@ -321,6 +322,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const maxApiCalls = maxIterations * 3;
     const isAutopilotMode = mode === 'autopilot';
     const imageModelReferenceWarning = referenceRunPlan.referenceLimitMessage;
+    const resultReferenceCapacityMessage = getImageModelReferenceCapacityMessage(model, referenceImages.length, 'generation');
     const activeModelDraftKey = getImageModelDraftKey(model);
     const activeModelControls = draft[activeModelDraftKey] as Record<string, string | number>;
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
@@ -333,6 +335,23 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                 [controlId]: coerceImageModelControlValue(model, controlId, value),
             },
         } as Partial<GenerateDraft>);
+    };
+
+    const handleUseResultAsReference = (result: Extract<GenerateResultSlot, { status: 'success' }>) => {
+        if (resultReferenceCapacityMessage) {
+            return;
+        }
+
+        try {
+            addGeneratedResultAsReference({
+                slot: result,
+                addReferenceFiles,
+                session: generateSessionStore,
+            });
+            setAutopilotNotice(null);
+        } catch (referenceError) {
+            setAutopilotNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
+        }
     };
 
 
@@ -647,6 +666,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                         <div className="error-message">{activeReasoningModel.label} API key missing. Go to Settings to configure.</div>
                     )}
                     {imageModelReferenceWarning && <div className="info-message">{imageModelReferenceWarning}</div>}
+                    {resultReferenceCapacityMessage && successfulBatchResults.length > 0 && <div className="info-message">{resultReferenceCapacityMessage}</div>}
                     {error && <div className="error-message">{error}</div>}
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
@@ -675,6 +695,14 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                                     </button>
                                                     <button className="btn-ghost" onClick={() => downloadResult(result.slotIndex)}>
                                                         <Download size={16} /> Download
+                                                    </button>
+                                                    <button
+                                                        className="btn-ghost"
+                                                        onClick={() => handleUseResultAsReference(result)}
+                                                        disabled={!!resultReferenceCapacityMessage}
+                                                        title={resultReferenceCapacityMessage ?? 'Use this result as a reference image'}
+                                                    >
+                                                        <ImagePlus size={16} /> Use as Reference
                                                     </button>
                                                 </div>
                                             </>
@@ -719,6 +747,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                 <button className="btn-ghost" onClick={download}>
                                     <Download size={18} /> Download
                                 </button>
+                                {singleResultSlot && (
+                                    <button
+                                        className="btn-ghost"
+                                        onClick={() => handleUseResultAsReference(singleResultSlot)}
+                                        disabled={!!resultReferenceCapacityMessage}
+                                        title={resultReferenceCapacityMessage ?? 'Use this result as a reference image'}
+                                    >
+                                        <ImagePlus size={18} /> Use as Reference
+                                    </button>
+                                )}
                                 <button onClick={() => { void clear(); }} className="btn-ghost">
                                     <Trash2 size={18} />
                                 </button>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useRef, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X, ImagePlus } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { generateSessionStore, getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
-import { addGeneratedResultAsReference, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
+import { addGeneratedResultAsReferenceFromAction, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
@@ -338,20 +338,13 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     };
 
     const handleUseResultAsReference = (result: Extract<GenerateResultSlot, { status: 'success' }>) => {
-        if (resultReferenceCapacityMessage) {
-            return;
-        }
-
-        try {
-            addGeneratedResultAsReference({
-                slot: result,
-                addReferenceFiles,
-                session: generateSessionStore,
-            });
-            setAutopilotNotice(null);
-        } catch (referenceError) {
-            setAutopilotNotice(referenceError instanceof Error ? referenceError.message : 'Failed to use result as reference.');
-        }
+        addGeneratedResultAsReferenceFromAction({
+            slot: result,
+            addReferenceFiles,
+            session: generateSessionStore,
+            capacityMessage: resultReferenceCapacityMessage,
+            setNotice: setAutopilotNotice,
+        });
     };
 
 

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -6,7 +6,13 @@ import { useGenerateController } from '../generate-session/useGenerateController
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
+import ActualParametersPanel from '../components/ActualParametersPanel';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import {
+    buildActualParameterDetails,
+    getRequestedGenerateParameters,
+    hasActualParameterDetails,
+} from '../generate-session/actualParameters';
 import { DEFAULT_AUTOPILOT_MAX_ITERATIONS, DEFAULT_AUTOPILOT_SATISFACTION_THRESHOLD, MAX_AUTOPILOT_ITERATIONS } from '../autopilot/AutopilotSession';
 import { createGoalPromptTranslator } from '../autopilot/GoalPromptTranslator';
 import { createPromptRefiner } from '../autopilot/PromptRefiner';
@@ -201,6 +207,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const {
         currentResult,
         currentBatchResults,
+        currentRunDraft,
         loading,
         error,
         autopilot,
@@ -326,6 +333,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
     const showBatchGrid = currentBatchResults.length > 1 || currentBatchResults.some((result) => result.status === 'failed');
     const singleResultSlot = !showBatchGrid ? successfulBatchResults[0] : null;
+    const requestedParameters = getRequestedGenerateParameters(currentRunDraft ?? draft);
+    const singleResultActualDetails = singleResultSlot
+        ? buildActualParameterDetails({
+            actualParameters: singleResultSlot.actualParameters,
+            requestedParameters,
+        })
+        : null;
+    const hasSingleResultActualDetails = singleResultActualDetails
+        ? hasActualParameterDetails(singleResultActualDetails)
+        : false;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
         updateDraft({
             [activeModelDraftKey]: {
@@ -665,6 +682,13 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                         {result.status === 'success' ? (
                                             <>
                                                 <img src={result.imageUrl} alt={`Generated result ${result.slotIndex + 1}`} className="result-slot-image" />
+                                                <ActualParametersPanel
+                                                    compact
+                                                    details={buildActualParameterDetails({
+                                                        actualParameters: result.actualParameters,
+                                                        requestedParameters,
+                                                    })}
+                                                />
                                                 <div className="result-slot-actions">
                                                     <button
                                                         onClick={() => { void saveResult(result.slotIndex); }}
@@ -692,8 +716,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                             </button>
                         </div>
                     ) : currentResult ? (
-                        <div className="result-container">
+                        <div className={`result-container${hasSingleResultActualDetails ? ' has-actual-parameters' : ''}`}>
                             <img src={currentResult} alt="Generated result" className="result-image" />
+                            {singleResultActualDetails && (
+                                <ActualParametersPanel details={singleResultActualDetails} />
+                            )}
                             {isAutopilotMode && autopilot.iterations.length > 0 && (
                                 <div className="autopilot-result-banner glass-panel">
                                     <strong>

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -200,6 +200,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const removeReferenceAt = referenceCollection.removeAt;
     const {
         currentResult,
+        currentPartialResult,
         currentBatchResults,
         loading,
         error,
@@ -651,8 +652,17 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                     {autopilotNotice && <div className="info-message">{autopilotNotice}</div>}
                 </section>
 
-                <section className={`preview-panel glass-panel${showBatchGrid ? ' batch-preview-panel' : ''}`}>
-                    {showBatchGrid ? (
+                <section className={`preview-panel glass-panel${showBatchGrid && !currentPartialResult ? ' batch-preview-panel' : ''}`}>
+                    {currentPartialResult ? (
+                        <div className="result-container partial-result-container">
+                            <img src={currentPartialResult} alt="In-progress generation preview" className="result-image partial-result-image" />
+                            <div className="partial-result-banner glass-panel">
+                                <Loader2 className="spin" size={18} />
+                                <strong>Generating preview</strong>
+                                <span>Final result is still rendering.</span>
+                            </div>
+                        </div>
+                    ) : showBatchGrid ? (
                         <div className="result-batch-container">
                             <div className="result-batch-grid">
                                 {currentBatchResults.map((result) => (

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -210,6 +210,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
         cancelAutopilot,
         save,
         saveResult,
+        saveAllResults,
         download,
         downloadResult,
         clear,
@@ -324,6 +325,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const activeModelDraftKey = getImageModelDraftKey(model);
     const activeModelControls = draft[activeModelDraftKey] as Record<string, string | number>;
     const successfulBatchResults = currentBatchResults.filter((result) => result.status === 'success');
+    const hasUnsavedSuccessfulBatchResults = successfulBatchResults.some((result) => !result.isSaved);
     const showBatchGrid = currentBatchResults.length > 1 || currentBatchResults.some((result) => result.status === 'failed');
     const singleResultSlot = !showBatchGrid ? successfulBatchResults[0] : null;
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
@@ -687,9 +689,18 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                     </div>
                                 ))}
                             </div>
-                            <button onClick={() => { void clear(); }} className="btn-ghost result-batch-clear">
-                                <Trash2 size={18} /> Clear Results
-                            </button>
+                            <div className="result-batch-actions">
+                                <button
+                                    onClick={() => { void saveAllResults(); }}
+                                    className="btn-amber"
+                                    disabled={!hasUnsavedSuccessfulBatchResults}
+                                >
+                                    <Archive size={18} /> Save All
+                                </button>
+                                <button onClick={() => { void clear(); }} className="btn-ghost result-batch-clear">
+                                    <Trash2 size={18} /> Clear Results
+                                </button>
+                            </div>
                         </div>
                     ) : currentResult ? (
                         <div className="result-container">


### PR DESCRIPTION
## Summary

Integrates the remaining generation workflow slices from PRs #85-#90 in the validated merge order:

- #85 / #75: batch result persistence and save-all behavior
- #87 / #76: Nano Banana batch fan-out
- #89 / #77: streaming partial previews
- #90 / #78: actual generation parameters
- #88 / #79: use generated results as reference images
- #86 / #80: transform mask lineage replay

This PR preserves the conflict resolutions across the overlapping controller, workflow, archive, lineage, and UI files.

Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80

Supersedes #85
Supersedes #86
Supersedes #87
Supersedes #88
Supersedes #89
Supersedes #90

## Validation

- pnpm vitest run src/generate-session/GenerateSession.test.ts src/generate-session/useGenerateController.test.ts src/image-workflow/ImageWorkflow.test.ts src/utils/openai.test.ts src/archive/ArchiveStore.test.ts src/archive/ArchiveManifest.test.ts src/archive/ArchiveTransfer.test.ts src/archive/recoverArchiveMetadata.test.ts src/generate-session/saveGeneratedImage.test.ts src/image-models/ImageModelControls.test.ts src/editor/saveEditedImage.test.ts src/editor/useEditorController.test.ts src/lineage/LineageNavigator.test.ts src/lineage/replayLineageStep.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- pnpm run build