### PR TITLE
Add image cost ledger and archive lineage tracking

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,5 @@
+# todo
+
+- remove background from image or from layer in editor 
+- transparent color (or color range) picker (to declare transparent color in layer)
+- add text to image

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,13 +36,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -61,21 +61,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,14 +92,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -109,14 +109,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -136,29 +136,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -208,27 +208,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -270,33 +270,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -304,14 +304,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1812,15 +1812,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1829,13 +1829,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1869,13 +1869,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1884,13 +1884,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1912,13 +1912,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2007,13 +2007,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2028,9 +2031,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2048,11 +2051,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2082,9 +2085,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001761",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
-      "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2258,9 +2261,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2834,10 +2837,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3038,9 +3051,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "devOptional": true,
       "funding": [
         {
@@ -3064,11 +3077,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3197,9 +3213,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "devOptional": true,
       "funding": [
         {
@@ -3217,7 +3233,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3763,13 +3779,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -3861,20 +3877,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3904,8 +3920,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -3977,9 +3993,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/src/archive/ArchiveManifest.test.ts
+++ b/src/archive/ArchiveManifest.test.ts
@@ -71,6 +71,36 @@ describe('ArchiveManifest', () => {
         ]);
     });
 
+    it('preserves cost ledger metadata while keeping legacy images compatible by omission', () => {
+        const costLedger = {
+            version: 1 as const,
+            currency: 'USD' as const,
+            items: [{
+                id: 'image-generation:openai:gpt-image-2',
+                kind: 'image-generation' as const,
+                operation: 'image-generation',
+                provider: 'openai',
+                model: 'gpt-image-2',
+                label: 'Image generation 1',
+                status: 'calculated' as const,
+                currency: 'USD' as const,
+                amountUsd: 0.04,
+            }],
+        };
+        const manifest = parseArchiveManifest({
+            version: ARCHIVE_MANIFEST_VERSION,
+            images: [
+                createManifestImage({ id: 'cost-image', costLedger }),
+                createManifestImage({ id: 'legacy-image' }),
+            ],
+        });
+
+        expect(manifest.images).toEqual([
+            expect.objectContaining({ id: 'cost-image', costLedger }),
+            expect.not.objectContaining({ id: 'legacy-image', costLedger: expect.anything() }),
+        ]);
+    });
+
     it('rejects malformed layer stack entries', () => {
         expect(() => parseArchiveManifest({
             version: ARCHIVE_MANIFEST_VERSION,

--- a/src/archive/ArchiveManifest.ts
+++ b/src/archive/ArchiveManifest.ts
@@ -1,6 +1,7 @@
-import { isLayerBlendMode, type ActualImageParameters, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
+import { isLayerBlendMode, type ActualImageParameters, type ApiCostLedger, type ArchiveLayer, type ArchiveLayerBlendMode, type ArchiveLayerKind, type ArchiveLayerStack } from '../db/types';
 import { parseLineageMetadata } from '../lineage/lineageMetadata';
 import type { LineageStep } from '../lineage/types';
+import { sanitizeApiCostLedger } from '../costs/apiCost';
 
 export const ARCHIVE_MANIFEST_FILE = 'archive-manifest.json';
 export const LINEAGE_MANIFEST_FILE = 'lineage-manifest.json';
@@ -26,6 +27,7 @@ export interface ArchiveManifestImage {
     lighting?: string;
     palette?: string;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     imageFileName?: string;
     references: ArchiveManifestReference[];
     layerStack?: ArchiveManifestLayerStack;
@@ -162,6 +164,7 @@ function parseArchiveManifestImage(value: unknown): ArchiveManifestImage {
         lighting: optionalString(value.lighting),
         palette: optionalString(value.palette),
         actualParameters: optionalActualParameters(value.actualParameters),
+        costLedger: sanitizeApiCostLedger(value.costLedger),
         imageFileName: optionalString(value.imageFileName),
         references: Array.isArray(value.references) ? value.references.map(parseArchiveManifestReference) : [],
         layerStack: parseOptionalLayerStack(value.layerStack),

--- a/src/archive/ArchiveStore.test.ts
+++ b/src/archive/ArchiveStore.test.ts
@@ -271,6 +271,54 @@ describe('ArchiveStore layer asset ownership', () => {
         ]));
     });
 
+    it('persists cost ledger metadata and treats legacy metadata as absent', async () => {
+        const { store, metadata } = createStore();
+        const costLedger = {
+            version: 1 as const,
+            currency: 'USD' as const,
+            items: [{
+                id: 'image-generation:openai:gpt-image-2',
+                kind: 'image-generation' as const,
+                operation: 'image-generation',
+                provider: 'openai',
+                model: 'gpt-image-2',
+                label: 'Image generation 1',
+                status: 'calculated' as const,
+                currency: 'USD' as const,
+                amountUsd: 0.04,
+            }],
+        };
+
+        await store.save(createImageInput({
+            id: 'cost-image',
+            costLedger,
+        }));
+        metadata.records.set('legacy-image', {
+            id: 'legacy-image',
+            storedUrl: 'data:image/png;base64,legacy',
+            prompt: 'legacy prompt',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            timestamp: '2026-06-05T08:00:00.000Z',
+            width: 1024,
+            height: 1024,
+            referenceIds: [],
+        });
+
+        expect(metadata.records.get('cost-image')?.costLedger).toEqual(costLedger);
+        await expect(store.list()).resolves.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'cost-image',
+                costLedger,
+            }),
+            expect.not.objectContaining({
+                id: 'legacy-image',
+                costLedger: expect.anything(),
+            }),
+        ]));
+    });
+
     it('recovers orphaned image blobs when metadata is missing', async () => {
         const { store, metadata, blobs } = createStore();
         blobs.blobs.set('img_orphaned-image', 'data:image/png;base64,orphaned');
@@ -323,6 +371,7 @@ function createImageInput(overrides: Partial<ArchiveImage> = {}) {
         favorite: overrides.favorite,
         references: overrides.references,
         actualParameters: overrides.actualParameters,
+        costLedger: overrides.costLedger,
         layerStack: overrides.layerStack,
     };
 }

--- a/src/archive/ArchiveStore.ts
+++ b/src/archive/ArchiveStore.ts
@@ -135,6 +135,7 @@ class LocalArchiveStore implements ArchiveStore {
                 lighting: input.lighting,
                 palette: input.palette,
                 actualParameters: input.actualParameters,
+                costLedger: input.costLedger,
                 referenceIds,
                 layerStack: durableLayerStack,
             });
@@ -161,6 +162,7 @@ class LocalArchiveStore implements ArchiveStore {
             lighting: input.lighting,
             palette: input.palette,
             actualParameters: input.actualParameters,
+            costLedger: input.costLedger,
             layerStack: input.layerStack,
         };
     }
@@ -218,6 +220,7 @@ class LocalArchiveStore implements ArchiveStore {
             lighting: record.lighting,
             palette: record.palette,
             actualParameters: record.actualParameters,
+            costLedger: record.costLedger,
             layerStack,
         };
     }

--- a/src/archive/ArchiveTransfer.ts
+++ b/src/archive/ArchiveTransfer.ts
@@ -72,6 +72,7 @@ export async function buildArchiveZip(images: ArchiveImage[], deps: BuildArchive
             lighting: image.lighting,
             palette: image.palette,
             actualParameters: image.actualParameters,
+            costLedger: image.costLedger,
             imageFileName,
             references,
             layerStack,
@@ -132,6 +133,7 @@ export async function importArchiveZip(zipInput: Blob | Uint8Array | ArrayBuffer
             lighting: image.lighting,
             palette: image.palette,
             actualParameters: image.actualParameters,
+            costLedger: image.costLedger,
             references,
             layerStack,
         });

--- a/src/archive/SQLiteArchiveMetadataPort.ts
+++ b/src/archive/SQLiteArchiveMetadataPort.ts
@@ -2,12 +2,14 @@ import { SQLocal } from 'sqlocal';
 import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { createDurableLayerStackMetadata } from './ArchiveAssets';
+import { sanitizeApiCostLedger } from '../costs/apiCost';
 
 type ArchiveImageRow = ArchiveImage & {
     favorite?: number | null;
     ref_ids?: string;
     layer_stack?: string;
     actual_parameters?: string | null;
+    cost_ledger?: string | null;
 };
 
 type ArchiveMetadataRecord = Omit<ArchiveImage, 'url' | 'references'> & {
@@ -52,6 +54,7 @@ export class SQLiteArchiveMetadataPort {
         await this.sql.sql`ALTER TABLE images ADD COLUMN layer_stack TEXT`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN favorite INTEGER`.catch(() => null);
         await this.sql.sql`ALTER TABLE images ADD COLUMN actual_parameters TEXT`.catch(() => null);
+        await this.sql.sql`ALTER TABLE images ADD COLUMN cost_ledger TEXT`.catch(() => null);
 
         this.initialized = true;
     }
@@ -60,7 +63,7 @@ export class SQLiteArchiveMetadataPort {
         await this.init();
 
         await this.sql.sql`
-            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack, actual_parameters)
+            INSERT OR REPLACE INTO images (id, url, prompt, quality, aspectRatio, background, timestamp, model, width, height, favorite, ref_ids, style, lighting, palette, layer_stack, actual_parameters, cost_ledger)
             VALUES (
                 ${record.id},
                 ${record.storedUrl},
@@ -78,7 +81,8 @@ export class SQLiteArchiveMetadataPort {
                 ${record.lighting || null},
                 ${record.palette || null},
                 ${record.layerStack ? JSON.stringify(createDurableLayerStackMetadata(record.layerStack)) : null},
-                ${record.actualParameters ? JSON.stringify(record.actualParameters) : null}
+                ${record.actualParameters ? JSON.stringify(record.actualParameters) : null},
+                ${record.costLedger ? JSON.stringify(record.costLedger) : null}
             )
         `;
     }
@@ -104,6 +108,7 @@ export class SQLiteArchiveMetadataPort {
             lighting: image.lighting,
             palette: image.palette,
             actualParameters: parseActualParameters(image.actual_parameters),
+            costLedger: parseCostLedger(image.cost_ledger),
             referenceIds: parseReferenceIds(image.ref_ids),
             layerStack: parseLayerStack(image.layer_stack),
         }));
@@ -134,6 +139,7 @@ export class SQLiteArchiveMetadataPort {
             lighting: row.lighting,
             palette: row.palette,
             actualParameters: parseActualParameters(row.actual_parameters),
+            costLedger: parseCostLedger(row.cost_ledger),
             referenceIds: parseReferenceIds(row.ref_ids),
             layerStack: parseLayerStack(row.layer_stack),
         };
@@ -154,6 +160,18 @@ const parseReferenceIds = (value?: string): number[] => {
         return JSON.parse(value) as number[];
     } catch {
         return [];
+    }
+};
+
+const parseCostLedger = (value?: string | null): ArchiveImage['costLedger'] | undefined => {
+    if (!value) {
+        return undefined;
+    }
+
+    try {
+        return sanitizeApiCostLedger(JSON.parse(value) as unknown);
+    } catch {
+        return undefined;
     }
 };
 

--- a/src/archive/recoverArchiveMetadata.ts
+++ b/src/archive/recoverArchiveMetadata.ts
@@ -1,5 +1,5 @@
 import { archiveMetadataPort } from '../db/AuraPersistence';
-import type { ActualImageParameters, ArchiveLayerStack } from '../db/types';
+import type { ActualImageParameters, ApiCostLedger, ArchiveLayerStack } from '../db/types';
 import { lineageStore, type LineageStore } from '../lineage/LineageStore';
 import { storage, type StorageProvider } from '../services/StorageService';
 import { getArchiveImageBlobKey } from './ArchiveAssets';
@@ -26,6 +26,7 @@ interface ArchiveMetadataRecord {
     lighting?: string;
     palette?: string;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     referenceIds: number[];
     layerStack?: ArchiveLayerStack;
 }
@@ -82,6 +83,7 @@ export async function recoverArchiveMetadataFromManifests(
             lighting: image.lighting,
             palette: image.palette,
             actualParameters: image.actualParameters,
+            costLedger: image.costLedger,
             referenceIds: image.references.map((_, index) => index),
             layerStack: image.layerStack ? createLayerStackMetadata(image.layerStack) : undefined,
         });

--- a/src/autopilot/AutopilotSession.test.ts
+++ b/src/autopilot/AutopilotSession.test.ts
@@ -4,6 +4,7 @@ import type { LineageMetadataPort, LineageStep } from '../lineage/LineageStore';
 import { createLineageStore, type LineageStore } from '../lineage/LineageStore';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
 import { GEMINI_FLASH_REASONING_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
+import type { ApiCostLedger, ApiCostLineItem } from '../db/types';
 
 class InMemoryLineageMetadataPort implements LineageMetadataPort {
     private readonly steps = new Map<string, LineageStep>();
@@ -172,6 +173,45 @@ describe('AutopilotSession', () => {
         }));
     });
 
+    it('includes initial reasoning costs in the final best iteration total', async () => {
+        const lineage = createStore();
+        const initialCostLedger = createCostLedger(createCostItem('goal-translation', 0.00055));
+        const imageCostLedger = createCostLedger(createCostItem('image-generation', 0.04));
+        const evaluationCostLedger = createCostLedger(createCostItem('satisfaction-evaluation', 0.005275));
+
+        const result = await createAutopilotSession({
+            goal: 'A cinematic portrait',
+            initialPrompt: 'prompt 1',
+            settings: createSettings(),
+            apiKey: 'key',
+            maxIterations: 1,
+            satisfactionThreshold: 90,
+            initialCostLedger,
+            generate: vi.fn().mockResolvedValueOnce({
+                imageDataUrl: 'data:image/png;base64,one',
+                costLedger: imageCostLedger,
+            }),
+            evaluate: vi.fn().mockResolvedValueOnce({
+                score: 95,
+                feedback: ['Strong match.'],
+                costLedger: evaluationCostLedger,
+            }),
+            refine: vi.fn(),
+            lineageStore: lineage,
+        }).run();
+
+        expect(result.bestIteration?.costLedger?.items.map((item) => item.id)).toEqual([
+            'goal-translation',
+            'image-generation',
+            'satisfaction-evaluation',
+        ]);
+        expect(result.bestIteration?.costLedger?.items.reduce((sum, item) => sum + (item.amountUsd ?? 0), 0)).toBeCloseTo(0.045825);
+        expect(result.iterations[0]?.costLedger?.items.map((item) => item.id)).toEqual([
+            'image-generation',
+            'satisfaction-evaluation',
+        ]);
+    });
+
     it('freezes the Reference image snapshot for every iteration', async () => {
         const lineage = createStore();
         const firstReference = new File(['reference-0'], 'ref-0.png', { type: 'image/png' });
@@ -315,5 +355,27 @@ function createSettings(
         palette: 'copper + teal + cream',
         referenceImages: [],
         ...overrides,
+    };
+}
+
+function createCostLedger(item: ApiCostLineItem): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [item],
+    };
+}
+
+function createCostItem(id: string, amountUsd: number): ApiCostLineItem {
+    return {
+        id,
+        kind: id === 'image-generation' ? 'image-generation' : 'reasoning',
+        operation: id,
+        provider: id === 'image-generation' ? 'openai' : 'openai',
+        model: id === 'image-generation' ? 'gpt-image-2' : 'gpt-5.4',
+        label: id,
+        status: 'calculated',
+        currency: 'USD',
+        amountUsd,
     };
 }

--- a/src/autopilot/AutopilotSession.ts
+++ b/src/autopilot/AutopilotSession.ts
@@ -1,10 +1,11 @@
 import { promptRefiner } from './PromptRefiner';
 import { satisfactionEvaluator } from './SatisfactionEvaluator';
 import type { LineageStore } from '../lineage/LineageStore';
-import type { ActualImageParameters } from '../db/types';
+import type { ActualImageParameters, ApiCostLedger } from '../db/types';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
 import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { buildAutopilotLineageMetadata } from '../lineage/autopilotLineageMetadata';
+import { mergeApiCostLedgers } from '../costs/apiCost';
 
 export const DEFAULT_AUTOPILOT_MAX_ITERATIONS = 4;
 export const MAX_AUTOPILOT_ITERATIONS = 8;
@@ -17,6 +18,7 @@ export interface AutopilotIteration {
     prompt: string;
     imageDataUrl: string;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     score: number;
     feedback: string[];
 }
@@ -24,6 +26,7 @@ export interface AutopilotIteration {
 export interface AutopilotGeneratedImage {
     imageDataUrl: string;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
 }
 
 export interface AutopilotSessionResult {
@@ -51,11 +54,12 @@ interface CreateAutopilotSessionInput {
     reasoningApiKey?: string;
     reasoningModel?: string;
     initialParentStepId?: string | null;
+    initialCostLedger?: ApiCostLedger;
     maxIterations?: number;
     satisfactionThreshold?: number;
     generate?: (input: GenerateImageInput) => Promise<string | AutopilotGeneratedImage>;
-    evaluate?: (input: { imageDataUrl: string; goal: string; apiKey: string }) => Promise<{ score: number; feedback: string[] }>;
-    refine?: (input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }) => Promise<string>;
+    evaluate?: (input: { imageDataUrl: string; goal: string; apiKey: string }) => Promise<{ score: number; feedback: string[]; costLedger?: ApiCostLedger }>;
+    refine?: (input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }) => Promise<string | { prompt: string; costLedger?: ApiCostLedger }>;
     lineageStore: Pick<LineageStore, 'save'>;
     callbacks?: ProgressCallbacks;
     makeRunId?: () => string;
@@ -86,6 +90,7 @@ class DefaultAutopilotSession implements AutopilotSession {
         let currentPrompt = this.input.initialPrompt;
         let parentStepId = this.input.initialParentStepId ?? null;
         let runningBest: AutopilotIteration | null = null;
+        let runCostLedger = this.input.initialCostLedger;
 
         for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
             try {
@@ -102,6 +107,11 @@ class DefaultAutopilotSession implements AutopilotSession {
                     goal: this.input.goal,
                     apiKey: reasoningApiKey,
                 });
+                const iterationCostLedger = mergeApiCostLedgers(
+                    generatedImage.costLedger,
+                    evaluation.costLedger,
+                );
+                runCostLedger = mergeApiCostLedgers(runCostLedger, iterationCostLedger);
 
                 const archiveImageId = `autopilot:${runId}:iteration:${iterationNumber}`;
                 const step = await this.input.lineageStore.save({
@@ -117,6 +127,8 @@ class DefaultAutopilotSession implements AutopilotSession {
                         prompt: currentPrompt,
                         settings: snapshotAutopilotSettings(runSettings),
                         outputImageDataUrl: imageDataUrl,
+                        actualParameters: generatedImage.actualParameters,
+                        costLedger: iterationCostLedger,
                     }),
                 });
 
@@ -127,6 +139,7 @@ class DefaultAutopilotSession implements AutopilotSession {
                     prompt: currentPrompt,
                     imageDataUrl,
                     actualParameters: generatedImage.actualParameters,
+                    costLedger: iterationCostLedger,
                     score: evaluation.score,
                     feedback: evaluation.feedback,
                 };
@@ -137,39 +150,50 @@ class DefaultAutopilotSession implements AutopilotSession {
                 parentStepId = step.id;
 
                 if (evaluation.score >= satisfactionThreshold) {
-                    return buildResult('satisfied', iterations, null);
+                    return buildResult('satisfied', iterations, null, runCostLedger);
                 }
 
                 if (this.cancelled) {
-                    return buildResult('cancelled', iterations, null);
+                    return buildResult('cancelled', iterations, null, runCostLedger);
                 }
 
                 if (iterationNumber === maxIterations) {
-                    return buildResult('max-iterations', iterations, null);
+                    return buildResult('max-iterations', iterations, null, runCostLedger);
                 }
 
-                currentPrompt = await refine({
+                const refinement = normalizePromptRefinement(await refine({
                     goal: this.input.goal,
                     currentPrompt,
                     feedback: evaluation.feedback,
                     apiKey: reasoningApiKey,
-                });
+                }));
+                runCostLedger = mergeApiCostLedgers(runCostLedger, refinement.costLedger);
+                currentPrompt = refinement.prompt;
             } catch (error) {
                 const normalizedError = error instanceof Error ? error : new Error('Autopilot run failed');
                 this.input.callbacks?.onError?.(normalizedError, iterationNumber);
-                return buildResult('failed', iterations, normalizedError);
+                return buildResult('failed', iterations, normalizedError, runCostLedger);
             }
         }
 
-        return buildResult('max-iterations', iterations, null);
+        return buildResult('max-iterations', iterations, null, runCostLedger);
     }
 }
 
-function buildResult(status: AutopilotSessionResult['status'], iterations: AutopilotIteration[], error: Error | null): AutopilotSessionResult {
+function buildResult(
+    status: AutopilotSessionResult['status'],
+    iterations: AutopilotIteration[],
+    error: Error | null,
+    runCostLedger?: ApiCostLedger,
+): AutopilotSessionResult {
+    const bestIteration = getBestIteration(iterations);
+
     return {
         status,
         iterations,
-        bestIteration: getBestIteration(iterations),
+        bestIteration: bestIteration && runCostLedger
+            ? { ...bestIteration, costLedger: runCostLedger }
+            : bestIteration,
         error,
     };
 }
@@ -213,12 +237,19 @@ async function generateSingleImage(input: GenerateImageInput): Promise<Autopilot
     return {
         imageDataUrl: result.imageUrl,
         actualParameters: result.actualParameters,
+        costLedger: result.costLedger,
     };
 }
 
 function normalizeAutopilotGeneratedImage(result: string | AutopilotGeneratedImage): AutopilotGeneratedImage {
     return typeof result === 'string'
         ? { imageDataUrl: result }
+        : result;
+}
+
+function normalizePromptRefinement(result: string | { prompt: string; costLedger?: ApiCostLedger }) {
+    return typeof result === 'string'
+        ? { prompt: result }
         : result;
 }
 

--- a/src/autopilot/GoalPromptTranslator.test.ts
+++ b/src/autopilot/GoalPromptTranslator.test.ts
@@ -12,7 +12,9 @@ describe('GoalPromptTranslator', () => {
         await expect(translator.translate({
             apiKey: 'key',
             goal: 'I want a moody jazz singer portrait in a smoky club with dramatic gold light',
-        })).resolves.toBe('Cinematic portrait of a jazz singer in deep blue haze, gold rim light, smoky club interior');
+        })).resolves.toEqual({
+            prompt: 'Cinematic portrait of a jazz singer in deep blue haze, gold rim light, smoky club interior',
+        });
     });
 
     it('propagates API errors', async () => {
@@ -26,5 +28,34 @@ describe('GoalPromptTranslator', () => {
             apiKey: 'key',
             goal: 'A brutalist hotel lobby at dawn',
         })).rejects.toThrow('translator failed');
+    });
+
+    it('attaches reasoning cost metadata when the client returns usage', async () => {
+        const translator = createGoalPromptTranslator({
+            provider: 'openai',
+            model: 'gpt-5.4',
+            createResponse: vi.fn(async () => ({
+                outputText: 'A precise image prompt',
+                usage: {
+                    input_tokens: 100,
+                    output_tokens: 20,
+                    total_tokens: 120,
+                },
+            })),
+        });
+
+        await expect(translator.translate({
+            apiKey: 'key',
+            goal: 'A precise image',
+        })).resolves.toMatchObject({
+            prompt: 'A precise image prompt',
+            costLedger: {
+                items: [expect.objectContaining({
+                    operation: 'goal-translation',
+                    status: 'calculated',
+                    amountUsd: 0.00055,
+                })],
+            },
+        });
     });
 });

--- a/src/autopilot/GoalPromptTranslator.ts
+++ b/src/autopilot/GoalPromptTranslator.ts
@@ -1,4 +1,6 @@
 import { openAiReasoningClient, type ReasoningClient } from './ReasoningClient';
+import { buildReasoningCostLedger } from '../costs/apiCost';
+import type { ApiCostLedger } from '../db/types';
 
 export const GOAL_PROMPT_TRANSLATOR_PROMPT_VERSION = 'goal-prompt-translator.v1';
 
@@ -10,7 +12,12 @@ export const GOAL_PROMPT_TRANSLATOR_SYSTEM_PROMPT = [
 ].join('\n');
 
 export interface GoalPromptTranslator {
-    translate(input: { goal: string; apiKey: string }): Promise<string>;
+    translate(input: { goal: string; apiKey: string }): Promise<GoalPromptTranslation>;
+}
+
+export interface GoalPromptTranslation {
+    prompt: string;
+    costLedger?: ApiCostLedger;
 }
 
 export function createGoalPromptTranslator(client: ReasoningClient = openAiReasoningClient): GoalPromptTranslator {
@@ -27,9 +34,28 @@ export function createGoalPromptTranslator(client: ReasoningClient = openAiReaso
                 throw new Error('Goal prompt translator returned an empty prompt');
             }
 
-            return prompt;
+            return {
+                prompt,
+                ...buildReasoningCost(client, response.usage),
+            };
         },
     };
 }
 
 export const goalPromptTranslator = createGoalPromptTranslator();
+
+function buildReasoningCost(client: ReasoningClient, usage: unknown): { costLedger?: ApiCostLedger } {
+    if (!client.provider || !client.model) {
+        return {};
+    }
+
+    return {
+        costLedger: buildReasoningCostLedger({
+            provider: client.provider,
+            model: client.model,
+            operation: 'goal-translation',
+            label: 'Goal translation',
+            usage,
+        }),
+    };
+}

--- a/src/autopilot/PromptRefiner.test.ts
+++ b/src/autopilot/PromptRefiner.test.ts
@@ -14,7 +14,9 @@ describe('PromptRefiner', () => {
             goal: 'A cinematic editorial portrait',
             currentPrompt: 'portrait',
             feedback: ['The lighting should be more dramatic.'],
-        })).resolves.toBe('Cinematic fashion portrait, strong rim lighting, tailored black coat, moody editorial studio backdrop');
+        })).resolves.toEqual({
+            prompt: 'Cinematic fashion portrait, strong rim lighting, tailored black coat, moody editorial studio backdrop',
+        });
     });
 
     it('propagates API errors to the caller', async () => {
@@ -30,5 +32,36 @@ describe('PromptRefiner', () => {
             currentPrompt: 'still life',
             feedback: ['The composition should feel more intentional.'],
         })).rejects.toThrow('upstream unavailable');
+    });
+
+    it('attaches reasoning cost metadata when the client returns usage', async () => {
+        const refiner = createPromptRefiner({
+            provider: 'openai',
+            model: 'gpt-5.4',
+            createResponse: vi.fn(async () => ({
+                outputText: 'Sharper prompt',
+                usage: {
+                    input_tokens: 200,
+                    output_tokens: 30,
+                    total_tokens: 230,
+                },
+            })),
+        });
+
+        await expect(refiner.refine({
+            apiKey: 'test-key',
+            goal: 'A sharper image',
+            currentPrompt: 'image',
+            feedback: ['Be more specific.'],
+        })).resolves.toMatchObject({
+            prompt: 'Sharper prompt',
+            costLedger: {
+                items: [expect.objectContaining({
+                    operation: 'prompt-refinement',
+                    status: 'calculated',
+                    amountUsd: 0.00095,
+                })],
+            },
+        });
     });
 });

--- a/src/autopilot/PromptRefiner.ts
+++ b/src/autopilot/PromptRefiner.ts
@@ -1,4 +1,6 @@
 import { openAiReasoningClient, type ReasoningClient } from './ReasoningClient';
+import { buildReasoningCostLedger } from '../costs/apiCost';
+import type { ApiCostLedger } from '../db/types';
 
 export const PROMPT_REFINER_PROMPT_VERSION = 'prompt-refiner.v1';
 
@@ -10,7 +12,12 @@ export const PROMPT_REFINER_SYSTEM_PROMPT = [
 ].join('\n');
 
 export interface PromptRefiner {
-    refine(input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }): Promise<string>;
+    refine(input: { goal: string; currentPrompt: string; feedback: string[]; apiKey: string }): Promise<PromptRefinement>;
+}
+
+export interface PromptRefinement {
+    prompt: string;
+    costLedger?: ApiCostLedger;
 }
 
 export function createPromptRefiner(client: ReasoningClient = openAiReasoningClient): PromptRefiner {
@@ -31,9 +38,28 @@ export function createPromptRefiner(client: ReasoningClient = openAiReasoningCli
                 throw new Error('Prompt refiner returned an empty prompt');
             }
 
-            return prompt;
+            return {
+                prompt,
+                ...buildReasoningCost(client, response.usage),
+            };
         },
     };
 }
 
 export const promptRefiner = createPromptRefiner();
+
+function buildReasoningCost(client: ReasoningClient, usage: unknown): { costLedger?: ApiCostLedger } {
+    if (!client.provider || !client.model) {
+        return {};
+    }
+
+    return {
+        costLedger: buildReasoningCostLedger({
+            provider: client.provider,
+            model: client.model,
+            operation: 'prompt-refinement',
+            label: 'Prompt refinement',
+            usage,
+        }),
+    };
+}

--- a/src/autopilot/ReasoningClient.test.ts
+++ b/src/autopilot/ReasoningClient.test.ts
@@ -3,19 +3,20 @@ import {
     buildGeminiReasoningRequest,
     createGeminiReasoningClient,
     createOpenAiReasoningClient,
+    extractGeminiReasoningUsage,
     extractGeminiReasoningText,
 } from './ReasoningClient';
 
 describe('ReasoningClient', () => {
     it('wraps the OpenAI responses client', async () => {
-        const createResponse = vi.fn(async () => ({ outputText: 'translated prompt' }));
+        const createResponse = vi.fn(async () => ({ outputText: 'translated prompt', usage: { input_tokens: 10 } }));
         const client = createOpenAiReasoningClient({ createResponse });
 
         await expect(client.createResponse({
             apiKey: 'sk-test',
             systemPrompt: 'system',
             userText: 'user',
-        })).resolves.toEqual({ outputText: 'translated prompt' });
+        })).resolves.toEqual({ outputText: 'translated prompt', usage: { input_tokens: 10 } });
 
         expect(createResponse).toHaveBeenCalledWith({
             apiKey: 'sk-test',
@@ -90,5 +91,20 @@ describe('ReasoningClient', () => {
             }],
         })).toBe('first\nsecond');
         expect(extractGeminiReasoningText({ candidates: [{ content: { parts: [] } }] })).toBeNull();
+    });
+
+    it('extracts numeric Gemini reasoning usage metadata', () => {
+        expect(extractGeminiReasoningUsage({
+            usageMetadata: {
+                promptTokenCount: 120,
+                candidatesTokenCount: 30,
+                thoughtsTokenCount: 50,
+                promptTokensDetails: [{ modality: 'TEXT', tokenCount: 120 }],
+            },
+        })).toEqual({
+            promptTokenCount: 120,
+            candidatesTokenCount: 30,
+            thoughtsTokenCount: 50,
+        });
     });
 });

--- a/src/autopilot/ReasoningClient.ts
+++ b/src/autopilot/ReasoningClient.ts
@@ -1,5 +1,5 @@
 import { openAiResponsesClient, type OpenAiResponsesClient, type OpenAiResponsesResponse } from '../utils/openai';
-import { GEMINI_FLASH_REASONING_MODEL, OPENAI_RESPONSES_MODEL, REASONING_MODEL_REGISTRY, type ReasoningModelSlug } from '../utils/openaiModels';
+import { GEMINI_FLASH_REASONING_MODEL, GOOGLE_PROVIDER, OPENAI_PROVIDER, OPENAI_RESPONSES_MODEL, REASONING_MODEL_REGISTRY, type Provider, type ReasoningModelSlug } from '../utils/openaiModels';
 
 export interface ReasoningClientRequest {
     apiKey: string;
@@ -12,11 +12,15 @@ export interface ReasoningClientRequest {
 export type ReasoningClientResponse = OpenAiResponsesResponse;
 
 export interface ReasoningClient {
+    provider?: Provider;
+    model?: string;
     createResponse(request: ReasoningClientRequest): Promise<ReasoningClientResponse>;
 }
 
 export function createOpenAiReasoningClient(client: OpenAiResponsesClient = openAiResponsesClient): ReasoningClient {
     return {
+        provider: OPENAI_PROVIDER,
+        model: OPENAI_RESPONSES_MODEL,
         createResponse(request) {
             return client.createResponse(request);
         },
@@ -26,6 +30,8 @@ export function createOpenAiReasoningClient(client: OpenAiResponsesClient = open
 export function createGeminiReasoningClient(fetchImpl: typeof fetch = fetch): ReasoningClient {
     const config = REASONING_MODEL_REGISTRY[GEMINI_FLASH_REASONING_MODEL];
     return {
+        provider: GOOGLE_PROVIDER,
+        model: config.apiModel,
         async createResponse(request) {
             const response = await fetchImpl(config.endpoint, {
                 method: 'POST',
@@ -43,11 +49,15 @@ export function createGeminiReasoningClient(fetchImpl: typeof fetch = fetch): Re
 
             const data: unknown = await response.json();
             const outputText = extractGeminiReasoningText(data);
+            const usage = extractGeminiReasoningUsage(data);
             if (!outputText) {
                 throw new Error('No text response returned from Google Gemini');
             }
 
-            return { outputText };
+            return {
+                outputText,
+                ...(usage ? { usage } : {}),
+            };
         },
     };
 }
@@ -103,6 +113,22 @@ export function extractGeminiReasoningText(data: unknown) {
         .trim();
 
     return text || null;
+}
+
+export function extractGeminiReasoningUsage(data: unknown): Record<string, number> | null {
+    if (!data || typeof data !== 'object') {
+        return null;
+    }
+
+    const usageMetadata = (data as { usageMetadata?: unknown }).usageMetadata;
+    if (!usageMetadata || typeof usageMetadata !== 'object' || Array.isArray(usageMetadata)) {
+        return null;
+    }
+
+    const entries = Object.entries(usageMetadata)
+        .filter((entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1]));
+
+    return entries.length > 0 ? Object.fromEntries(entries) : null;
 }
 
 function dataUrlToInlineDataPart(dataUrl: string) {

--- a/src/autopilot/SatisfactionEvaluator.test.ts
+++ b/src/autopilot/SatisfactionEvaluator.test.ts
@@ -51,6 +51,43 @@ describe('SatisfactionEvaluator', () => {
         })).rejects.toThrow('rate limited');
     });
 
+    it('attaches reasoning cost metadata when the client returns usage', async () => {
+        const evaluator = createSatisfactionEvaluator({
+            provider: 'openai',
+            model: 'gpt-5.4',
+            createResponse: vi.fn(async () => ({
+                outputText: JSON.stringify({
+                    score: 80,
+                    feedback: ['Close.'],
+                }),
+                usage: {
+                    input_tokens: 1000,
+                    output_tokens: 200,
+                    total_tokens: 1200,
+                    input_tokens_details: {
+                        cached_tokens: 100,
+                    },
+                },
+            })),
+        });
+
+        await expect(evaluator.evaluate({
+            apiKey: 'test-key',
+            goal: 'A cinematic portrait',
+            imageDataUrl: 'data:image/png;base64,abc',
+        })).resolves.toMatchObject({
+            score: 80,
+            feedback: ['Close.'],
+            costLedger: {
+                items: [expect.objectContaining({
+                    operation: 'satisfaction-evaluation',
+                    status: 'calculated',
+                    amountUsd: 0.005275,
+                })],
+            },
+        });
+    });
+
     it('parses and clamps valid JSON evaluations', () => {
         expect(parseEvaluation(JSON.stringify({
             score: 104.4,

--- a/src/autopilot/SatisfactionEvaluator.ts
+++ b/src/autopilot/SatisfactionEvaluator.ts
@@ -1,4 +1,6 @@
 import { openAiReasoningClient, type ReasoningClient } from './ReasoningClient';
+import { buildReasoningCostLedger } from '../costs/apiCost';
+import type { ApiCostLedger } from '../db/types';
 
 export const SATISFACTION_EVALUATOR_PROMPT_VERSION = 'satisfaction-evaluator.v1';
 
@@ -22,6 +24,7 @@ const FALLBACK_EVALUATION = {
 export interface SatisfactionEvaluation {
     score: number;
     feedback: string[];
+    costLedger?: ApiCostLedger;
 }
 
 export interface SatisfactionEvaluator {
@@ -49,7 +52,10 @@ export function createSatisfactionEvaluator(client: ReasoningClient = openAiReas
                 },
             });
 
-            return parseEvaluation(response.outputText);
+            return {
+                ...parseEvaluation(response.outputText),
+                ...buildReasoningCost(client, response.usage),
+            };
         },
     };
 }
@@ -96,3 +102,19 @@ function normalizeFeedback(value: unknown) {
 }
 
 export const satisfactionEvaluator = createSatisfactionEvaluator();
+
+function buildReasoningCost(client: ReasoningClient, usage: unknown): { costLedger?: ApiCostLedger } {
+    if (!client.provider || !client.model) {
+        return {};
+    }
+
+    return {
+        costLedger: buildReasoningCostLedger({
+            provider: client.provider,
+            model: client.model,
+            operation: 'satisfaction-evaluation',
+            label: 'Satisfaction evaluation',
+            usage,
+        }),
+    };
+}

--- a/src/components/CostSummaryPanel.tsx
+++ b/src/components/CostSummaryPanel.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import type { ApiCostLedger, ApiCostLineItem } from '../db/types';
+import { calculateApiCostTotals, formatUsd } from '../costs/apiCost';
+
+interface CostSummaryPanelProps {
+    ledger?: ApiCostLedger;
+    compact?: boolean;
+    showBreakdown?: boolean;
+}
+
+const CostSummaryPanel: React.FC<CostSummaryPanelProps> = ({
+    ledger,
+    compact = false,
+    showBreakdown = true,
+}) => {
+    if (!hasApiCostLedger(ledger)) {
+        return null;
+    }
+
+    const totals = calculateApiCostTotals(ledger);
+    const hasReasoningCosts = ledger.items.some((item) => item.kind === 'reasoning');
+    const showSeparateTotals = hasReasoningCosts && !compact;
+
+    return (
+        <div className={`cost-summary-panel${compact ? ' compact' : ''}`}>
+            <label className="section-label">API Cost</label>
+
+            <div className="cost-total-list">
+                {showSeparateTotals && (
+                    <CostTotalRow
+                        label="Image generation"
+                        amountUsd={totals.imageGenerationTotalUsd}
+                        unavailableLabel={getUnavailableLabel(ledger.items.filter((item) => item.kind !== 'reasoning'))}
+                    />
+                )}
+                <CostTotalRow
+                    label={showSeparateTotals ? 'Autopilot API total' : 'Total'}
+                    amountUsd={totals.totalUsd}
+                    unavailableLabel={totals.status === 'unavailable' ? 'Unavailable' : totals.status === 'partial' ? 'Partial' : undefined}
+                />
+            </div>
+
+            {!compact && showBreakdown && (
+                <div className="cost-breakdown-list">
+                    {ledger.items.map((item) => (
+                        <div key={item.id} className={`cost-line-item ${item.status}`}>
+                            <span>{item.label}</span>
+                            <strong>{formatLineItemCost(item)}</strong>
+                            {item.note && <small>{item.note}</small>}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+function CostTotalRow({
+    label,
+    amountUsd,
+    unavailableLabel,
+}: {
+    label: string;
+    amountUsd?: number;
+    unavailableLabel?: string;
+}) {
+    return (
+        <div className="cost-total-row">
+            <span>{label}</span>
+            <strong>{typeof amountUsd === 'number' ? formatUsd(amountUsd) : unavailableLabel ?? 'Unavailable'}</strong>
+        </div>
+    );
+}
+
+export function hasApiCostLedger(ledger?: ApiCostLedger | null): ledger is ApiCostLedger {
+    return Boolean(ledger && Array.isArray(ledger.items) && ledger.items.length > 0);
+}
+
+export function getApiCostSummaryLabel(ledger?: ApiCostLedger | null): string | null {
+    if (!hasApiCostLedger(ledger)) {
+        return null;
+    }
+
+    const totals = calculateApiCostTotals(ledger);
+    if (typeof totals.totalUsd === 'number') {
+        return formatUsd(totals.totalUsd);
+    }
+
+    return 'Cost unavailable';
+}
+
+function formatLineItemCost(item: ApiCostLineItem) {
+    return item.status === 'calculated' && typeof item.amountUsd === 'number'
+        ? formatUsd(item.amountUsd)
+        : 'Unavailable';
+}
+
+function getUnavailableLabel(items: ApiCostLineItem[]) {
+    if (items.length === 0) {
+        return undefined;
+    }
+
+    return items.every((item) => item.status === 'unavailable') ? 'Unavailable' : 'Partial';
+}
+
+export default CostSummaryPanel;

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Download, Trash2, Edit2, Clock, Star } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { downloadArchiveImage } from '../download/download';
+import { getApiCostSummaryLabel } from './CostSummaryPanel';
 
 interface ImageCardProps {
     image: ArchiveImage;
@@ -17,6 +18,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
     image, onDelete, onEdit, onToggleFavorite, onClick, selected = false, onSelect
 }) => {
     const dateStr = new Date(image.timestamp).toLocaleDateString();
+    const costLabel = getApiCostSummaryLabel(image.costLedger);
 
     const handleDownload = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -70,6 +72,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
                 <p className="card-prompt" title={image.prompt}>{image.prompt}</p>
                 <div className="card-meta">
                     <span className="card-tag">{image.quality.toUpperCase()}</span>
+                    {costLabel && <span className="card-cost">{costLabel}</span>}
                     <div className="card-date">
                         <Clock size={12} />
                         <span>{dateStr}</span>

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
-import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2, GitBranch, History, Star, Coins } from 'lucide-react';
+import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2, GitBranch, History, Star } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { downloadArchiveImage } from '../download/download';
 import { lineageStore } from '../lineage/LineageStore';
+import { buildLineageCostLedger } from '../lineage/lineageCostLedger';
 import { loadLineageTimeline, type LineageTimelineData } from '../lineage/loadLineageTimeline';
 import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLineageStep';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig } from '../utils/openaiModels';
 import ActualParametersPanel from './ActualParametersPanel';
-import CostSummaryPanel, { getApiCostSummaryLabel } from './CostSummaryPanel';
+import CostSummaryPanel from './CostSummaryPanel';
 import {
     buildActualParameterDetails,
     getRequestedArchiveParameters,
@@ -47,7 +48,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
         actualParameters: image.actualParameters,
         requestedParameters: getRequestedArchiveParameters(image),
     });
-    const costLabel = getApiCostSummaryLabel(image.costLedger);
+    const detailCostLedger = buildLineageCostLedger(timeline?.entries ?? [], image.costLedger);
 
     const copyPrompt = () => {
         navigator.clipboard.writeText(image.prompt);
@@ -203,16 +204,10 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                     <span className="status-badge">{image.style}</span>
                                 </div>
                             )}
-                            {costLabel && (
-                                <div className="info-cell">
-                                    <label><Coins size={12} /> COST</label>
-                                    <span className="status-badge">{costLabel}</span>
-                                </div>
-                            )}
                         </div>
 
                         <ActualParametersPanel details={actualParameterDetails} />
-                        <CostSummaryPanel ledger={image.costLedger} />
+                        <CostSummaryPanel ledger={detailCostLedger} />
 
                         {image.references && image.references.length > 0 && (
                             <div className="sidebar-section">

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2, GitBranch, History, Star } from 'lucide-react';
+import { X, Download, Edit2, Trash2, Calendar, Layout, Sparkles, Layers, ChevronRight, ChevronLeft, Copy, Check, Wand2, GitBranch, History, Star, Coins } from 'lucide-react';
 import type { ArchiveImage } from '../db/types';
 import { downloadArchiveImage } from '../download/download';
 import { lineageStore } from '../lineage/LineageStore';
@@ -8,6 +8,7 @@ import { isEditorReplayable, isGenerateReplayable } from '../lineage/replayLinea
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL, isImageModelSlug, resolveImageModelConfig } from '../utils/openaiModels';
 import ActualParametersPanel from './ActualParametersPanel';
+import CostSummaryPanel, { getApiCostSummaryLabel } from './CostSummaryPanel';
 import {
     buildActualParameterDetails,
     getRequestedArchiveParameters,
@@ -46,6 +47,7 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
         actualParameters: image.actualParameters,
         requestedParameters: getRequestedArchiveParameters(image),
     });
+    const costLabel = getApiCostSummaryLabel(image.costLedger);
 
     const copyPrompt = () => {
         navigator.clipboard.writeText(image.prompt);
@@ -201,9 +203,16 @@ const ImageDetailModal: React.FC<ImageDetailModalProps> = ({
                                     <span className="status-badge">{image.style}</span>
                                 </div>
                             )}
+                            {costLabel && (
+                                <div className="info-cell">
+                                    <label><Coins size={12} /> COST</label>
+                                    <span className="status-badge">{costLabel}</span>
+                                </div>
+                            )}
                         </div>
 
                         <ActualParametersPanel details={actualParameterDetails} />
+                        <CostSummaryPanel ledger={image.costLedger} />
 
                         {image.references && image.references.length > 0 && (
                             <div className="sidebar-section">

--- a/src/costs/apiCost.test.ts
+++ b/src/costs/apiCost.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildImageCostLedger,
+    buildReasoningCostLedger,
+    calculateApiCostTotals,
+    formatUsd,
+    mergeApiCostLedgers,
+    sanitizeApiCostLedger,
+} from './apiCost';
+
+describe('apiCost', () => {
+    it('calculates GPT Image cost from image usage tokens', () => {
+        const ledger = buildImageCostLedger({
+            provider: 'openai',
+            model: 'gpt-image-2',
+            operation: 'image-generation',
+            usage: {
+                input_tokens: 120,
+                output_tokens: 1600,
+                total_tokens: 1720,
+                input_tokens_details: {
+                    text_tokens: 100,
+                    image_tokens: 20,
+                },
+                output_tokens_details: {
+                    image_tokens: 1600,
+                },
+            },
+        });
+
+        expect(ledger.items[0]).toMatchObject({
+            status: 'calculated',
+            amountUsd: 0.04866,
+            usage: {
+                inputTextTokens: 100,
+                inputImageTokens: 20,
+                outputImageTokens: 1600,
+                totalTokens: 1720,
+            },
+        });
+        expect(calculateApiCostTotals(ledger)).toMatchObject({
+            status: 'calculated',
+            totalUsd: 0.04866,
+            imageGenerationTotalUsd: 0.04866,
+        });
+    });
+
+    it('allocates shared OpenAI image request cost across returned images', () => {
+        const ledger = buildImageCostLedger({
+            provider: 'openai',
+            model: 'gpt-image-2',
+            operation: 'image-generation',
+            usageScope: 'request',
+            usageImageCount: 2,
+            usage: {
+                input_tokens_details: {
+                    text_tokens: 100,
+                    image_tokens: 0,
+                },
+                output_tokens_details: {
+                    image_tokens: 2000,
+                },
+            },
+        });
+
+        expect(ledger.items[0]).toMatchObject({
+            amountUsd: 0.03025,
+            usage: expect.objectContaining({
+                sharedRequestImageCount: 2,
+            }),
+            note: 'Allocated 1/2 of a shared image-generation request.',
+        });
+    });
+
+    it('creates unavailable line items when usage metadata is missing', () => {
+        const ledger = buildImageCostLedger({
+            provider: 'google',
+            model: 'gemini-3-pro-image-preview',
+            operation: 'image-generation',
+        });
+
+        expect(ledger.items[0]).toMatchObject({
+            status: 'unavailable',
+        });
+        expect(ledger.items[0]).not.toHaveProperty('amountUsd');
+        expect(calculateApiCostTotals(ledger)).toEqual({
+            status: 'unavailable',
+            currency: 'USD',
+        });
+    });
+
+    it('calculates reasoning and image subtotals from a merged ledger', () => {
+        const imageLedger = buildImageCostLedger({
+            provider: 'google',
+            model: 'gemini-3-pro-image-preview',
+            operation: 'image-generation',
+            usage: {
+                promptTokenCount: 1000,
+                candidatesTokenCount: 1290,
+                candidatesTokensDetails: [{ modality: 'IMAGE', tokenCount: 1290 }],
+                totalTokenCount: 2290,
+            },
+        });
+        const reasoningLedger = buildReasoningCostLedger({
+            provider: 'openai',
+            model: 'gpt-5.4',
+            operation: 'satisfaction-evaluation',
+            label: 'Satisfaction evaluation',
+            usage: {
+                input_tokens: 1000,
+                output_tokens: 200,
+                total_tokens: 1200,
+                input_tokens_details: {
+                    cached_tokens: 100,
+                },
+            },
+        });
+
+        const totals = calculateApiCostTotals(mergeApiCostLedgers(imageLedger, reasoningLedger));
+
+        expect(totals).toMatchObject({
+            status: 'calculated',
+            imageGenerationTotalUsd: 0.1568,
+            reasoningTotalUsd: 0.005275,
+            totalUsd: 0.162075,
+        });
+    });
+
+    it('sanitizes persisted cost ledgers and drops invalid line items', () => {
+        expect(sanitizeApiCostLedger({
+            currency: 'USD',
+            items: [
+                {
+                    id: 'known',
+                    kind: 'reasoning',
+                    operation: 'prompt-refinement',
+                    provider: 'openai',
+                    model: 'gpt-5.4',
+                    label: 'Prompt refinement',
+                    status: 'calculated',
+                    currency: 'USD',
+                    amountUsd: 0.01,
+                    usage: { inputTokens: 10 },
+                    pricing: {
+                        source: 'https://example.test',
+                        snapshotDate: '2026-06-27',
+                        unit: 'per_1m_tokens',
+                        ratesUsdPer1M: { input: 1 },
+                    },
+                },
+                { status: 'calculated' },
+            ],
+        })).toEqual({
+            version: 1,
+            currency: 'USD',
+            items: [expect.objectContaining({
+                id: 'known',
+                amountUsd: 0.01,
+            })],
+        });
+    });
+
+    it('formats sub-cent costs without rounding them to zero', () => {
+        expect(formatUsd(0.0042)).toBe('$0.0042');
+        expect(formatUsd(1.2)).toBe('$1.20');
+    });
+});

--- a/src/costs/apiCost.ts
+++ b/src/costs/apiCost.ts
@@ -1,0 +1,592 @@
+import type { ApiCostLedger, ApiCostLineItem, ApiCostPricingSnapshot } from '../db/types';
+
+export const API_COST_PRICING_SNAPSHOT_DATE = '2026-06-27';
+
+const OPENAI_PRICING_SOURCE = 'https://developers.openai.com/api/docs/pricing';
+const GEMINI_PRICING_SOURCE = 'https://ai.google.dev/gemini-api/docs/pricing';
+
+const GPT_IMAGE_2_PRICING: ApiCostPricingSnapshot = {
+    source: OPENAI_PRICING_SOURCE,
+    snapshotDate: API_COST_PRICING_SNAPSHOT_DATE,
+    unit: 'per_1m_tokens',
+    ratesUsdPer1M: {
+        inputText: 5,
+        inputImage: 8,
+        outputImage: 30,
+    },
+};
+
+const NANO_BANANA_PRO_PRICING: ApiCostPricingSnapshot = {
+    source: GEMINI_PRICING_SOURCE,
+    snapshotDate: API_COST_PRICING_SNAPSHOT_DATE,
+    unit: 'per_1m_tokens',
+    ratesUsdPer1M: {
+        inputText: 2,
+        inputImage: 2,
+        outputTextAndThinking: 12,
+        outputImage: 120,
+    },
+};
+
+const GPT_5_4_PRICING: ApiCostPricingSnapshot = {
+    source: OPENAI_PRICING_SOURCE,
+    snapshotDate: API_COST_PRICING_SNAPSHOT_DATE,
+    unit: 'per_1m_tokens',
+    ratesUsdPer1M: {
+        input: 2.5,
+        cachedInput: 0.25,
+        output: 15,
+    },
+};
+
+const GEMINI_FLASH_REASONING_PRICING: ApiCostPricingSnapshot = {
+    source: GEMINI_PRICING_SOURCE,
+    snapshotDate: API_COST_PRICING_SNAPSHOT_DATE,
+    unit: 'per_1m_tokens',
+    ratesUsdPer1M: {
+        input: 0.3,
+        output: 2.5,
+    },
+};
+
+export interface ApiCostTotals {
+    status: 'calculated' | 'partial' | 'unavailable';
+    currency: 'USD';
+    totalUsd?: number;
+    imageGenerationTotalUsd?: number;
+    reasoningTotalUsd?: number;
+}
+
+export interface BuildImageCostLedgerInput {
+    provider: string;
+    model: string;
+    operation: 'image-generation' | 'image-edit';
+    label?: string;
+    usage?: unknown;
+    usageScope?: 'result' | 'request';
+    usageImageCount?: number;
+}
+
+export interface BuildReasoningCostLedgerInput {
+    provider: string;
+    model: string;
+    operation: string;
+    label: string;
+    usage?: unknown;
+}
+
+export function buildImageCostLedger(input: BuildImageCostLedgerInput): ApiCostLedger {
+    if (input.provider === 'openai') {
+        return createLedger([buildOpenAiImageLineItem(input)]);
+    }
+
+    if (input.provider === 'google') {
+        return createLedger([buildGeminiImageLineItem(input)]);
+    }
+
+    return createLedger([
+        createUnavailableLineItem({
+            kind: input.operation,
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label: input.label ?? titleizeOperation(input.operation),
+            note: 'No pricing calculator is configured for this image provider.',
+        }),
+    ]);
+}
+
+export function buildReasoningCostLedger(input: BuildReasoningCostLedgerInput): ApiCostLedger {
+    if (input.provider === 'openai') {
+        return createLedger([buildOpenAiReasoningLineItem(input)]);
+    }
+
+    if (input.provider === 'google') {
+        return createLedger([buildGeminiReasoningLineItem(input)]);
+    }
+
+    return createLedger([
+        createUnavailableLineItem({
+            kind: 'reasoning',
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label: input.label,
+            note: 'No pricing calculator is configured for this reasoning provider.',
+        }),
+    ]);
+}
+
+export function mergeApiCostLedgers(...ledgers: Array<ApiCostLedger | null | undefined>): ApiCostLedger | undefined {
+    const items = ledgers.flatMap((ledger) => ledger?.items ?? []);
+    return items.length > 0 ? createLedger(items) : undefined;
+}
+
+export function calculateApiCostTotals(ledger: ApiCostLedger | null | undefined): ApiCostTotals {
+    const items = ledger?.items ?? [];
+    if (items.length === 0) {
+        return { status: 'unavailable', currency: 'USD' };
+    }
+
+    const calculatedItems = items.filter((item) => item.status === 'calculated' && typeof item.amountUsd === 'number' && Number.isFinite(item.amountUsd));
+    const unavailableItems = items.filter((item) => item.status !== 'calculated' || typeof item.amountUsd !== 'number' || !Number.isFinite(item.amountUsd));
+
+    if (calculatedItems.length === 0) {
+        return { status: 'unavailable', currency: 'USD' };
+    }
+
+    const sum = (nextItems: ApiCostLineItem[]) => roundUsd(nextItems.reduce((total, item) => total + (item.amountUsd ?? 0), 0));
+    const imageItems = calculatedItems.filter((item) => item.kind === 'image-generation' || item.kind === 'image-edit');
+    const reasoningItems = calculatedItems.filter((item) => item.kind === 'reasoning');
+
+    return {
+        status: unavailableItems.length > 0 ? 'partial' : 'calculated',
+        currency: 'USD',
+        totalUsd: sum(calculatedItems),
+        ...(imageItems.length > 0 ? { imageGenerationTotalUsd: sum(imageItems) } : {}),
+        ...(reasoningItems.length > 0 ? { reasoningTotalUsd: sum(reasoningItems) } : {}),
+    };
+}
+
+export function formatUsd(amountUsd: number): string {
+    if (amountUsd > 0 && amountUsd < 0.01) {
+        return `$${amountUsd.toFixed(4)}`;
+    }
+
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(amountUsd);
+}
+
+export function sanitizeApiCostLedger(value: unknown): ApiCostLedger | undefined {
+    if (!isRecord(value) || value.currency !== 'USD' || !Array.isArray(value.items)) {
+        return undefined;
+    }
+
+    const items = value.items
+        .map(sanitizeApiCostLineItem)
+        .filter((item): item is ApiCostLineItem => item !== null);
+
+    return items.length > 0 ? createLedger(items) : undefined;
+}
+
+function buildOpenAiImageLineItem(input: BuildImageCostLedgerInput): ApiCostLineItem {
+    const usage = normalizeOpenAiImageUsage(input.usage);
+    const label = input.label ?? titleizeOperation(input.operation);
+
+    if (!usage) {
+        return createUnavailableLineItem({
+            kind: input.operation,
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label,
+            note: 'OpenAI did not return image usage metadata for this call.',
+        });
+    }
+
+    const imageCount = input.usageScope === 'request'
+        ? Math.max(1, Math.trunc(input.usageImageCount ?? 1))
+        : 1;
+    const fullAmount = calculateTokenCost([
+        [usage.inputTextTokens, GPT_IMAGE_2_PRICING.ratesUsdPer1M.inputText],
+        [usage.inputImageTokens, GPT_IMAGE_2_PRICING.ratesUsdPer1M.inputImage],
+        [usage.outputImageTokens, GPT_IMAGE_2_PRICING.ratesUsdPer1M.outputImage],
+    ]);
+    const amountUsd = roundUsd(fullAmount / imageCount);
+
+    return createCalculatedLineItem({
+        kind: input.operation,
+        operation: input.operation,
+        provider: input.provider,
+        model: input.model,
+        label,
+        amountUsd,
+        usage: {
+            inputTextTokens: usage.inputTextTokens,
+            inputImageTokens: usage.inputImageTokens,
+            outputImageTokens: usage.outputImageTokens,
+            totalTokens: usage.totalTokens,
+            ...(imageCount > 1 ? { sharedRequestImageCount: imageCount } : {}),
+        },
+        pricing: GPT_IMAGE_2_PRICING,
+        note: imageCount > 1 ? `Allocated 1/${imageCount} of a shared image-generation request.` : undefined,
+    });
+}
+
+function buildGeminiImageLineItem(input: BuildImageCostLedgerInput): ApiCostLineItem {
+    const usage = normalizeGeminiUsage(input.usage);
+    const label = input.label ?? titleizeOperation(input.operation);
+
+    if (!usage) {
+        return createUnavailableLineItem({
+            kind: input.operation,
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label,
+            note: 'Google did not return Gemini usage metadata for this call.',
+        });
+    }
+
+    const promptTextTokens = sumModalityTokens(usage.promptTokensDetails, 'TEXT');
+    const promptImageTokens = sumModalityTokens(usage.promptTokensDetails, 'IMAGE');
+    const promptDetailTokens = promptTextTokens + promptImageTokens;
+    const promptFallbackTokens = promptDetailTokens > 0 ? Math.max(0, usage.promptTokenCount - promptDetailTokens) : usage.promptTokenCount;
+    const candidateTextTokens = sumModalityTokens(usage.candidatesTokensDetails, 'TEXT');
+    const candidateImageTokens = sumModalityTokens(usage.candidatesTokensDetails, 'IMAGE');
+    const candidateDetailTokens = candidateTextTokens + candidateImageTokens;
+    const outputImageTokens = candidateDetailTokens > 0 ? candidateImageTokens : usage.candidatesTokenCount;
+    const outputTextAndThinkingTokens = candidateTextTokens + usage.thoughtsTokenCount;
+    const fullAmount = calculateTokenCost([
+        [promptTextTokens + promptFallbackTokens, NANO_BANANA_PRO_PRICING.ratesUsdPer1M.inputText],
+        [promptImageTokens, NANO_BANANA_PRO_PRICING.ratesUsdPer1M.inputImage],
+        [outputTextAndThinkingTokens, NANO_BANANA_PRO_PRICING.ratesUsdPer1M.outputTextAndThinking],
+        [outputImageTokens, NANO_BANANA_PRO_PRICING.ratesUsdPer1M.outputImage],
+    ]);
+
+    return createCalculatedLineItem({
+        kind: input.operation,
+        operation: input.operation,
+        provider: input.provider,
+        model: input.model,
+        label,
+        amountUsd: roundUsd(fullAmount),
+        usage: {
+            promptTokenCount: usage.promptTokenCount,
+            candidatesTokenCount: usage.candidatesTokenCount,
+            thoughtsTokenCount: usage.thoughtsTokenCount,
+            outputImageTokens,
+            totalTokenCount: usage.totalTokenCount,
+        },
+        pricing: NANO_BANANA_PRO_PRICING,
+        note: 'Gemini image responses expose aggregate prompt and generated-image token counts.',
+    });
+}
+
+function buildOpenAiReasoningLineItem(input: BuildReasoningCostLedgerInput): ApiCostLineItem {
+    const usage = normalizeOpenAiResponsesUsage(input.usage);
+    if (!usage) {
+        return createUnavailableLineItem({
+            kind: 'reasoning',
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label: input.label,
+            note: 'OpenAI did not return reasoning usage metadata for this call.',
+        });
+    }
+
+    const billableInputTokens = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+    const amountUsd = calculateTokenCost([
+        [billableInputTokens, GPT_5_4_PRICING.ratesUsdPer1M.input],
+        [usage.cachedInputTokens, GPT_5_4_PRICING.ratesUsdPer1M.cachedInput],
+        [usage.outputTokens, GPT_5_4_PRICING.ratesUsdPer1M.output],
+    ]);
+
+    return createCalculatedLineItem({
+        kind: 'reasoning',
+        operation: input.operation,
+        provider: input.provider,
+        model: input.model,
+        label: input.label,
+        amountUsd: roundUsd(amountUsd),
+        usage: {
+            inputTokens: usage.inputTokens,
+            cachedInputTokens: usage.cachedInputTokens,
+            outputTokens: usage.outputTokens,
+            totalTokens: usage.totalTokens,
+        },
+        pricing: GPT_5_4_PRICING,
+    });
+}
+
+function buildGeminiReasoningLineItem(input: BuildReasoningCostLedgerInput): ApiCostLineItem {
+    const usage = normalizeGeminiUsage(input.usage);
+    if (!usage) {
+        return createUnavailableLineItem({
+            kind: 'reasoning',
+            operation: input.operation,
+            provider: input.provider,
+            model: input.model,
+            label: input.label,
+            note: 'Google did not return Gemini usage metadata for this reasoning call.',
+        });
+    }
+
+    const outputTokens = usage.candidatesTokenCount + usage.thoughtsTokenCount;
+    const amountUsd = calculateTokenCost([
+        [usage.promptTokenCount, GEMINI_FLASH_REASONING_PRICING.ratesUsdPer1M.input],
+        [outputTokens, GEMINI_FLASH_REASONING_PRICING.ratesUsdPer1M.output],
+    ]);
+
+    return createCalculatedLineItem({
+        kind: 'reasoning',
+        operation: input.operation,
+        provider: input.provider,
+        model: input.model,
+        label: input.label,
+        amountUsd: roundUsd(amountUsd),
+        usage: {
+            promptTokenCount: usage.promptTokenCount,
+            candidatesTokenCount: usage.candidatesTokenCount,
+            thoughtsTokenCount: usage.thoughtsTokenCount,
+            totalTokenCount: usage.totalTokenCount,
+        },
+        pricing: GEMINI_FLASH_REASONING_PRICING,
+    });
+}
+
+function normalizeOpenAiImageUsage(value: unknown) {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const inputDetails = asRecord(record.input_tokens_details);
+    const outputDetails = asRecord(record.output_tokens_details);
+    const inputTextTokens = optionalFiniteNumber(inputDetails?.text_tokens);
+    const inputImageTokens = optionalFiniteNumber(inputDetails?.image_tokens);
+    const outputImageTokens = optionalFiniteNumber(outputDetails?.image_tokens)
+        ?? optionalFiniteNumber(record.output_tokens);
+    const totalTokens = optionalFiniteNumber(record.total_tokens);
+
+    if (inputTextTokens === null && inputImageTokens === null && outputImageTokens === null) {
+        return null;
+    }
+
+    return {
+        inputTextTokens: inputTextTokens ?? 0,
+        inputImageTokens: inputImageTokens ?? 0,
+        outputImageTokens: outputImageTokens ?? 0,
+        totalTokens: totalTokens ?? 0,
+    };
+}
+
+function normalizeOpenAiResponsesUsage(value: unknown) {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const inputTokens = optionalFiniteNumber(record.input_tokens);
+    const outputTokens = optionalFiniteNumber(record.output_tokens);
+    const totalTokens = optionalFiniteNumber(record.total_tokens);
+    const details = asRecord(record.input_tokens_details);
+    const cachedInputTokens = optionalFiniteNumber(details?.cached_tokens) ?? 0;
+
+    if (inputTokens === null && outputTokens === null) {
+        return null;
+    }
+
+    return {
+        inputTokens: inputTokens ?? 0,
+        cachedInputTokens,
+        outputTokens: outputTokens ?? 0,
+        totalTokens: totalTokens ?? (inputTokens ?? 0) + (outputTokens ?? 0),
+    };
+}
+
+function normalizeGeminiUsage(value: unknown) {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const promptTokenCount = optionalFiniteNumber(record.promptTokenCount);
+    const candidatesTokenCount = optionalFiniteNumber(record.candidatesTokenCount);
+    const thoughtsTokenCount = optionalFiniteNumber(record.thoughtsTokenCount);
+    const totalTokenCount = optionalFiniteNumber(record.totalTokenCount);
+    const promptTokensDetails = normalizeModalityTokenDetails(record.promptTokensDetails);
+    const candidatesTokensDetails = normalizeModalityTokenDetails(record.candidatesTokensDetails);
+
+    if (
+        promptTokenCount === null
+        && candidatesTokenCount === null
+        && thoughtsTokenCount === null
+        && totalTokenCount === null
+        && promptTokensDetails.length === 0
+        && candidatesTokensDetails.length === 0
+    ) {
+        return null;
+    }
+
+    return {
+        promptTokenCount: promptTokenCount ?? 0,
+        candidatesTokenCount: candidatesTokenCount ?? 0,
+        thoughtsTokenCount: thoughtsTokenCount ?? 0,
+        totalTokenCount: totalTokenCount ?? 0,
+        promptTokensDetails,
+        candidatesTokensDetails,
+    };
+}
+
+function normalizeModalityTokenDetails(value: unknown): Array<{ modality: string; tokenCount: number }> {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.flatMap((item) => {
+        const record = asRecord(item);
+        const tokenCount = optionalFiniteNumber(record?.tokenCount);
+        return record && typeof record.modality === 'string' && tokenCount !== null
+            ? [{ modality: record.modality, tokenCount }]
+            : [];
+    });
+}
+
+function sumModalityTokens(
+    details: Array<{ modality: string; tokenCount: number }>,
+    modality: string,
+): number {
+    return details
+        .filter((detail) => detail.modality.toUpperCase() === modality)
+        .reduce((total, detail) => total + detail.tokenCount, 0);
+}
+
+function createCalculatedLineItem(input: Omit<ApiCostLineItem, 'id' | 'status' | 'currency'>): ApiCostLineItem {
+    return {
+        id: buildCostLineItemId(input.operation, input.provider, input.model),
+        status: 'calculated',
+        currency: 'USD',
+        ...input,
+    };
+}
+
+function createUnavailableLineItem(input: Pick<ApiCostLineItem, 'kind' | 'operation' | 'provider' | 'model' | 'label'> & { note: string }): ApiCostLineItem {
+    return {
+        id: buildCostLineItemId(input.operation, input.provider, input.model),
+        kind: input.kind,
+        operation: input.operation,
+        provider: input.provider,
+        model: input.model,
+        label: input.label,
+        status: 'unavailable',
+        currency: 'USD',
+        note: input.note,
+    };
+}
+
+function createLedger(items: ApiCostLineItem[]): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: uniquifyLineItemIds(items),
+    };
+}
+
+function uniquifyLineItemIds(items: ApiCostLineItem[]): ApiCostLineItem[] {
+    const used = new Set<string>();
+    const nextCounts = new Map<string, number>();
+
+    return items.map((item) => {
+        if (!used.has(item.id)) {
+            used.add(item.id);
+            nextCounts.set(item.id, 2);
+            return item;
+        }
+
+        let suffix = nextCounts.get(item.id) ?? 2;
+        let nextId = `${item.id}:${suffix}`;
+        while (used.has(nextId)) {
+            suffix += 1;
+            nextId = `${item.id}:${suffix}`;
+        }
+        nextCounts.set(item.id, suffix + 1);
+        used.add(nextId);
+        return { ...item, id: nextId };
+    });
+}
+
+function sanitizeApiCostLineItem(value: unknown): ApiCostLineItem | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const kind = record.kind === 'image-generation' || record.kind === 'image-edit' || record.kind === 'reasoning'
+        ? record.kind
+        : null;
+    const status = record.status === 'calculated' || record.status === 'unavailable'
+        ? record.status
+        : null;
+    if (!kind || !status || record.currency !== 'USD') {
+        return null;
+    }
+
+    return {
+        id: typeof record.id === 'string' && record.id ? record.id : buildCostLineItemId(String(record.operation), String(record.provider), String(record.model)),
+        kind,
+        operation: typeof record.operation === 'string' ? record.operation : kind,
+        provider: typeof record.provider === 'string' ? record.provider : 'unknown',
+        model: typeof record.model === 'string' ? record.model : 'unknown',
+        label: typeof record.label === 'string' ? record.label : titleizeOperation(kind),
+        status,
+        currency: 'USD',
+        ...(optionalFiniteNumber(record.amountUsd) !== null ? { amountUsd: optionalFiniteNumber(record.amountUsd) ?? undefined } : {}),
+        ...(isFiniteNumberRecord(record.usage) ? { usage: record.usage } : {}),
+        ...(sanitizePricing(record.pricing) ? { pricing: sanitizePricing(record.pricing) } : {}),
+        ...(typeof record.note === 'string' ? { note: record.note } : {}),
+    };
+}
+
+function sanitizePricing(value: unknown): ApiCostPricingSnapshot | undefined {
+    const record = asRecord(value);
+    if (
+        !record
+        || typeof record.source !== 'string'
+        || typeof record.snapshotDate !== 'string'
+        || record.unit !== 'per_1m_tokens'
+        || !isFiniteNumberRecord(record.ratesUsdPer1M)
+    ) {
+        return undefined;
+    }
+
+    return {
+        source: record.source,
+        snapshotDate: record.snapshotDate,
+        unit: 'per_1m_tokens',
+        ratesUsdPer1M: record.ratesUsdPer1M,
+        ...(Array.isArray(record.notes) && record.notes.every((note) => typeof note === 'string')
+            ? { notes: record.notes }
+            : {}),
+    };
+}
+
+function calculateTokenCost(entries: Array<[number, number | undefined]>): number {
+    return entries.reduce((total, [tokens, rate]) => total + ((rate ?? 0) * tokens / 1_000_000), 0);
+}
+
+function roundUsd(value: number): number {
+    return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function buildCostLineItemId(operation: string, provider: string, model: string) {
+    return `${operation}:${provider}:${model}`;
+}
+
+function titleizeOperation(value: string) {
+    return value
+        .split('-')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+function isFiniteNumberRecord(value: unknown): value is Record<string, number> {
+    return isRecord(value) && Object.values(value).every((entry) => typeof entry === 'number' && Number.isFinite(entry));
+}
+
+function optionalFiniteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return isRecord(value) ? value : null;
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -5,6 +5,39 @@ export interface ActualImageParameters {
     elapsedMs?: number;
 }
 
+export type ApiCostKind = 'image-generation' | 'image-edit' | 'reasoning';
+
+export type ApiCostStatus = 'calculated' | 'unavailable';
+
+export interface ApiCostPricingSnapshot {
+    source: string;
+    snapshotDate: string;
+    unit: 'per_1m_tokens';
+    ratesUsdPer1M: Record<string, number>;
+    notes?: string[];
+}
+
+export interface ApiCostLineItem {
+    id: string;
+    kind: ApiCostKind;
+    operation: string;
+    provider: string;
+    model: string;
+    label: string;
+    status: ApiCostStatus;
+    currency: 'USD';
+    amountUsd?: number;
+    usage?: Record<string, number>;
+    pricing?: ApiCostPricingSnapshot;
+    note?: string;
+}
+
+export interface ApiCostLedger {
+    version: 1;
+    currency: 'USD';
+    items: ApiCostLineItem[];
+}
+
 export interface ArchiveImage {
     id: string;
     url: string;
@@ -22,6 +55,7 @@ export interface ArchiveImage {
     lighting?: string;
     palette?: string;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     layerStack?: ArchiveLayerStack;
 }
 

--- a/src/editor/aiTransform.ts
+++ b/src/editor/aiTransform.ts
@@ -1,4 +1,4 @@
-import type { ArchiveLayerStack } from '../db/types';
+import type { ApiCostLedger, ArchiveLayerStack } from '../db/types';
 import type { EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { ImageModelSlug } from '../utils/openaiModels';
 import { fileToDataURL } from '../utils/file';
@@ -45,12 +45,14 @@ export interface AiTransformSaveProvenance extends AiTransformTargetMetadata {
     aiEditModel: ImageModelSlug;
     aiResultLayerId: string;
     aiResultLayerName: string | null;
+    costLedger?: ApiCostLedger;
     transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
 export interface AiTransformProvenanceInput {
     prompt: string;
     model: ImageModelSlug;
+    costLedger?: ApiCostLedger;
     transformMask?: EditorLineageTransformMaskAsset | null;
 }
 
@@ -102,6 +104,7 @@ export function applyAiTransformResultToDraft(
             ? {
                 aiEditPrompt: provenanceInput.prompt,
                 aiEditModel: provenanceInput.model,
+                ...(provenanceInput.costLedger ? { costLedger: provenanceInput.costLedger } : {}),
                 ...(provenanceInput.transformMask ? { transformMask: provenanceInput.transformMask } : {}),
                 targetMode: targetPlan.metadata.targetMode,
                 targetLayerCount: targetPlan.metadata.targetLayerCount,

--- a/src/editor/saveEditedImage.test.ts
+++ b/src/editor/saveEditedImage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ArchiveImage } from '../db/types';
+import type { ApiCostKind, ApiCostLedger, ArchiveImage } from '../db/types';
 import { createLineageStore, type LineageMetadataPort, type LineageStep } from '../lineage/LineageStore';
 import { saveEditedImage, type EditorSaveContext } from './saveEditedImage';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
@@ -96,6 +96,37 @@ describe('saveEditedImage', () => {
                 }),
             }),
         ]);
+    });
+
+    it('adds AI edit cost to the saved image total and records the edit step cost in lineage', async () => {
+        const lineage = createStore();
+        await seedSourceLineage(lineage);
+        const generationCostLedger = createCostLedger('image-generation', 'image-generation', 0.05);
+        const editCostLedger = createCostLedger('ai-edit', 'image-edit', 0.04);
+
+        const savedImage = await saveEditedImage(
+            createArchiveImage({ costLedger: generationCostLedger }),
+            'data:image/png;base64,edited-copy',
+            {
+                ...createSaveContext(),
+                isCopy: true,
+                aiEditPrompt: 'add a moonlit skyline',
+                costLedger: editCostLedger,
+            },
+            {
+                saveImage: vi.fn(async (image) => image),
+                lineageStore: lineage,
+                clock: () => '2026-04-04T12:00:00.000Z',
+                makeId: () => 'costed-edit-copy',
+            },
+        );
+
+        expect(savedImage.costLedger?.items.map((item) => [item.id, item.amountUsd])).toEqual([
+            ['image-generation', 0.05],
+            ['ai-edit', 0.04],
+        ]);
+        const steps = await lineage.getByArchiveImageId(savedImage.id);
+        expect(steps.at(-1)?.metadata.costLedger).toEqual(editCostLedger);
     });
 
     it('writes a save-as-copy step branching from the source image', async () => {
@@ -541,6 +572,24 @@ function createSaveContext(overrides: Partial<EditorSaveContext> = {}): EditorSa
         },
         aiEditPrompt: null,
         ...overrides,
+    };
+}
+
+function createCostLedger(id: string, kind: ApiCostKind, amountUsd: number): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [{
+            id,
+            kind,
+            operation: kind,
+            provider: 'openai',
+            model: 'gpt-image-2',
+            label: kind === 'image-edit' ? 'AI edit' : 'Image generation 1',
+            status: 'calculated',
+            currency: 'USD',
+            amountUsd,
+        }],
     };
 }
 

--- a/src/editor/saveEditedImage.ts
+++ b/src/editor/saveEditedImage.ts
@@ -1,4 +1,5 @@
-import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
+import type { ApiCostLedger, ArchiveImage, ArchiveLayerStack } from '../db/types';
+import { mergeApiCostLedgers } from '../costs/apiCost';
 import { buildEditorLineageMetadata, type EditorLineageTransformMaskAsset } from '../lineage/editorLineageMetadata';
 import type { LineageStore } from '../lineage/LineageStore';
 import type { EditorAdjustments } from './layers';
@@ -13,6 +14,7 @@ export interface EditorSaveContext {
     targetIncludesBaseLayer?: boolean | null;
     aiResultLayerId?: string | null;
     aiResultLayerName?: string | null;
+    costLedger?: ApiCostLedger;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
     transformMask?: EditorLineageTransformMaskAsset | null;
@@ -62,6 +64,7 @@ function buildSavedImage(
             timestamp,
             references: context.references ?? sourceImage.references,
             model: context.aiEditModel ?? sourceImage.model,
+            costLedger: mergeApiCostLedgers(sourceImage.costLedger, context.costLedger),
             layerStack: context.layerStack ?? undefined,
         };
     }
@@ -71,6 +74,7 @@ function buildSavedImage(
         url: updatedUrl,
         references: context.references ?? sourceImage.references,
         model: context.aiEditModel ?? sourceImage.model,
+        costLedger: mergeApiCostLedgers(sourceImage.costLedger, context.costLedger),
         layerStack: context.layerStack ?? undefined,
     };
 }
@@ -103,6 +107,7 @@ function buildMetadata(sourceImage: ArchiveImage, savedImage: ArchiveImage, cont
         targetIncludesBaseLayer: context.targetIncludesBaseLayer,
         aiResultLayerId: context.aiResultLayerId,
         aiResultLayerName: context.aiResultLayerName,
+        costLedger: context.costLedger,
         aiEditPrompt: context.aiEditPrompt,
         aiEditModel: context.aiEditModel,
         transformMask: context.transformMask,

--- a/src/editor/useEditorController.test.ts
+++ b/src/editor/useEditorController.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ArchiveLayerStack } from '../db/types';
+import type { ApiCostLedger, ArchiveLayerStack } from '../db/types';
 import type { EditImageInput } from '../image-workflow/ImageWorkflow';
 import { OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import type { AiTransformRenderer } from './aiTransform';
@@ -17,13 +17,17 @@ const adjustments: EditorAdjustments = {
 describe('Editor controller AI transform flow', () => {
     it('runs an end-to-end selected-layer transform and builds save-after-transform provenance', async () => {
         const draft = createDraft(createLayerStack(), ['layer-1']);
+        const costLedger = createCostLedger('ai-edit', 0.04866);
         const referenceImages = [
             new File(['reference'], 'reference.png', { type: 'image/png' }),
         ];
         const render = createRecordingRenderer();
         const editImage = vi.fn(async (input: EditImageInput) => {
             void input;
-            return 'data:image/png;base64,ai-result';
+            return {
+                imageUrl: 'data:image/png;base64,ai-result',
+                costLedger,
+            };
         });
         const maskImage = new File(['mask'], 'mask.png', { type: 'image/png' });
 
@@ -80,6 +84,7 @@ describe('Editor controller AI transform flow', () => {
             targetIncludesBaseLayer: false,
             aiResultLayerId: 'ai-layer',
             aiResultLayerName: 'AI result',
+            costLedger,
         }));
         expect(context.layerStack?.layers.map((layer) => [layer.id, layer.visible])).toEqual([
             ['base', true],
@@ -168,6 +173,24 @@ async function runTransform(draft: EditorDraft) {
         editImage: vi.fn(async () => 'data:image/png;base64,ai-result'),
         render: createRecordingRenderer(),
     });
+}
+
+function createCostLedger(id: string, amountUsd: number): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [{
+            id,
+            kind: 'image-edit',
+            operation: 'image-edit',
+            provider: 'openai',
+            model: 'gpt-image-2',
+            label: 'AI edit',
+            status: 'calculated',
+            currency: 'USD',
+            amountUsd,
+        }],
+    };
 }
 
 function createRecordingRenderer() {

--- a/src/editor/useEditorController.ts
+++ b/src/editor/useEditorController.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { imageWorkflow, type EditImageInput } from '../image-workflow/ImageWorkflow';
+import { imageWorkflow, type EditImageInput, type EditImageResult } from '../image-workflow/ImageWorkflow';
 import type { ImageModelSlug } from '../utils/openaiModels';
 import {
     applyAiTransformResultToDraft,
@@ -144,7 +144,7 @@ export function useEditorController({
     };
 }
 
-type EditImage = (input: EditImageInput) => Promise<string>;
+type EditImage = (input: EditImageInput) => Promise<string | EditImageResult>;
 
 export interface RunEditorAiTransformOptions {
     apiKey: string;
@@ -178,7 +178,7 @@ export async function runEditorAiTransform({
         referenceImages,
         render,
     });
-    const resultUrl = await editImage({
+    const editResult = normalizeEditImageResult(await editImage({
         apiKey,
         model,
         prompt: trimmedPrompt,
@@ -187,7 +187,7 @@ export async function runEditorAiTransform({
         referenceImages: editInput.referenceImages,
         maskImage,
         quality: 'medium',
-    });
+    }));
     const transformMask = maskImage
         ? await blobToTransformMaskAsset(maskImage)
         : null;
@@ -195,11 +195,12 @@ export async function runEditorAiTransform({
     return applyAiTransformResultToDraft(
         draft,
         editInput.targetPlan,
-        resultUrl,
+        editResult.imageUrl,
         makeId,
         {
             prompt: trimmedPrompt,
             model,
+            costLedger: editResult.costLedger,
             transformMask,
         },
     );
@@ -229,6 +230,7 @@ export function buildEditorSaveContext({
         layerStack: draft && hasDurableLayerStack(draft.layerStack) ? draft.layerStack : null,
         aiEditPrompt: saveProvenance?.aiEditPrompt,
         aiEditModel: saveProvenance?.aiEditModel,
+        costLedger: saveProvenance?.costLedger,
         transformMask: saveProvenance?.transformMask ?? undefined,
         targetMode: saveProvenance?.targetMode,
         targetLayerCount: saveProvenance?.targetLayerCount,
@@ -236,4 +238,10 @@ export function buildEditorSaveContext({
         aiResultLayerId: saveProvenance?.aiResultLayerId,
         aiResultLayerName: saveProvenance?.aiResultLayerName,
     };
+}
+
+function normalizeEditImageResult(result: string | EditImageResult): EditImageResult {
+    return typeof result === 'string'
+        ? { imageUrl: result }
+        : result;
 }

--- a/src/generate-session/GenerateSession.test.ts
+++ b/src/generate-session/GenerateSession.test.ts
@@ -137,6 +137,21 @@ describe('GenerateSession draft migration', () => {
                     imageUrl: 'data:image/png;base64,result-0',
                     isSaved: true,
                     archiveImageId: 'archive-0',
+                    costLedger: {
+                        version: 1,
+                        currency: 'USD',
+                        items: [{
+                            id: 'image-generation:openai:gpt-image-2',
+                            kind: 'image-generation',
+                            operation: 'image-generation',
+                            provider: 'openai',
+                            model: 'gpt-image-2',
+                            label: 'Image generation 1',
+                            status: 'calculated',
+                            currency: 'USD',
+                            amountUsd: 0.04,
+                        }],
+                    },
                 },
                 {
                     slotIndex: 1,

--- a/src/generate-session/GenerateSession.ts
+++ b/src/generate-session/GenerateSession.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import type { ActualImageParameters, ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ApiCostLedger, ArchiveImage } from '../db/types';
+import { sanitizeApiCostLedger } from '../costs/apiCost';
 import {
     buildActiveImageModelControls,
     buildImageModelArchiveFields,
@@ -65,6 +66,7 @@ export type GenerateResultSlot =
         imageUrl: string;
         isSaved: boolean;
         actualParameters?: ActualImageParameters;
+        costLedger?: ApiCostLedger;
         archiveImageId?: string;
     }
     | {
@@ -482,6 +484,7 @@ function sanitizeGenerateResultSlot(value: unknown): GenerateResultSlot | null {
             imageUrl: record.imageUrl,
             isSaved: record.isSaved === true,
             actualParameters: sanitizeActualParameters(record.actualParameters),
+            costLedger: sanitizeApiCostLedger(record.costLedger),
             ...(typeof record.archiveImageId === 'string' && record.archiveImageId
                 ? { archiveImageId: record.archiveImageId }
                 : {}),

--- a/src/generate-session/runGenerateAutopilot.test.ts
+++ b/src/generate-session/runGenerateAutopilot.test.ts
@@ -6,6 +6,21 @@ import type { LineageStep, SaveLineageStepInput } from '../lineage/LineageStore'
 
 describe('runGenerateAutopilot', () => {
     it('delegates to AutopilotSession and persists the best result', async () => {
+        const initialCostLedger = {
+            version: 1 as const,
+            currency: 'USD' as const,
+            items: [{
+                id: 'goal-translation',
+                kind: 'reasoning' as const,
+                operation: 'goal-translation',
+                provider: 'openai' as const,
+                model: 'gpt-5.4',
+                label: 'Goal translation',
+                status: 'calculated' as const,
+                currency: 'USD' as const,
+                amountUsd: 0.00055,
+            }],
+        };
         const run = vi.fn(async () => ({
             status: 'satisfied' as const,
             error: null,
@@ -72,6 +87,7 @@ describe('runGenerateAutopilot', () => {
                 save: vi.fn(),
             },
             createSession,
+            initialCostLedger,
             onSessionCreated,
         });
 
@@ -81,6 +97,7 @@ describe('runGenerateAutopilot', () => {
             reasoningApiKey: 'reasoning-key',
             reasoningModel: 'gemini-2.5-flash',
             initialParentStepId: 'step-parent',
+            initialCostLedger,
         }));
         expect(run).toHaveBeenCalledOnce();
         expect(onSessionCreated).toHaveBeenCalledWith(expect.objectContaining({ run, cancel }));

--- a/src/generate-session/runGenerateAutopilot.ts
+++ b/src/generate-session/runGenerateAutopilot.ts
@@ -6,6 +6,7 @@ import { imageWorkflow } from '../image-workflow/ImageWorkflow';
 import { promptRefiner } from '../autopilot/PromptRefiner';
 import { satisfactionEvaluator } from '../autopilot/SatisfactionEvaluator';
 import { buildImageModelGenerateReferenceRunPlan } from '../image-models/ImageModelControls';
+import type { ApiCostLedger } from '../db/types';
 
 interface RunGenerateAutopilotInput {
     goal: string;
@@ -20,6 +21,7 @@ interface RunGenerateAutopilotInput {
     workflow?: Pick<ImageWorkflow, 'generate' | 'serializeReferences'>;
     evaluate?: typeof satisfactionEvaluator.evaluate;
     refine?: typeof promptRefiner.refine;
+    initialCostLedger?: ApiCostLedger;
     maxIterations?: number;
     satisfactionThreshold?: number;
     onSessionCreated?: (session: ReturnType<typeof createAutopilotSession>) => void;
@@ -59,6 +61,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
         reasoningApiKey: input.reasoningApiKey,
         reasoningModel: input.reasoningModel,
         initialParentStepId: input.sessionStore.loadLineageSource()?.stepId ?? null,
+        initialCostLedger: input.initialCostLedger,
         maxIterations: input.maxIterations,
         satisfactionThreshold: input.satisfactionThreshold,
         generate: (request) => generateSingleImage(workflow, request),
@@ -87,6 +90,7 @@ export async function runGenerateAutopilot(input: RunGenerateAutopilotInput): Pr
                 imageUrl: result.bestIteration.imageDataUrl,
                 isSaved: false,
                 actualParameters: result.bestIteration.actualParameters,
+                costLedger: result.bestIteration.costLedger,
                 archiveImageId: result.bestIteration.archiveImageId,
             }],
             references: usedReferences,
@@ -121,5 +125,6 @@ async function generateSingleImage(
     return {
         imageDataUrl: result.imageUrl,
         actualParameters: result.actualParameters,
+        costLedger: result.costLedger,
     };
 }

--- a/src/generate-session/useGenerateController.ts
+++ b/src/generate-session/useGenerateController.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import type { ActualImageParameters, ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ApiCostLedger, ArchiveImage } from '../db/types';
 import { downloadGeneratedImage } from '../download/download';
 import {
     generateSessionStore,
@@ -72,6 +72,7 @@ interface BuildGeneratedArchiveImageInput {
     draft: GenerateDraft;
     references: string[];
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
 }
 
 interface SnapshotGeneratedReferenceImagesInput {
@@ -86,6 +87,7 @@ interface BuildGeneratedArchiveImageForSaveInput {
     draft: GenerateDraft;
     usedReferences: string[] | null;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     serializeReferences: () => Promise<string[]>;
 }
 
@@ -153,6 +155,7 @@ export function buildGeneratedArchiveImage({
     draft,
     references,
     actualParameters,
+    costLedger,
 }: BuildGeneratedArchiveImageInput): ArchiveImage {
     const archiveFields = getActiveGenerateArchiveFields(draft);
 
@@ -171,6 +174,7 @@ export function buildGeneratedArchiveImage({
         lighting: draft.lighting,
         palette: draft.palette,
         actualParameters,
+        costLedger,
         references,
     };
 }
@@ -189,6 +193,7 @@ export async function buildGeneratedArchiveImageForSave({
     draft,
     usedReferences,
     actualParameters,
+    costLedger,
     serializeReferences,
 }: BuildGeneratedArchiveImageForSaveInput): Promise<ArchiveImage> {
     const references = usedReferences ?? await serializeReferences();
@@ -199,6 +204,7 @@ export async function buildGeneratedArchiveImageForSave({
         timestamp,
         draft,
         actualParameters,
+        costLedger,
         references,
     });
 }
@@ -234,6 +240,7 @@ export async function saveGenerateResultSlots({
             draft: runDraft ?? draft,
             usedReferences,
             actualParameters: slot.actualParameters,
+            costLedger: slot.costLedger,
             serializeReferences,
         });
         await saveGeneratedImage(image, {
@@ -509,7 +516,12 @@ export function useGenerateController({
         }
     }, [apiKey, completionNotificationPort, completionNotificationsEnabled, draft, isDocumentHidden, referenceImages, session, updateDraft, workflow]);
 
-    const runAutopilot = useCallback(async (input: { goal: string; maxIterations?: number; satisfactionThreshold?: number }) => {
+    const runAutopilot = useCallback(async (input: {
+        goal: string;
+        maxIterations?: number;
+        satisfactionThreshold?: number;
+        initialCostLedger?: ApiCostLedger;
+    }) => {
         if (!apiKey) {
             setError('Please set the selected image model API key in Settings first.');
             return null;
@@ -556,6 +568,7 @@ export function useGenerateController({
                 createSession: createAutopilot,
                 evaluate,
                 refine,
+                initialCostLedger: input.initialCostLedger,
                 onSessionCreated: (sessionInstance) => {
                     autopilotSessionRef.current = sessionInstance;
                 },
@@ -775,6 +788,7 @@ export function buildGenerateResultSlots(results: GenerateBatchResult[]): Genera
             imageUrl: result.imageUrl,
             isSaved: false,
             actualParameters: result.actualParameters,
+            costLedger: result.costLedger,
         }
         : result);
 }
@@ -819,6 +833,7 @@ function buildAutopilotResultSlot(iteration: AutopilotIteration): Extract<Genera
         isSaved: false,
         archiveImageId: iteration.archiveImageId,
         ...(iteration.actualParameters ? { actualParameters: iteration.actualParameters } : {}),
+        ...(iteration.costLedger ? { costLedger: iteration.costLedger } : {}),
     };
 }
 

--- a/src/image-workflow/ImageProvider.ts
+++ b/src/image-workflow/ImageProvider.ts
@@ -73,12 +73,16 @@ export function createGoogleImageProvider(fetchImpl: typeof fetch = fetch): Imag
 
         const data: unknown = await response.json();
         const imageData = extractGoogleImageData(data);
+        const usage = extractGoogleUsageMetadata(data);
 
         if (!imageData) {
             throw new Error('No image returned from Google Gemini. The response may have been text-only or blocked by safety settings.');
         }
 
-        return { b64_json: imageData };
+        return {
+            b64_json: imageData,
+            ...(usage ? { usage } : {}),
+        };
     };
 
     return {
@@ -189,4 +193,51 @@ export function extractGoogleImageData(data: unknown): string | null {
     ));
 
     return (imagePart?.inlineData?.data ?? imagePart?.inline_data?.data ?? null) as string | null;
+}
+
+export function extractGoogleUsageMetadata(data: unknown): Record<string, unknown> | null {
+    if (!data || typeof data !== 'object') {
+        return null;
+    }
+
+    const usageMetadata = (data as { usageMetadata?: unknown }).usageMetadata;
+    if (!usageMetadata || typeof usageMetadata !== 'object' || Array.isArray(usageMetadata)) {
+        return null;
+    }
+
+    const usage: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(usageMetadata)) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            usage[key] = value;
+            continue;
+        }
+
+        if (key === 'promptTokensDetails' || key === 'candidatesTokensDetails') {
+            const details = extractGoogleModalityTokenDetails(value);
+            if (details.length > 0) {
+                usage[key] = details;
+            }
+        }
+    }
+
+    return Object.keys(usage).length > 0 ? usage : null;
+}
+
+function extractGoogleModalityTokenDetails(value: unknown): Array<{ modality: string; tokenCount: number }> {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.flatMap((item) => {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+            return [];
+        }
+
+        const record = item as { modality?: unknown; tokenCount?: unknown };
+        return typeof record.modality === 'string'
+            && typeof record.tokenCount === 'number'
+            && Number.isFinite(record.tokenCount)
+            ? [{ modality: record.modality, tokenCount: record.tokenCount }]
+            : [];
+    });
 }

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NANO_BANANA_PRO_IMAGE_MODEL, OPENAI_IMAGE_MODEL } from '../utils/openaiModels';
 import { createImageWorkflow, type ImageProvider, type ImageProviderRegistry } from './ImageWorkflow';
-import { createGoogleImageProvider, extractGoogleImageData } from './ImageProvider';
+import { createGoogleImageProvider, extractGoogleImageData, extractGoogleUsageMetadata } from './ImageProvider';
 
 describe('ImageWorkflow', () => {
     it('routes generate requests through the configured provider for the selected model', async () => {
@@ -37,6 +37,14 @@ describe('ImageWorkflow', () => {
             actualParameters: {
                 elapsedMs: expect.any(Number),
             },
+            costLedger: expect.objectContaining({
+                currency: 'USD',
+                items: [expect.objectContaining({
+                    status: 'unavailable',
+                    provider: 'openai',
+                    model: OPENAI_IMAGE_MODEL,
+                })],
+            }),
         }]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
             apiKey: 'sk-test',
@@ -88,6 +96,12 @@ describe('ImageWorkflow', () => {
                 actualParameters: {
                     elapsedMs: expect.any(Number),
                 },
+                costLedger: expect.objectContaining({
+                    items: [expect.objectContaining({
+                        label: 'Image generation 1',
+                        status: 'unavailable',
+                    })],
+                }),
             },
             { slotIndex: 1, status: 'failed', error: 'No image data returned from image provider' },
             {
@@ -97,6 +111,12 @@ describe('ImageWorkflow', () => {
                 actualParameters: {
                     elapsedMs: expect.any(Number),
                 },
+                costLedger: expect.objectContaining({
+                    items: [expect.objectContaining({
+                        label: 'Image generation 3',
+                        status: 'unavailable',
+                    })],
+                }),
             },
         ]);
         expect(generate).toHaveBeenCalledWith(expect.objectContaining({
@@ -136,6 +156,12 @@ describe('ImageWorkflow', () => {
                 actualParameters: {
                     elapsedMs: expect.any(Number),
                 },
+                costLedger: expect.objectContaining({
+                    items: [expect.objectContaining({
+                        label: 'Image generation 1',
+                        status: 'unavailable',
+                    })],
+                }),
             },
             { slotIndex: 1, status: 'failed', error: 'Google Gemini API Error: overloaded' },
             {
@@ -145,6 +171,12 @@ describe('ImageWorkflow', () => {
                 actualParameters: {
                     elapsedMs: expect.any(Number),
                 },
+                costLedger: expect.objectContaining({
+                    items: [expect.objectContaining({
+                        label: 'Image generation 3',
+                        status: 'unavailable',
+                    })],
+                }),
             },
         ]);
     });
@@ -187,7 +219,63 @@ describe('ImageWorkflow', () => {
                 quality: 'high',
                 elapsedMs: 275,
             },
+            costLedger: expect.objectContaining({
+                items: [expect.objectContaining({
+                    status: 'unavailable',
+                })],
+            }),
         }]);
+    });
+
+    it('calculates image generation costs from provider usage metadata', async () => {
+        const generate = vi.fn(async () => [{
+            b64_json: 'generated',
+            usage: {
+                input_tokens_details: {
+                    text_tokens: 100,
+                    image_tokens: 20,
+                },
+                output_tokens_details: {
+                    image_tokens: 1600,
+                },
+                total_tokens: 1720,
+            },
+        }]);
+        const workflow = createImageWorkflow({
+            openai: {
+                generate,
+                edit: vi.fn(),
+            },
+        });
+
+        const results = await workflow.generate({
+            apiKey: 'sk-test',
+            prompt: 'blue hour mountain',
+            quality: 'high',
+            aspectRatio: '1024x1024',
+            background: 'transparent',
+            style: 'none',
+            lighting: 'none',
+            palette: 'none',
+            referenceImages: [],
+        });
+
+        expect(results[0]).toMatchObject({
+            status: 'success',
+            costLedger: {
+                version: 1,
+                currency: 'USD',
+                items: [expect.objectContaining({
+                    status: 'calculated',
+                    amountUsd: 0.04866,
+                    usage: expect.objectContaining({
+                        inputTextTokens: 100,
+                        inputImageTokens: 20,
+                        outputImageTokens: 1600,
+                    }),
+                })],
+            },
+        });
     });
 
     it('forwards single-slot OpenAI partial images as data URLs', async () => {
@@ -649,6 +737,43 @@ describe('googleImageProvider', () => {
         });
     });
 
+    it('preserves Gemini image usage metadata when present', async () => {
+        const usageMetadata = {
+            promptTokenCount: 1000,
+            candidatesTokenCount: 1290,
+            candidatesTokensDetails: [{ modality: 'IMAGE', tokenCount: 1290 }],
+            totalTokenCount: 2290,
+        };
+        const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+            candidates: [{
+                content: {
+                    parts: [{ inlineData: { data: 'gemini-image' } }],
+                },
+            }],
+            usageMetadata,
+        })));
+        const provider = createGoogleImageProvider(fetchImpl);
+
+        const result = await provider.generate({
+            apiKey: 'google-key',
+            model: {
+                slug: NANO_BANANA_PRO_IMAGE_MODEL,
+                provider: 'google',
+                apiModel: 'gemini-3-pro-image-preview',
+                label: 'Nano Banana Pro',
+                endpoints: {
+                    generate: 'https://example.test/generate',
+                    edit: 'https://example.test/generate',
+                },
+                parameters: {},
+                capabilities: { transformMask: false, partialImageStreaming: false },
+            },
+            prompt: 'a luminous teapot city',
+        });
+
+        expect(result).toEqual([{ b64_json: 'gemini-image', usage: usageMetadata }]);
+    });
+
     it('ignores partial image callbacks for Gemini requests', async () => {
         const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
             candidates: [{
@@ -826,6 +951,26 @@ describe('googleImageProvider', () => {
                 },
             }],
         })).toBe('snake123');
+    });
+
+    it('extracts numeric Gemini usage metadata and modality token details', () => {
+        expect(extractGoogleUsageMetadata({
+            usageMetadata: {
+                promptTokenCount: 100,
+                candidatesTokenCount: 20,
+                promptTokensDetails: [{ modality: 'TEXT', tokenCount: 100 }],
+                candidatesTokensDetails: [
+                    { modality: 'IMAGE', tokenCount: 20 },
+                    { modality: 'TEXT', tokenCount: 'ignored' },
+                ],
+            },
+        })).toEqual({
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            promptTokensDetails: [{ modality: 'TEXT', tokenCount: 100 }],
+            candidatesTokensDetails: [{ modality: 'IMAGE', tokenCount: 20 }],
+        });
+        expect(extractGoogleUsageMetadata({ usageMetadata: {} })).toBeNull();
     });
 
     it('uses default Gemini imageConfig values when values are not provided', async () => {

--- a/src/image-workflow/ImageWorkflow.test.ts
+++ b/src/image-workflow/ImageWorkflow.test.ts
@@ -384,8 +384,20 @@ describe('ImageWorkflow', () => {
         }));
     });
 
-    it('routes edit requests through the configured provider for the default model', async () => {
-        const edit = vi.fn(async () => ({ b64_json: 'edited' }));
+    it('routes edit requests through the configured provider for the default model and keeps cost metadata', async () => {
+        const edit = vi.fn(async () => ({
+            b64_json: 'edited',
+            usage: {
+                input_tokens_details: {
+                    text_tokens: 100,
+                    image_tokens: 20,
+                },
+                output_tokens_details: {
+                    image_tokens: 1600,
+                },
+                total_tokens: 1720,
+            },
+        }));
         const providers: ImageProviderRegistry = {
             openai: {
                 generate: vi.fn(),
@@ -395,14 +407,23 @@ describe('ImageWorkflow', () => {
         const workflow = createImageWorkflow(providers);
         const sourceImage = new Blob(['source'], { type: 'image/png' });
 
-        const dataUrl = await workflow.edit({
+        const result = await workflow.edit({
             apiKey: 'sk-test',
             prompt: 'make it cinematic',
             sourceImage,
             referenceImages: [],
         });
 
-        expect(dataUrl).toBe('data:image/png;base64,edited');
+        expect(result).toEqual(expect.objectContaining({
+            imageUrl: 'data:image/png;base64,edited',
+            costLedger: expect.objectContaining({
+                items: [expect.objectContaining({
+                    kind: 'image-edit',
+                    label: 'AI edit',
+                    amountUsd: 0.04866,
+                })],
+            }),
+        }));
         expect(edit).toHaveBeenCalledWith(expect.objectContaining({
             apiKey: 'sk-test',
             model: expect.objectContaining({

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -59,9 +59,15 @@ export type GenerateBatchResult =
         error: string;
     };
 
+export interface EditImageResult {
+    imageUrl: string;
+    actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
+}
+
 export interface ImageWorkflow {
     generate(input: GenerateImageInput): Promise<GenerateBatchResult[]>;
-    edit(input: EditImageInput): Promise<string>;
+    edit(input: EditImageInput): Promise<EditImageResult>;
     serializeReferences(files: File[]): Promise<string[]>;
     hydrateReferences(dataUrls: string[]): File[];
 }
@@ -140,13 +146,20 @@ export function createImageWorkflow(
                 imageSize: input.imageSize,
             });
 
-            return requestImageDataUrl(provider.edit({
+            const startedAt = now();
+            const response = await provider.edit({
                 apiKey: input.apiKey,
                 model,
                 prompt: input.prompt,
                 maskImage: input.maskImage,
                 ...providerRequest,
-            }));
+            });
+            const elapsedMs = Math.max(0, Math.round(now() - startedAt));
+
+            return mapEditResult(response, elapsedMs, {
+                provider: model.provider,
+                model: model.apiModel,
+            });
         },
 
         serializeReferences(files) {
@@ -212,16 +225,6 @@ const resolveImageProvider = (slug: ImageModelSlug = DEFAULT_IMAGE_MODEL, provid
     return { model, modelSlug: slug, provider };
 };
 
-const requestImageDataUrl = async (request: Promise<ImageProviderResponse>) => {
-    const result = await request;
-
-    if (!result.b64_json) {
-        throw new Error('No image data returned from image provider');
-    }
-
-    return `data:image/png;base64,${result.b64_json}`;
-};
-
 export function getFirstSuccessfulGeneratedImage(results: GenerateBatchResult[]): string | null {
     return results.find((result) => result.status === 'success')?.imageUrl ?? null;
 }
@@ -266,6 +269,33 @@ function mapGenerateBatchResults(
             error: response?.error ?? 'No image data returned from image provider',
         };
     });
+}
+
+function mapEditResult(
+    response: ImageProviderResponse,
+    elapsedMs: number,
+    costContext: {
+        provider: string;
+        model: string;
+    },
+): EditImageResult {
+    if (!response.b64_json) {
+        throw new Error(response.error ?? 'No image data returned from image provider');
+    }
+
+    return {
+        imageUrl: `data:image/png;base64,${response.b64_json}`,
+        actualParameters: buildActualImageParameters(response, elapsedMs),
+        costLedger: buildImageCostLedger({
+            provider: costContext.provider,
+            model: costContext.model,
+            operation: 'image-edit',
+            label: 'AI edit',
+            usage: response.usage,
+            usageScope: response.usageScope,
+            usageImageCount: response.usageImageCount,
+        }),
+    };
 }
 
 function buildActualImageParameters(response: ImageProviderResponse, elapsedMs: number): ActualImageParameters {

--- a/src/image-workflow/ImageWorkflow.ts
+++ b/src/image-workflow/ImageWorkflow.ts
@@ -10,6 +10,8 @@ import {
 } from '../image-models/ImageModelControls';
 import { DEFAULT_IMAGE_MODEL, resolveImageModelConfig, type ImageModelSlug, type NanoBananaAspectRatio, type NanoBananaImageSize } from '../utils/openaiModels';
 import { imageProviderRegistry, type ImageProvider, type ImageProviderRegistry, type ImageProviderResponse } from './ImageProvider';
+import { buildImageCostLedger } from '../costs/apiCost';
+import type { ApiCostLedger } from '../db/types';
 
 export type { ImageProvider, ImageProviderRegistry } from './ImageProvider';
 export { NANO_REFERENCE_LIMIT } from '../image-models/ImageModelControls';
@@ -49,6 +51,7 @@ export type GenerateBatchResult =
         status: 'success';
         imageUrl: string;
         actualParameters?: ActualImageParameters;
+        costLedger?: ApiCostLedger;
     }
     | {
         slotIndex: number;
@@ -100,7 +103,10 @@ export function createImageWorkflow(
                     ...(onPartialImage ? { onPartialImage } : {}),
                 });
                 const elapsedMs = Math.max(0, Math.round(now() - startedAt));
-                const results = mapGenerateBatchResults(responses, batchSize, elapsedMs);
+                const results = mapGenerateBatchResults(responses, batchSize, elapsedMs, {
+                    provider: model.provider,
+                    model: model.apiModel,
+                });
 
                 if (!hasSuccessfulGeneratedImage(results) && batchSize === 1) {
                     const [result] = results;
@@ -228,6 +234,10 @@ function mapGenerateBatchResults(
     responses: ImageProviderResponse[],
     batchSize: number,
     elapsedMs: number,
+    costContext: {
+        provider: string;
+        model: string;
+    },
 ): GenerateBatchResult[] {
     return Array.from({ length: batchSize }, (_, slotIndex) => {
         const response = responses[slotIndex];
@@ -238,6 +248,15 @@ function mapGenerateBatchResults(
                 status: 'success',
                 imageUrl: `data:image/png;base64,${response.b64_json}`,
                 actualParameters: buildActualImageParameters(response, elapsedMs),
+                costLedger: buildImageCostLedger({
+                    provider: costContext.provider,
+                    model: costContext.model,
+                    operation: 'image-generation',
+                    label: `Image generation ${slotIndex + 1}`,
+                    usage: response.usage,
+                    usageScope: response.usageScope,
+                    usageImageCount: response.usageImageCount,
+                }),
             };
         }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1227,7 +1227,8 @@ textarea.aura-input {
 
 .card-prompt,
 .card-tag,
-.card-date {
+.card-date,
+.card-cost {
     color: var(--color-steel);
     font-family: var(--font-suisse-intl-mono);
     font-size: var(--text-caption);
@@ -1255,13 +1256,6 @@ textarea.aura-input {
     display: flex;
     align-items: center;
     gap: 6px;
-}
-
-.card-cost {
-    color: var(--color-charcoal);
-    font-family: var(--font-suisse-intl-mono);
-    font-size: var(--text-caption);
-    line-height: var(--leading-caption);
 }
 
 .card-selector {

--- a/src/index.css
+++ b/src/index.css
@@ -813,12 +813,12 @@ textarea.aura-input {
     color: var(--color-steel);
 }
 
-.result-container.has-actual-parameters {
+.result-container.has-result-metadata {
     gap: var(--spacing-16);
     padding-bottom: var(--spacing-16);
 }
 
-.result-container.has-actual-parameters .result-image {
+.result-container.has-result-metadata .result-image {
     height: auto;
     max-height: min(70vh, 720px);
     flex: 1;
@@ -887,13 +887,73 @@ textarea.aura-input {
     color: var(--color-charcoal);
 }
 
+.cost-summary-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+    margin: 0 var(--spacing-16);
+    padding: var(--card-padding);
+    border: 1px solid var(--color-steel);
+    background: var(--color-snow);
+    color: var(--color-charcoal);
+}
+
 .result-slot-card .actual-parameters-panel,
-.modal-sidebar .actual-parameters-panel {
+.modal-sidebar .actual-parameters-panel,
+.result-slot-card .cost-summary-panel,
+.modal-sidebar .cost-summary-panel {
     margin: 0;
 }
 
-.actual-parameters-panel.compact {
+.actual-parameters-panel.compact,
+.cost-summary-panel.compact {
     padding: var(--spacing-8);
+}
+
+.cost-total-list,
+.cost-breakdown-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--element-gap);
+}
+
+.cost-total-row,
+.cost-line-item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-16);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
+}
+
+.cost-total-row span,
+.cost-line-item span {
+    color: var(--color-steel);
+    text-transform: uppercase;
+}
+
+.cost-total-row strong,
+.cost-line-item strong {
+    color: var(--color-charcoal);
+    font-weight: var(--font-weight-regular);
+    white-space: nowrap;
+}
+
+.cost-line-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.cost-line-item small {
+    grid-column: 1 / -1;
+    color: var(--color-steel);
+    overflow-wrap: anywhere;
+}
+
+.cost-line-item.unavailable strong {
+    color: var(--color-amber-glow);
 }
 
 .actual-parameter-list {
@@ -1187,12 +1247,21 @@ textarea.aura-input {
     align-items: center;
     justify-content: space-between;
     gap: var(--element-gap);
+    flex-wrap: wrap;
 }
 
-.card-date {
+.card-date,
+.card-cost {
     display: flex;
     align-items: center;
     gap: 6px;
+}
+
+.card-cost {
+    color: var(--color-charcoal);
+    font-family: var(--font-suisse-intl-mono);
+    font-size: var(--text-caption);
+    line-height: var(--leading-caption);
 }
 
 .card-selector {

--- a/src/lineage/autopilotLineageMetadata.ts
+++ b/src/lineage/autopilotLineageMetadata.ts
@@ -5,6 +5,7 @@ import {
     type NanoBananaProControls,
 } from '../image-models/ImageModelControls';
 import type { GenerateImageInput } from '../image-workflow/ImageWorkflow';
+import type { ActualImageParameters, ApiCostLedger } from '../db/types';
 import {
     DEFAULT_IMAGE_MODEL,
     NANO_BANANA_PRO_IMAGE_MODEL,
@@ -81,6 +82,8 @@ export interface AutopilotLineageMetadata extends Record<string, unknown> {
     evaluatorFeedback: string[];
     outputImageDataUrl: string;
     runLabel: string;
+    actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
 }
 
 export interface AutopilotTimelineMetadata {
@@ -116,6 +119,8 @@ export function buildAutopilotLineageMetadata(input: {
     prompt: string;
     settings: Omit<GenerateImageInput, 'apiKey' | 'prompt'>;
     outputImageDataUrl: string;
+    actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
 }): AutopilotLineageMetadata {
     const model = isImageModelSlug(input.settings.model) ? input.settings.model : DEFAULT_IMAGE_MODEL;
     const controls = buildAutopilotImageModelControls(model, input.settings);
@@ -163,6 +168,8 @@ export function buildAutopilotLineageMetadata(input: {
         evaluatorFeedback: feedback,
         outputImageDataUrl: input.outputImageDataUrl,
         runLabel,
+        ...(input.actualParameters ? { actualParameters: input.actualParameters } : {}),
+        ...(input.costLedger ? { costLedger: input.costLedger } : {}),
     };
 }
 

--- a/src/lineage/editorLineageMetadata.ts
+++ b/src/lineage/editorLineageMetadata.ts
@@ -1,4 +1,4 @@
-import type { ArchiveImage, ArchiveLayerStack } from '../db/types';
+import type { ApiCostLedger, ArchiveImage, ArchiveLayerStack } from '../db/types';
 import type { EditorAdjustments } from '../editor/layers';
 import { isImageModelSlug, type ImageModelSlug } from '../utils/openaiModels';
 
@@ -83,6 +83,7 @@ export interface EditorLineageMetadata extends Record<string, unknown> {
     targetIncludesBaseLayer: boolean | null;
     aiResultLayerId: string | null;
     aiResultLayerName: string | null;
+    costLedger?: ApiCostLedger;
     transformMaskAsset?: EditorLineageTransformMaskAsset;
 }
 
@@ -104,6 +105,7 @@ export function buildEditorLineageMetadata(input: {
     targetIncludesBaseLayer?: boolean | null;
     aiResultLayerId?: string | null;
     aiResultLayerName?: string | null;
+    costLedger?: ApiCostLedger;
     aiEditPrompt?: string | null;
     aiEditModel?: string | null;
     transformMask?: EditorLineageTransformMaskAsset | null;
@@ -164,6 +166,7 @@ export function buildEditorLineageMetadata(input: {
         targetIncludesBaseLayer: aiTransformTarget.includesBaseLayer,
         aiResultLayerId: layers.aiResultLayer?.id ?? null,
         aiResultLayerName: layers.aiResultLayer?.name ?? null,
+        ...(input.costLedger ? { costLedger: input.costLedger } : {}),
         ...(transformMask ? { transformMaskAsset: transformMask } : {}),
     };
 }

--- a/src/lineage/generateLineageMetadata.ts
+++ b/src/lineage/generateLineageMetadata.ts
@@ -1,4 +1,4 @@
-import type { ActualImageParameters, ArchiveImage } from '../db/types';
+import type { ActualImageParameters, ApiCostLedger, ArchiveImage } from '../db/types';
 import {
     buildImageModelArchiveFields,
     sanitizeArchiveImageModelControls,
@@ -50,6 +50,7 @@ export interface GenerateLineageMetadata extends Record<string, unknown> {
     palette: string;
     sourceArchiveImageId: string | null;
     actualParameters?: ActualImageParameters;
+    costLedger?: ApiCostLedger;
     referenceImages: GenerateLineageReferenceImages;
     referenceCount: number;
     referenceIds: string[];
@@ -85,6 +86,7 @@ export function buildGenerateLineageMetadata(input: {
         palette: input.image.palette ?? 'none',
         sourceArchiveImageId: input.sourceArchiveImageId,
         ...(input.image.actualParameters ? { actualParameters: input.image.actualParameters } : {}),
+        ...(input.image.costLedger ? { costLedger: input.image.costLedger } : {}),
         referenceImages: {
             count: referenceIds.length,
             ids: referenceIds,

--- a/src/lineage/lineageCostLedger.test.ts
+++ b/src/lineage/lineageCostLedger.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { ApiCostKind, ApiCostLedger } from '../db/types';
+import { buildLineageCostLedger } from './lineageCostLedger';
+
+describe('lineageCostLedger', () => {
+    it('sums recorded generation and edit step costs', () => {
+        const ledger = buildLineageCostLedger([
+            createEntry('step-1', 'generation', 'Generated', createCostLedger('generation', 'image-generation', 0.05)),
+            createEntry('step-2', 'ai-edit', 'AI Edit', createCostLedger('edit', 'image-edit', 0.04)),
+        ]);
+
+        expect(ledger?.items.map((item) => [item.id, item.amountUsd])).toEqual([
+            ['generation', 0.05],
+            ['edit', 0.04],
+        ]);
+    });
+
+    it('marks missing charged lineage step costs as unavailable when another step cost was recorded', () => {
+        const ledger = buildLineageCostLedger([
+            createEntry('step-1', 'generation', 'Generated', createCostLedger('generation', 'image-generation', 0.05)),
+            createEntry('step-2', 'ai-edit', 'AI Edit', null),
+        ]);
+
+        expect(ledger?.items).toEqual([
+            expect.objectContaining({
+                id: 'generation',
+                status: 'calculated',
+                amountUsd: 0.05,
+            }),
+            expect.objectContaining({
+                id: 'ai-edit:step-2:cost-unavailable',
+                kind: 'image-edit',
+                label: 'AI Edit',
+                status: 'unavailable',
+            }),
+        ]);
+    });
+
+    it('uses the archive image ledger when no lineage step costs were recorded', () => {
+        const fallbackLedger = createCostLedger('archive-total', 'image-generation', 0.05);
+
+        expect(buildLineageCostLedger([
+            createEntry('step-1', 'generation', 'Generated', null),
+            createEntry('step-2', 'ai-edit', 'AI Edit', null),
+        ], fallbackLedger)).toBe(fallbackLedger);
+    });
+});
+
+function createEntry(
+    id: string,
+    stepType: 'generation' | 'ai-edit',
+    label: string,
+    costLedger: ApiCostLedger | null,
+) {
+    return {
+        id,
+        archiveImageId: 'image-1',
+        stepType,
+        label,
+        summary: label,
+        timestamp: '2026-04-04T09:00:00.000Z',
+        goalText: null,
+        iterationNumber: null,
+        evaluatorScore: null,
+        evaluatorFeedback: [],
+        costLedger,
+        replayImageDataUrl: null,
+        runLabel: null,
+    };
+}
+
+function createCostLedger(id: string, kind: ApiCostKind, amountUsd: number): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [{
+            id,
+            kind,
+            operation: kind,
+            provider: 'openai',
+            model: 'gpt-image-2',
+            label: kind === 'image-edit' ? 'AI edit' : 'Image generation 1',
+            status: 'calculated',
+            currency: 'USD',
+            amountUsd,
+        }],
+    };
+}

--- a/src/lineage/lineageCostLedger.ts
+++ b/src/lineage/lineageCostLedger.ts
@@ -1,0 +1,68 @@
+import { mergeApiCostLedgers } from '../costs/apiCost';
+import type { ApiCostKind, ApiCostLedger, ApiCostLineItem } from '../db/types';
+import type { LineageStepType } from './types';
+
+interface LineageCostEntry {
+    id: string;
+    stepType: LineageStepType;
+    label: string;
+    costLedger: ApiCostLedger | null;
+}
+
+export function buildLineageCostLedger(
+    entries: LineageCostEntry[],
+    fallbackLedger?: ApiCostLedger,
+): ApiCostLedger | undefined {
+    const hasRecordedStepCost = entries.some((entry) => entry.costLedger);
+    if (!hasRecordedStepCost) {
+        return fallbackLedger;
+    }
+
+    const stepLedgers = entries
+        .map((entry) => entry.costLedger ?? buildMissingStepCostLedger(entry))
+        .filter((ledger): ledger is ApiCostLedger => ledger !== null);
+    const timelineLedger = mergeApiCostLedgers(...stepLedgers);
+
+    return timelineLedger && (!fallbackLedger || timelineLedger.items.length >= fallbackLedger.items.length)
+        ? timelineLedger
+        : fallbackLedger;
+}
+
+function buildMissingStepCostLedger(entry: LineageCostEntry): ApiCostLedger | null {
+    const kind = getChargeableStepCostKind(entry.stepType);
+    if (!kind) {
+        return null;
+    }
+
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [createUnavailableLineItem(entry, kind)],
+    };
+}
+
+function getChargeableStepCostKind(stepType: LineageStepType): ApiCostKind | null {
+    switch (stepType) {
+        case 'generation':
+        case 'reference-generation':
+            return 'image-generation';
+        case 'ai-edit':
+            return 'image-edit';
+        default:
+            return null;
+    }
+}
+
+function createUnavailableLineItem(entry: LineageCostEntry, kind: ApiCostKind): ApiCostLineItem {
+    return {
+        id: `${entry.stepType}:${entry.id}:cost-unavailable`,
+        kind,
+        operation: kind,
+        provider: 'unknown',
+        model: 'unknown',
+        label: entry.label,
+        status: 'unavailable',
+        currency: 'USD',
+        note: 'No API usage metadata was recorded for this lineage step.',
+    };
+}

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -39,6 +39,7 @@ function validateEditorMetadata(metadata: Record<string, unknown>) {
     validateEditorAiEdit(metadata.aiEdit);
     validateEditorLayers(metadata.layers);
     validateTransformMaskAsset(metadata.transformMaskAsset);
+    validateCostLedger(metadata.costLedger);
 }
 
 function validateAutopilotMetadata(metadata: Record<string, unknown>) {

--- a/src/lineage/lineageMetadata.ts
+++ b/src/lineage/lineageMetadata.ts
@@ -1,5 +1,6 @@
 import { isImageModelSlug, isReasoningModelSlug } from '../utils/openaiModels';
 import type { LineageStepType } from './types';
+import { sanitizeApiCostLedger } from '../costs/apiCost';
 
 export function parseLineageMetadata(
     stepType: LineageStepType,
@@ -27,6 +28,7 @@ function validateGenerateMetadata(metadata: Record<string, unknown>) {
     validateDimensions(metadata.dimensions);
     validateReferenceImages(metadata.referenceImages);
     validateActualParameters(metadata.actualParameters);
+    validateCostLedger(metadata.costLedger);
 }
 
 function validateEditorMetadata(metadata: Record<string, unknown>) {
@@ -48,6 +50,8 @@ function validateAutopilotMetadata(metadata: Record<string, unknown>) {
     validateReasoningModel(metadata.reasoningModel);
     validateImageModel(metadata.imageModel);
     validateDimensions(metadata.dimensions);
+    validateActualParameters(metadata.actualParameters);
+    validateCostLedger(metadata.costLedger);
 }
 
 function validateImageModel(value: unknown) {
@@ -104,6 +108,16 @@ function validateActualParameters(value: unknown) {
     }
     if (actualParameters.elapsedMs !== undefined) {
         requireFiniteNumber(actualParameters.elapsedMs, 'lineage actualParameters elapsedMs');
+    }
+}
+
+function validateCostLedger(value: unknown) {
+    if (value === undefined) {
+        return;
+    }
+
+    if (!sanitizeApiCostLedger(value)) {
+        throw new Error('Invalid lineage costLedger');
     }
 }
 

--- a/src/lineage/loadLineageTimeline.test.ts
+++ b/src/lineage/loadLineageTimeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ApiCostKind, ApiCostLedger } from '../db/types';
 import type { LineageStep } from './LineageStore';
 import { loadLineageTimeline } from './loadLineageTimeline';
 
@@ -74,6 +75,7 @@ describe('loadLineageTimeline', () => {
                     iterationNumber: null,
                     evaluatorScore: null,
                     evaluatorFeedback: [],
+                    costLedger: null,
                     replayImageDataUrl: null,
                     runLabel: null,
                 },
@@ -88,6 +90,7 @@ describe('loadLineageTimeline', () => {
                     iterationNumber: null,
                     evaluatorScore: null,
                     evaluatorFeedback: [],
+                    costLedger: null,
                     replayImageDataUrl: null,
                     runLabel: null,
                 },
@@ -102,6 +105,7 @@ describe('loadLineageTimeline', () => {
                     iterationNumber: null,
                     evaluatorScore: null,
                     evaluatorFeedback: [],
+                    costLedger: null,
                     replayImageDataUrl: null,
                     runLabel: null,
                 },
@@ -212,6 +216,48 @@ describe('loadLineageTimeline', () => {
                 stepType: 'generation',
                 runLabel: null,
             }),
+        ]);
+    });
+
+    it('preserves step cost ledgers for detail-view totals', async () => {
+        const generationCostLedger = createCostLedger('image-generation', 'image-generation', 0.05);
+        const editCostLedger = createCostLedger('ai-edit', 'image-edit', 0.04);
+        const timeline = await loadLineageTimeline('image-1', createStore({
+            byArchiveImageId: {
+                'image-1': [
+                    createStep({
+                        id: 'step-1',
+                        archiveImageId: 'image-1',
+                        stepType: 'generation',
+                        timestamp: '2026-04-04T09:00:00.000Z',
+                        metadata: {
+                            prompt: 'cosmic koi pond',
+                            costLedger: generationCostLedger,
+                        },
+                    }),
+                    createStep({
+                        id: 'step-2',
+                        archiveImageId: 'image-1',
+                        parentStepId: 'step-1',
+                        stepType: 'ai-edit',
+                        timestamp: '2026-04-04T10:00:00.000Z',
+                        metadata: {
+                            editPrompt: 'add aurora reflections',
+                            costLedger: editCostLedger,
+                        },
+                    }),
+                ],
+            },
+            byId: {},
+            children: {
+                'step-1': [],
+                'step-2': [],
+            },
+        }));
+
+        expect(timeline.entries.map((entry) => entry.costLedger?.items[0]?.id)).toEqual([
+            'image-generation',
+            'ai-edit',
         ]);
     });
 
@@ -426,5 +472,23 @@ function createStep(overrides: Partial<LineageStep> & Pick<LineageStep, 'id' | '
         parentStepId: null,
         metadata: {},
         ...overrides,
+    };
+}
+
+function createCostLedger(id: string, kind: ApiCostKind, amountUsd: number): ApiCostLedger {
+    return {
+        version: 1,
+        currency: 'USD',
+        items: [{
+            id,
+            kind,
+            operation: kind,
+            provider: 'openai',
+            model: 'gpt-image-2',
+            label: kind === 'image-edit' ? 'AI edit' : 'Image generation 1',
+            status: 'calculated',
+            currency: 'USD',
+            amountUsd,
+        }],
     };
 }

--- a/src/lineage/loadLineageTimeline.ts
+++ b/src/lineage/loadLineageTimeline.ts
@@ -1,4 +1,6 @@
 import type { LineageStore, LineageStep } from './LineageStore';
+import type { ApiCostLedger } from '../db/types';
+import { sanitizeApiCostLedger } from '../costs/apiCost';
 import { readAutopilotTimelineMetadata, type AutopilotTimelineMetadata } from './autopilotLineageMetadata';
 import {
     readEditorTimelineMetadata,
@@ -19,6 +21,7 @@ export interface LineageTimelineEntry {
     iterationNumber: number | null;
     evaluatorScore: number | null;
     evaluatorFeedback: string[];
+    costLedger: ApiCostLedger | null;
     replayImageDataUrl: string | null;
     runLabel: string | null;
 }
@@ -119,6 +122,7 @@ function toTimelineEntry(step: LineageStep): LineageTimelineEntry {
         iterationNumber: autopilotMetadata?.iterationNumber ?? null,
         evaluatorScore: autopilotMetadata?.evaluatorScore ?? null,
         evaluatorFeedback: autopilotMetadata?.evaluatorFeedback ?? [],
+        costLedger: sanitizeApiCostLedger(step.metadata.costLedger) ?? null,
         replayImageDataUrl: autopilotMetadata?.replayImageDataUrl ?? null,
         runLabel: autopilotMetadata?.runLabel ?? null,
     };

--- a/src/utils/openai.test.ts
+++ b/src/utils/openai.test.ts
@@ -71,6 +71,40 @@ describe('openAiImageClient', () => {
         }
     });
 
+    it('preserves top-level usage from image responses for cost calculation', async () => {
+        const usage = {
+            input_tokens_details: {
+                text_tokens: 100,
+                image_tokens: 20,
+            },
+            output_tokens_details: {
+                image_tokens: 1600,
+            },
+            total_tokens: 1720,
+        };
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            data: [{ b64_json: 'generated' }],
+            usage,
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            const result = await openAiImageClient.createImage({
+                apiKey: 'sk-test',
+                prompt: 'a cat',
+            });
+
+            expect(result).toEqual({
+                b64_json: 'generated',
+                usage,
+                usageScope: 'result',
+                usageImageCount: 1,
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
     it('posts batched image generation requests with native n and returns every image payload', async () => {
         const fetchMock = vi.fn(async () => new Response(JSON.stringify({
             data: [
@@ -108,7 +142,7 @@ describe('openAiImageClient', () => {
         const fetchMock = vi.fn(async () => createSseResponse([
             'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","b64_json":"partial-0"}\n\n',
             'event: image_generation.partial_image\ndata: {"type":"image_generation.partial_image","partial_image":{"b64_json":"partial-1"}}\n\n',
-            'event: image_generation.completed\ndata: {"type":"image_generation.completed","size":"1536x1024","quality":"high","data":[{"b64_json":"final","revised_prompt":"a refined slow cat"}]}\n\n',
+            'event: image_generation.completed\ndata: {"type":"image_generation.completed","size":"1536x1024","quality":"high","usage":{"input_tokens_details":{"text_tokens":10},"output_tokens_details":{"image_tokens":20}},"data":[{"b64_json":"final","revised_prompt":"a refined slow cat"}]}\n\n',
         ]));
         const partials: Array<{ b64_json?: string }> = [];
 
@@ -125,6 +159,12 @@ describe('openAiImageClient', () => {
                 revised_prompt: 'a refined slow cat',
                 size: '1536x1024',
                 quality: 'high',
+                usage: {
+                    input_tokens_details: { text_tokens: 10 },
+                    output_tokens_details: { image_tokens: 20 },
+                },
+                usageScope: 'request',
+                usageImageCount: 1,
             });
             expect(partials).toEqual([
                 { b64_json: 'partial-0' },
@@ -351,6 +391,35 @@ describe('openAiResponsesClient', () => {
             });
 
             expect(result).toEqual({ outputText: 'fallback text' });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('preserves Responses API usage for reasoning cost calculation', async () => {
+        const usage = {
+            input_tokens: 1000,
+            output_tokens: 200,
+            total_tokens: 1200,
+            input_tokens_details: {
+                cached_tokens: 100,
+            },
+        };
+        const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+            output_text: 'summary',
+            usage,
+        })));
+
+        vi.stubGlobal('fetch', fetchMock);
+        try {
+            await expect(openAiResponsesClient.createResponse({
+                apiKey: 'res-key',
+                systemPrompt: 'act',
+                userText: 'describe',
+            })).resolves.toEqual({
+                outputText: 'summary',
+                usage,
+            });
         } finally {
             vi.unstubAllGlobals();
         }

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -28,6 +28,9 @@ export interface OpenAiImageResponse {
     revised_prompt?: string;
     size?: string;
     quality?: string;
+    usage?: unknown;
+    usageScope?: 'result' | 'request';
+    usageImageCount?: number;
 }
 
 export interface OpenAiResponsesRequest {
@@ -39,6 +42,7 @@ export interface OpenAiResponsesRequest {
 
 export interface OpenAiResponsesResponse {
     outputText: string;
+    usage?: unknown;
 }
 
 export interface OpenAiImageClient {
@@ -149,6 +153,7 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         data?: OpenAiImageResponse[];
         size?: string;
         quality?: string;
+        usage?: unknown;
     } = await response.json();
 
     if (!data.data || data.data.length === 0) {
@@ -159,6 +164,11 @@ async function requestOpenAiImages(request: OpenAiImageRequest): Promise<OpenAiI
         ...image,
         ...(image.size === undefined && data.size !== undefined ? { size: data.size } : {}),
         ...(image.quality === undefined && data.quality !== undefined ? { quality: data.quality } : {}),
+        ...(image.usage === undefined && data.usage !== undefined ? {
+            usage: data.usage,
+            usageScope: data.data && data.data.length > 1 ? 'request' as const : 'result' as const,
+            usageImageCount: data.data?.length ?? 1,
+        } : {}),
     }));
 }
 
@@ -334,7 +344,7 @@ function parseJsonRecord(value: string): Record<string, unknown> | null {
 
 function extractImageResponses(
     value: unknown,
-    inheritedParameters: Pick<OpenAiImageResponse, 'size' | 'quality'> = {},
+    inheritedParameters: Pick<OpenAiImageResponse, 'size' | 'quality' | 'usage' | 'usageScope' | 'usageImageCount'> = {},
 ): OpenAiImageResponse[] {
     if (typeof value !== 'object' || value === null) {
         return [];
@@ -344,9 +354,22 @@ function extractImageResponses(
     const actualParameters = {
         size: typeof record.size === 'string' ? record.size : inheritedParameters.size,
         quality: typeof record.quality === 'string' ? record.quality : inheritedParameters.quality,
+        usage: record.usage !== undefined ? record.usage : inheritedParameters.usage,
+        usageScope: record.usage !== undefined ? 'request' as const : inheritedParameters.usageScope,
+        usageImageCount: inheritedParameters.usageImageCount,
     };
     if (Array.isArray(record.data)) {
-        return record.data.flatMap((item) => extractImageResponses(item, actualParameters));
+        const images = record.data.flatMap((item) => extractImageResponses(item, actualParameters));
+        if (record.usage !== undefined) {
+            return images.map((image) => ({
+                ...image,
+                usage: image.usage ?? record.usage,
+                usageScope: 'request',
+                usageImageCount: images.length,
+            }));
+        }
+
+        return images;
     }
 
     if (typeof record.data === 'object' && record.data !== null) {
@@ -360,6 +383,11 @@ function extractImageResponses(
             ...(typeof record.revised_prompt === 'string' ? { revised_prompt: record.revised_prompt } : {}),
             ...(actualParameters.size ? { size: actualParameters.size } : {}),
             ...(actualParameters.quality ? { quality: actualParameters.quality } : {}),
+            ...(record.usage !== undefined || actualParameters.usage !== undefined ? {
+                usage: record.usage ?? actualParameters.usage,
+                usageScope: record.usage !== undefined ? 'result' : actualParameters.usageScope,
+                ...(actualParameters.usageImageCount ? { usageImageCount: actualParameters.usageImageCount } : {}),
+            } : {}),
         }]
         : [];
 }
@@ -439,9 +467,20 @@ export const openAiResponsesClient: OpenAiResponsesClient = {
             throw new Error('No text response returned from OpenAI');
         }
 
-        return { outputText };
+        return {
+            outputText,
+            ...(extractResponseUsage(data) !== undefined ? { usage: extractResponseUsage(data) } : {}),
+        };
     },
 };
+
+function extractResponseUsage(data: unknown): unknown {
+    if (!data || typeof data !== 'object') {
+        return undefined;
+    }
+
+    return (data as { usage?: unknown }).usage;
+}
 
 function extractResponseOutputText(data: unknown) {
     if (!data || typeof data !== 'object') {

--- a/src/views/GenerateView.tsx
+++ b/src/views/GenerateView.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
 import { Sparkles, Loader2, Download, Archive, Trash2, Upload, X, ImagePlus } from 'lucide-react';
-import type { ArchiveImage } from '../db/types';
+import type { ApiCostLedger, ArchiveImage } from '../db/types';
 import { generateSessionStore, getImageModelDraftKey, useGenerateDraft, type GenerateDraft } from '../generate-session/GenerateSession';
 import { addGeneratedResultAsReferenceFromAction, useGenerateController, type GenerateResultSlot } from '../generate-session/useGenerateController';
 import { getImageFilesFromClipboard } from '../references/clipboard';
 import { useReferenceImageCollection } from '../references/useReferenceImageCollection';
 import ReferenceImageModal from '../components/ReferenceImageModal';
 import ActualParametersPanel from '../components/ActualParametersPanel';
+import CostSummaryPanel, { hasApiCostLedger } from '../components/CostSummaryPanel';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import {
     buildActualParameterDetails,
@@ -187,6 +188,11 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const [showCostDisclosure, setShowCostDisclosure] = useState(false);
     const [autopilotNotice, setAutopilotNotice] = useState<string | null>(null);
     const [translatingGoal, setTranslatingGoal] = useState(false);
+    const [goalTranslationCostContext, setGoalTranslationCostContext] = useState<{
+        goal: string;
+        prompt: string;
+        ledger: ApiCostLedger;
+    } | null>(null);
     const { prompt, model, style, lighting, palette, isSaved } = draft;
     const activeModel = resolveImageModelConfig(model);
     const activeImageApiKey = getProviderKey(activeModel.provider);
@@ -292,9 +298,15 @@ const GenerateView: React.FC<GenerateViewProps> = ({
         setTranslatingGoal(true);
         setAutopilotNotice(null);
         try {
-            const nextPrompt = await goalPromptTranslator.translate({ goal, apiKey: reasoningApiKey });
-            updateDraft({ prompt: nextPrompt, isSaved: false });
+            const translation = await goalPromptTranslator.translate({ goal, apiKey: reasoningApiKey });
+            updateDraft({ prompt: translation.prompt, isSaved: false });
+            setGoalTranslationCostContext(translation.costLedger ? {
+                goal,
+                prompt: translation.prompt,
+                ledger: translation.costLedger,
+            } : null);
         } catch (translationError) {
+            setGoalTranslationCostContext(null);
             setAutopilotNotice(translationError instanceof Error ? translationError.message : 'Failed to translate goal');
         } finally {
             setTranslatingGoal(false);
@@ -303,10 +315,16 @@ const GenerateView: React.FC<GenerateViewProps> = ({
 
     const handleRunAutopilot = async () => {
         setAutopilotNotice(null);
+        const initialCostLedger = goalTranslationCostContext
+            && goalTranslationCostContext.goal === goal
+            && goalTranslationCostContext.prompt === draft.prompt
+            ? goalTranslationCostContext.ledger
+            : undefined;
         const result = await runAutopilot({
             goal,
             maxIterations,
             satisfactionThreshold,
+            initialCostLedger,
         });
 
         if (!result) {
@@ -348,6 +366,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
     const hasSingleResultActualDetails = singleResultActualDetails
         ? hasActualParameterDetails(singleResultActualDetails)
         : false;
+    const hasSingleResultMetadata = hasSingleResultActualDetails || hasApiCostLedger(singleResultSlot?.costLedger);
     const updateImageModelControl = (controlId: ImageModelControlId, value: string) => {
         updateDraft({
             [activeModelDraftKey]: {
@@ -714,6 +733,7 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                                                         requestedParameters,
                                                     })}
                                                 />
+                                                <CostSummaryPanel compact ledger={result.costLedger} />
                                                 <div className="result-slot-actions">
                                                     <button
                                                         onClick={() => { void saveResult(result.slotIndex); }}
@@ -758,11 +778,12 @@ const GenerateView: React.FC<GenerateViewProps> = ({
                             </div>
                         </div>
                     ) : currentResult ? (
-                        <div className={`result-container${hasSingleResultActualDetails ? ' has-actual-parameters' : ''}`}>
+                        <div className={`result-container${hasSingleResultMetadata ? ' has-result-metadata' : ''}`}>
                             <img src={currentResult} alt="Generated result" className="result-image" />
                             {singleResultActualDetails && (
                                 <ActualParametersPanel details={singleResultActualDetails} />
                             )}
+                            <CostSummaryPanel ledger={singleResultSlot?.costLedger} />
                             {isAutopilotMode && autopilot.iterations.length > 0 && (
                                 <div className="autopilot-result-banner glass-panel">
                                     <strong>


### PR DESCRIPTION
## Summary
- Add a cost ledger across generation, editing, and autopilot flows so image operations carry consistent spend metadata
- Persist and recover archive metadata, with updated store/transfer logic and coverage for recovery paths
- Tighten prompt translation, refinement, satisfaction evaluation, and reasoning client behavior used by the autopilot pipeline
- Refresh UI surfaces for cost visibility in the image card, detail modal, and cost summary panel
- Update lineage timeline and metadata helpers to reflect the new archive and workflow model

## Testing
- Added and updated unit tests across archive, autopilot, editor, generate-session, workflow, lineage, and API cost modules
- Local validation covered the new ledger and recovery paths along with related controller and UI behavior